### PR TITLE
webui: filter low quality problems

### DIFF
--- a/src/webfaf/static/faf/css/style.css
+++ b/src/webfaf/static/faf/css/style.css
@@ -189,3 +189,7 @@ select, input[type="file"] {
 .cursor-help {
   cursor: help;
 }
+
+.lowquality {
+  display: none;
+}

--- a/src/webfaf/static/faf/js/form.js
+++ b/src/webfaf/static/faf/js/form.js
@@ -36,4 +36,15 @@ $(document).ready(function() {
         second_button.attr('href',
             second_button.attr('href') + match[2]);
     }
+
+    $('#quality_toggle').click(function() {
+      $(this).text(function(i, text) {
+        return text === "Show low quality problems" ? "Hide low quality problems" : "Show low quality problems"
+      });
+      $('.lowquality').toggle();
+    });
+});
+
+
+$(document).ready(function() {
 });

--- a/src/webfaf/templates/Makefile.am
+++ b/src/webfaf/templates/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS = openid problems reports summary status dumpdirs stats
 template_DATA = base.html report_graph.html filter_form.html paginator.html \
-		404.html external_links.html metric_table.html
+		problem_filter_form.html 404.html external_links.html metric_table.html
 
 templatedir = $(pythondir)/webfaf/templates
 

--- a/src/webfaf/templates/problem_filter_form.html
+++ b/src/webfaf/templates/problem_filter_form.html
@@ -1,0 +1,7 @@
+<form id='filter' class='well centered form-inline' action='' method='get'>
+  {% for field in form %}
+    {{ field }}
+  {% endfor %}
+  <button type='submit' class='btn'>Submit</button>
+  <button type='button' id='quality_toggle' class='btn'>Show low quality problems</button>
+</form>

--- a/src/webfaf/templates/problems/hot.html
+++ b/src/webfaf/templates/problems/hot.html
@@ -3,7 +3,7 @@
 {% block title %}Hot problems{% endblock %}
 
 {% block content %}
-  {% include "filter_form.html" %}
+  {% include "problem_filter_form.html" %}
   {% with 'hot' as list_type %}
     {% include "problems/list.html" %}
   {% endwith %}

--- a/src/webfaf/templates/problems/list.html
+++ b/src/webfaf/templates/problems/list.html
@@ -17,7 +17,11 @@
     <th class="cursor-help" title="Release date of the oldest affected package since which the problem stopped occuring.">Probably fixed</th>
   </tr>
   {% for problem in problems.object_list %}
-    <tr>
+    <tr
+      {% if problem.quality < 0 %}
+      class="lowquality"
+      {% endif %}
+      >
       <td>
         <a href={% url 'webfaf.problems.views.item' problem.id %}>
           {{ problem.id }}

--- a/src/webfaf/templates/problems/longterm.html
+++ b/src/webfaf/templates/problems/longterm.html
@@ -3,7 +3,7 @@
 {% block title %}Long-term problems{% endblock %}
 
 {% block content %}
-  {% include "filter_form.html" %}
+  {% include "problem_filter_form.html" %}
   {% with 'longterm' as list_type %}
     {% include "problems/list.html" %}
   {% endwith %}


### PR DESCRIPTION
For this to work properly, quality recomputation for all ReportBacktrace objects is required.

This snippet should work when pasted to faf shell, not sure where to put session.flush though

for obj in db.session.query(ReportBacktrace):
  obj.quality = obj.compute_quality()
