### PR TITLE
pyfaf: always create new backtrace for report if it has none

### DIFF
--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -315,13 +315,7 @@ class CoredumpProblem(ProblemType):
         if len(bthashes) < 1:
             raise FafError("Unable to get backtrace hash")
 
-        bts = filter(None, set(get_backtrace_by_hash(db, b) for b in bthashes))
-        if len(bts) > 1:
-            raise FafError("Unable to reliably identify backtrace by hash")
-
-        if len(bts) == 1:
-            db_backtrace = bts.pop()
-        else:
+        if len(db_report.backtraces) < 1:
             new_symbols = {}
             new_symbolsources = {}
 

--- a/src/pyfaf/problemtypes/java.py
+++ b/src/pyfaf/problemtypes/java.py
@@ -243,8 +243,8 @@ class JavaProblem(ProblemType):
         db_report.errname = errname
 
         bthash = self._hash_backtrace(ureport["threads"])
-        db_backtrace = get_backtrace_by_hash(db, bthash)
-        if db_backtrace is None:
+
+        if len(db_report.backtraces) < 1:
             db_backtrace = ReportBacktrace()
             db_backtrace.report = db_report
             db_backtrace.crashfn = crashfn

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -331,35 +331,7 @@ class KerneloopsProblem(ProblemType):
         bthash1 = self._hash_koops(ureport["frames"], skip_unreliable=False)
         bthash2 = self._hash_koops(ureport["frames"], skip_unreliable=True)
 
-        db_bt1 = get_backtrace_by_hash(db, bthash1)
-        if bthash2 is not None:
-            db_bt2 = get_backtrace_by_hash(db, bthash2)
-        else:
-            db_bt2 = None
-
-        if db_bt1 is not None and db_bt2 is not None:
-            if db_bt1 != db_bt2:
-                raise FafError("Can't reliably get backtrace from bthash")
-
-            db_backtrace = db_bt1
-        elif db_bt1 is not None:
-            db_backtrace = db_bt1
-
-            if bthash2 is not None:
-                db_bthash2 = ReportBtHash()
-                db_bthash2.backtrace = db_backtrace
-                db_bthash2.hash = bthash2
-                db_bthash2.type = "NAMES"
-                db.session.add(db_bthash2)
-        elif db_bt2 is not None:
-            db_backtrace = db_bt2
-
-            db_bthash1 = ReportBtHash()
-            db_bthash1.backtrace = db_backtrace
-            db_bthash1.hash = bthash1
-            db_bthash1.type = "NAMES"
-            db.session.add(db_bthash1)
-        else:
+        if len(db_report.backtraces) < 1:
             db_backtrace = ReportBacktrace()
             db_backtrace.report = db_report
             db.session.add(db_backtrace)

--- a/src/pyfaf/problemtypes/python.py
+++ b/src/pyfaf/problemtypes/python.py
@@ -195,8 +195,8 @@ class PythonProblem(ProblemType):
         db_reportexe.count += 1
 
         bthash = self._hash_traceback(ureport["stacktrace"])
-        db_backtrace = get_backtrace_by_hash(db, bthash)
-        if db_backtrace is None:
+
+        if len(db_report.backtraces) < 1:
             db_backtrace = ReportBacktrace()
             db_backtrace.report = db_report
             db_backtrace.crashfn = crashfn


### PR DESCRIPTION
Closes #357

This basically disables backtrace deduplication that never worked. A new backtrace will be created every time a report with a new ReportHash comes in (or an older report that has no backtrace).