### PR TITLE
Add gen-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ Makefile.in
 /ltmain.sh
 /install-sh
 /depcomp
-
+faf-version
 
 /*.1
 /*.html

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = config src tests
 
-EXTRA_DIST = autogen.sh faf.spec.in
+EXTRA_DIST = autogen.sh gen-version faf-version faf.spec.in
 
 RPM_DIRS = --define "_sourcedir `pwd`" \
            --define "_rpmdir `pwd`" \

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+./gen-version
 autoreconf -i

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,6 @@
-AC_INIT([faf], [0.12])
+AC_INIT([faf],
+    m4_esyscmd([cat ./faf-version]),
+    [crash-catcher@fedorahosted.org])
 
 AM_INIT_AUTOMAKE([-Wall])
 AM_MAINTAINER_MODE

--- a/gen-version
+++ b/gen-version
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+DEF_VER=2.0.10
+LF='
+'
+
+if test -d .git -o -f .git &&
+    VN=$(git describe --tags --match "[0-9]*" --abbrev=4 HEAD 2>/dev/null) &&
+    case "$VN" in
+    *$LF*) (exit 1) ;;
+    [0-9]*)
+        git update-index -q --refresh
+        test -z "$(git diff-index --name-only HEAD --)" || VN="$VN-dirty"
+    esac
+then
+    VN=$(echo "$VN" | sed -e 's/-/./g');
+else
+    VN="$DEF_VER"
+fi
+
+echo -n $VN > faf-version


### PR DESCRIPTION
commit 739f9b1965863a116e9ef1e77bced981d5a4a006
Author: Richard Marko rmarko@fedoraproject.org
Date:   Thu Nov 6 12:39:41 2014 +0100

```
Add gen-version

Similar to the rest of ABRT projects, faf version now contains
number of commits after the last tag and short
commit hash of the last commit built e.g.:

faf-0.12.20.g0af7-1.fc20.noarch.rpm

Signed-off-by: Richard Marko <rmarko@fedoraproject.org>
```
