### PR TITLE
Fix Fedora related interaction with pkgdb2

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -41,7 +41,7 @@ BuildRequires: libtool
 # requirements for tests
 BuildRequires: createrepo
 BuildRequires: %{python_argparse}
-BuildRequires: python-fedora
+BuildRequires: packagedb-cli
 BuildRequires: python-setuptools
 BuildRequires: python-unittest2
 BuildRequires: python-bugzilla
@@ -175,7 +175,7 @@ A plugin for %{name} implementing unified access to yum repositories.
 %package opsys-fedora
 Summary: %{name}'s Fedora operating system plugin
 Requires: %{name} = %{faf_version}
-Requires: python-fedora
+Requires: packagedb-cli
 
 %description opsys-fedora
 A plugin for %{name} implementing support for Fedora operating system.

--- a/src/pyfaf/actions/pull_associates.py
+++ b/src/pyfaf/actions/pull_associates.py
@@ -17,7 +17,6 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 from pyfaf.actions import Action
-from pyfaf.common import FafError
 from pyfaf.opsys import systems
 from pyfaf.queries import (get_associate_by_name,
                            get_opsys_by_name,
@@ -37,7 +36,8 @@ class PullAssociates(Action):
             tasks = []
             for opsys in systems.values():
                 releases = get_releases(db, opsys_name=opsys.nice_name)
-                tasks += [(opsys, release) for release in releases]
+                tasks += [(opsys, release) for release in releases if
+                          release.status != "EOL"]
         elif len(cmdline.opsys) == 1:
             shortname = cmdline.opsys[0]
             if shortname not in systems:

--- a/src/pyfaf/actions/pull_components.py
+++ b/src/pyfaf/actions/pull_components.py
@@ -35,7 +35,7 @@ class PullComponents(Action):
     def _get_tasks(self, cmdline, db):
         result = set()
 
-        # no arguments - pull everything
+        # no arguments - pull everything for non-EOL releases
         if len(cmdline.opsys) < 1:
             for osplugin in systems.values():
                 db_opsys = get_opsys_by_name(db, osplugin.nice_name)
@@ -44,7 +44,8 @@ class PullComponents(Action):
                                    "storage".format(osplugin.nice_name))
 
                 for db_release in db_opsys.releases:
-                    result.add((osplugin, db_release))
+                    if db_release.status != "EOL":
+                        result.add((osplugin, db_release))
 
         # a single opsys - respect opsysrelease
         elif len(cmdline.opsys) == 1:

--- a/src/pyfaf/actions/pull_releases.py
+++ b/src/pyfaf/actions/pull_releases.py
@@ -60,7 +60,14 @@ class PullReleases(Action):
         releases = opsys_plugin.get_releases()
 
         for release, props in releases.items():
-            remote_status = OpSysReleaseStatus.enums[props["status"]]
+            try:
+                lookup = OpSysReleaseStatus.enums.index(props["status"])
+                remote_status = OpSysReleaseStatus.enums[lookup]
+            except ValueError:
+                self.log_error("Unknown release status {0} for release {1}"
+                               .format(props["status"], release))
+                continue
+
             if release in db_releases:
                 db_release = db_releases[release]
 

--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -17,7 +17,7 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import
 
-import fedora.client
+import pkgdb2client
 from pyfaf.opsys import System
 from pyfaf.checker import DictChecker, IntChecker, ListChecker, StringChecker
 from pyfaf.common import FafError, log
@@ -85,7 +85,7 @@ class Fedora(System):
 
     def __init__(self):
         super(Fedora, self).__init__()
-        self._pkgdb = fedora.client.PackageDB()
+        self._pkgdb = pkgdb2client.PkgDB()
 
     def _save_packages(self, db, db_report, packages):
         for package in packages:
@@ -170,76 +170,71 @@ class Fedora(System):
 
     def get_releases(self):
         result = {}
-        collections = [c[0] for c in self._pkgdb.get_collection_list()]
+        collections = self._pkgdb.get_collections()["collections"]
+
         for collection in collections:
             # there is EPEL in collections, we are only interested in Fedora
-            if collection.name.lower() != Fedora.name:
+            if collection["name"].lower() != Fedora.name:
                 continue
 
             # "devel" is called "rawhide" on all other places
-            if collection.version.lower() == "devel":
-                collection.version = "rawhide"
+            if collection["version"].lower() == "devel":
+                collection["version"] = "rawhide"
 
