### PR TITLE
webfaf2: add configurable proxy fix

### DIFF
--- a/config/plugins/web2.conf
+++ b/config/plugins/web2.conf
@@ -1,5 +1,6 @@
 [hub2]
 debug = false
+proxy_setup = false
 secret_key = @SECRET_KEY@
 url = https://example.org/faf/
 

--- a/src/webfaf2/config.py
+++ b/src/webfaf2/config.py
@@ -14,6 +14,7 @@ class Config(object):
     SQLALCHEMY_DATABASE_URI = dburl
     OPENID_ENABLED = str2bool(config.get("openid.enabled", "false"))
     OPENID_FS_STORE = os.path.join(paths["spool"], "openid_store")
+    PROXY_SETUP = False
     MAX_CONTENT_LENGTH = int(config["dumpdir.maxdumpdirsize"])
     RSTPAGES_SRC = os.path.join(WEBFAF_DIR, "templates")
     RSTPAGES_RST_SETTINGS = {'initial_header_level': 3}
@@ -26,6 +27,7 @@ class Config(object):
 
 class ProductionConfig(Config):
     DEBUG = str2bool(config["hub2.debug"])
+    PROXY_SETUP = str2bool(config["hub2.proxy_setup"])
     SECRET_KEY = config["hub2.secret_key"]
 
 

--- a/src/webfaf2/webfaf2_main.py
+++ b/src/webfaf2/webfaf2_main.py
@@ -6,6 +6,7 @@ import flask
 from flask import Flask
 from flask.ext.rstpages import RSTPages
 from flask.ext.sqlalchemy import SQLAlchemy
+from werkzeug.contrib.fixers import ProxyFix
 
 from pyfaf.storage.user import User
 
@@ -20,11 +21,15 @@ else:
 
 db = SQLAlchemy(app)
 
+if app.config["PROXY_SETUP"]:
+    app.wsgi_app = ProxyFix(app.wsgi_app)
+
 if app.config["OPENID_ENABLED"]:
     from flask.ext.openid import OpenID
     oid = OpenID(app, safe_roots=[])
     from login import login
     app.register_blueprint(login)
+
 from dumpdirs import dumpdirs
 app.register_blueprint(dumpdirs, url_prefix="/dumpdirs")
 from reports import reports

--- a/tests/faftests/test_config.conf
+++ b/tests/faftests/test_config.conf
@@ -14,6 +14,7 @@ UrlPrefix = ""
 
 [Hub2]
 debug = True
+proxy_setup = False
 secret_key = "NO."
 
 [DumpDir]


### PR DESCRIPTION
Required when running faf behind HTTP proxy to properly rewrite
environment variables

See
http://flask.pocoo.org/docs/0.10/deploying/wsgi-standalone/#proxy-setups

Signed-off-by: Richard Marko rmarko@fedoraproject.org
