### PR TITLE
- Add an option to effectively create the schema in a clean database.

### DIFF
--- a/src/bin/faf
+++ b/src/bin/faf
@@ -81,7 +81,7 @@ def main():
 
     # connect to the database
     try:
-        db = getDatabase(debug=cmdline.sql_verbose, dry=cmdline.dry_run)
+        db = getDatabase(debug=cmdline.sql_verbose, dry=cmdline.dry_run, create_schema=cmdline.create_schema)
     except Exception as ex:
         log.critical("Unable to connect to the database: {0}: {1}"
                      .format(ex.__class__.__name__, str(ex)))

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -98,7 +98,7 @@ class CmdlineParser(ArgumentParser):
                           help="show full traceback for unhandled exceptions")
         self.add_argument("--dry-run", action="store_true", default=False,
                           help="do not flush any changes to the database")
-        self.add_argument("--create-schema", action="create_schema", default=False,
+        self.add_argument("--create-schema", action="store_true", default=False,
                           help="create the schemas for clean databases")
 
         if toplevel:

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -98,6 +98,8 @@ class CmdlineParser(ArgumentParser):
                           help="show full traceback for unhandled exceptions")
         self.add_argument("--dry-run", action="store_true", default=False,
                           help="do not flush any changes to the database")
+        self.add_argument("--create-schema", action="create_schema", default=False,
+                          help="create the schemas for clean databases")
 
         if toplevel:
             action_parsers = self.add_subparsers(title="action")


### PR DESCRIPTION
On current status, abrt-server just create the database, and faf init
just try to access the tables, but storage/__init__.py never has the
create_schema option changed, so it failds 100% of the times on a clean
db.

Signed-off-by: Helio Chissini de Castro <helio@kde.org>