-            result[collection.version] = {"status": collection.statuscode,
-                                          "kojitag": collection.koji_name,
-                                          "shortname": collection.branchname, }
+            result[collection["version"]] = {
+                "status": collection["status"].upper().replace(' ', '_'),
+                "kojitag": collection["koji_name"],
+                "shortname": collection["branchname"],
+            }
 
         return result
 
     def get_components(self, release):
-        if release is not None:
-            if not isinstance(release, basestring):
-                release = str(release)
+        branch = self._release_to_pkgdb_branch(release)
 
-            # "rawhide" is called "devel" in pkgdb
-            if release.lower() == "rawhide":
-                collection = "devel"
-            else:
-                try:
-                    release_num = int(release)
-                except ValueError:
-                    raise FafError("{0} is not a valid Fedora version"
-                                   .format(release))
+        try:
+            pkgs = self._pkgdb.get_packages(branches=branch, page='all')
+        except pkgdb2client.PkgDBException as e:
+            raise FafError("Unable to get components for {0}, error was: {1}"
+                           .format(release, e))
 
-                if release_num > 13:
-                    collection = "f{0}".format(release_num)
-                elif release_num > 6:
-                    collection = "F-{0}".format(release_num)
-                else:
-                    collection = "FC-{0}".format(release_num)
-
-        return self._pkgdb.get_package_list(collectn=collection)
+        return [pkg["name"] for pkg in pkgs["packages"]]
 
     def get_component_acls(self, component, release=None):
-        # "rawhide" is called "devel" in pkgdb
-        if release is not None and release.lower() == "rawhide":
-            release = "devel"
+        branch = None
+        if release:
+            branch = self._release_to_pkgdb_branch(release)
 
         result = {}
 
-        owner_info = self._pkgdb.get_owners(component, collctn_name="Fedora",
-                                            collctn_ver=release)
+        try:
+            packages = self._pkgdb.get_package(component, branches=branch)
+        except pkgdb2client.PkgDBException as e:
+            self.log_error("Unable to get package information for component"
+                           " {0}, error was: {1}".format(component, e))
+            return result
 
-        # Instance of 'tuple' has no 'packageListings' member
-        # pylint: disable-msg=E1103
-        for rel in owner_info.packageListings:
-            # "devel" is called "rawhide" on all other places
-            if rel.collection.version.lower() == "devel":
-                relname = "rawhide"
-            else:
-                relname = rel.collection.version
+        for pkg in packages["packages"]:
+            acls = {pkg["point_of_contact"]: {"owner": True, }, }
 
-            acls = {rel.owner: {"owner": True, }, }
+            if not "acls" in pkg:
+                continue
 
-            for person in rel.people:
-                if any(person.aclOrder.values()):
-                    acls[person.username] = {}
-                    for acl, value in person.aclOrder.items():
-                        acls[person.username][acl] = value is not None
+            for acl in pkg["acls"]:
+                aclname = acl["acl"]
+                person = acl["fas_name"]
+                status = acl["status"] == "Approved"
 
-            if release is not None:
+                if person in acls:
+                    acls[person][aclname] = status
+                else:
+                    acls[person] = {aclname: status}
+
+            if release:
                 return acls
 
+            branch = pkg["branchname"]
+            relname = self._pkgdb_branch_to_release(branch)
             result[relname] = acls
 
         return result
@@ -265,3 +260,31 @@ class Fedora(System):
                 return True
 
         return False
+
+    def _release_to_pkgdb_branch(self, release):
+        """
+        Convert faf's release to pkgdb2 branch name
+        """
+
+        if not isinstance(release, basestring):
+            release = str(release)
+
+        # "rawhide" is called "master" in pkgdb2
+        if release.lower() == "rawhide":
+            branch = "master"
+        elif release.isdigit():
+            branch = "f{0}".format(release)
+        else:
+            raise FafError("{0} is not a valid Fedora version")
+
+        return branch
+
+    def _pkgdb_branch_to_release(self, branch):
+        """
+        Convert pkgdb2 branch name to faf's release
+        """
+
+        if branch == "master":
+            return "rawhide"
+
+        return branch[1:]


### PR DESCRIPTION
Fix Fedora related interaction with pkgdb2

```
Now using pkgdb2client (from packagedb-cli) instead of python-fedora.

Some minor changes like not pulling EOLed release components
and acls included.

Signed-off-by: Richard Marko <rmarko@fedoraproject.org>
```
