### PR TITLE
webfaf2: show frame addresses and build IDs

### DIFF
--- a/src/webfaf2/filters.py
+++ b/src/webfaf2/filters.py
@@ -89,3 +89,12 @@ def problem_label(state):
 
 def timestamp(date):
     return int(time.mktime(date.timetuple()))
+
+
+def memory_address(address):
+    if not address:
+        return address
+    # kerneloops addresses are mapped to signed longs
+    if address < 0:
+        address += (1 << 64)
+    return "0x{0:x}".format(address)

--- a/src/webfaf2/templates/_helpers.html
+++ b/src/webfaf2/templates/_helpers.html
@@ -140,8 +140,26 @@
 {% if type != 'PYTHON' %}
   <td>{{ frame.symbolsource.path }}</td>
 {% endif %}
-<td>{{ frame.symbolsource.source_path or '-' }}</td>
-<td>{{ frame.symbolsource.line_number or '-' }}</td>
+<td>
+  {%- if frame.symbolsource.source_path %}
+    <abbr title="{{ frame.symbolsource.offset|memory_address }} Build id: {{frame.symbolsource.build_id}}">{{ frame.symbolsource.source_path }}</abbr>
+  {%- elif frame.symbolsource.offset %}
+    {{ frame.symbolsource.offset|memory_address }}
+    {%- if frame.symbolsource.build_id %}
+      <br/>Build id: {{frame.symbolsource.build_id}}
+    {%- endif %}
+  {%- endif %}
+</td>
+<td>
+  {%- if frame.symbolsource.line_number %}
+    {%- if frame.symbolsource.func_offset %}
+      <abbr title="{{frame.symbolsource.func_offset|memory_address}}">{{ frame.symbolsource.line_number}}</abbr>
+    {%- else %}
+      {{ frame.symbolsource.line_number}}
+    {%- endif %}
+  {%- else %}
+    {{ frame.symbolsource.func_offset|memory_address or '-' }}</td>
+  {%- endif %}
 {%- endmacro %}
 
 {% macro show_backtrace(backtrace, type, oops) -%}
@@ -152,7 +170,7 @@
     {% if type != 'PYTHON' %}
       <th>Binary</th>
     {% endif %}
-    <th>Source</th>
+    <th>Source or offset</th>
     <th>Line</th>
   </tr>
   {% for frame in backtrace %}

--- a/src/webfaf2/webfaf2_main.py
+++ b/src/webfaf2/webfaf2_main.py
@@ -77,10 +77,11 @@ def import_blueprint_plugins(app):
         except Exception as ex:
             logging.exception("Error importing {0} blueprint.".format(filename))
 
-from filters import problem_label, fancydate, timestamp
+from filters import problem_label, fancydate, timestamp, memory_address
 app.jinja_env.filters['problem_label'] = problem_label
 app.jinja_env.filters['fancydate'] = fancydate
 app.jinja_env.filters['timestamp'] = timestamp
+app.jinja_env.filters['memory_address'] = memory_address
 
 from utils import cache, fed_raw_name, WebfafJSONEncoder
 app.json_encoder = WebfafJSONEncoder


### PR DESCRIPTION
For users to have at least some information about the frame in
case retracing didn't succeed.
Closes #389