### PR TITLE
webfaf2: generate random secret key in %post

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -469,6 +469,14 @@ getent group faf >/dev/null || groupadd --system faf
 getent passwd faf >/dev/null || useradd --system -g faf -d /etc/faf -s /sbin/nologin faf
 exit 0
 
+%post webui2
+if [ "$1" = 1 ]
+then
+    # alphanumeric string of 50 characters
+    RANDOM_STR="$( cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 50 | head -n 1 )"
+    sed -i "s#@SECRET_KEY@#$RANDOM_STR#g" %{_sysconfdir}/faf/plugins/web2.conf
+fi
+
 %files
 # /etc
 %dir %{_sysconfdir}/faf


### PR DESCRIPTION
If /etc/faf/web2.conf contains @SECRET_KEY@ during installation
it's replaced by randomly generated alphanumeric string.

Signed-off-by: Richard Marko rmarko@fedoraproject.org
