### PR TITLE
webfaf2: require SQLAlchemy in hub.wsgi too

### DIFF
--- a/src/webfaf2/hub.wsgi
+++ b/src/webfaf2/hub.wsgi
@@ -3,6 +3,14 @@ import os
 import sys
 import logging
 
+# sqlalchemy dependency is preferred to be explicit
+# also required for EL6
+import __main__
+import pkg_resources
+__main__.__requires__ = __requires__ = []
+__requires__.append("SQLAlchemy >= 0.8.2")
+pkg_resources.require(__requires__)
+
 logging.basicConfig(stream=sys.stderr)
 os.environ["WEBFAF_ENVIRON_PRODUCTION"] = "1"
 sys.path.insert(0, os.path.dirname(__file__))


### PR DESCRIPTION
Required for EL6 to use correct SQLAlchemy.

Semver PR should be merged first as it add correct Requires to spec.