### PR TITLE
pyfaf: only get fXX and fXX-updates tags from koji (no inherit)

### DIFF
--- a/config/plugins/fedora.conf
+++ b/config/plugins/fedora.conf
@@ -2,5 +2,4 @@
 PkgDBURL = https://admin.fedoraproject.org/pkgdb/
 SupportEOL = False
 build-aging-days = 14
-koji-tag = f{0}-updates
 koji-url = http://koji.fedoraproject.org/kojihub


### PR DESCRIPTION
Before this, we fetched fXX-update with inherit=True, which meant
that we would get f20 builds for f21 release, because f21-updates
inherits everything older. This could cause probable fixes to be
from an older release.
