### PR TITLE
pyfaf: better reuse old problems in create-problems

### DIFF
--- a/tests/create_problems
+++ b/tests/create_problems
@@ -7,6 +7,7 @@ except ImportError:
 
 import logging
 import datetime
+import random
 
 import faftests
 from pyfaf.storage import Report, Problem
@@ -61,6 +62,86 @@ class CreateProblemsTestCase(faftests.DatabaseCase):
 
         self.call_action("create-problems")
         self.assertEqual(self.db.session.query(Problem).count(), 1)
+
+    def randomize_ureport(self, ureport, rnd, mode, amount=1):
+        result = ureport.copy()
+        frames = result["problem"]["stacktrace"][0]["frames"]
+        # Drop random frame
+        if mode == 0:
+            for i in range(amount):
+                if len(frames) > 2:
+                    frames.pop(rnd.randint(0, len(frames)-1))
+        # Insert random frame
+        if mode == 1:
+            for i in range(amount):
+                f = {
+                    "address": rnd.randint(1000, 1000000),
+                    "build_id": str(rnd.randint(10000000000, 99999999999)),
+                    "build_id_offset": rnd.randint(1000, 1000000),
+                    "function_name": "func_"+str(rnd.randint(10000000000, 99999999999)),
+                    "file_name": "/usr/bin/fn_"+str(rnd.randint(10000000000, 99999999999))
+                }
+                frames.insert(rnd.randint(0, len(frames)), f)
+        # Shuffle
+        if mode == 2:
+            rnd.shuffle(frames)
+
+        return result
+
+    def test_create_problems_clustering(self):
+        ureport_core = self.load_report("ureport_core")
+        ureport_core1 = self.load_report("ureport_core1")
+
+        self.save_report_dict(ureport_core1)
+        self.call_action("create-problems")
+        self.assertEqual(self.db.session.query(Problem).count(), 1)
+
+        rnd = random.Random()
+        rnd.seed(1337)
+
+        # Drop 1 frame
+        self.save_report_dict(self.randomize_ureport(ureport_core1, rnd, 0, 1))
+        self.call_action("create-problems")
+        self.assertEqual(self.db.session.query(Problem).count(), 1)
+
+        # Drop 2 frames
+        self.save_report_dict(self.randomize_ureport(ureport_core1, rnd, 0, 2))
+        self.call_action("create-problems")
+        self.assertEqual(self.db.session.query(Problem).count(), 1)
+
+        # Insert 1 random frame
+        self.save_report_dict(self.randomize_ureport(ureport_core1, rnd, 1))
+        self.call_action("create-problems")
+        self.assertEqual(self.db.session.query(Problem).count(), 1)
+
+        # Insert 2 random frames
+        self.save_report_dict(self.randomize_ureport(ureport_core1, rnd, 1, 2))
+        self.call_action("create-problems")
+        self.assertEqual(self.db.session.query(Problem).count(), 1)
+
+        # Shuffle
+        self.save_report_dict(self.randomize_ureport(ureport_core1, rnd, 2))
+        self.call_action("create-problems")
+        self.assertEqual(self.db.session.query(Problem).count(), 2)
+
+        # Different report
+        self.save_report_dict(ureport_core)
+        self.call_action("create-problems")
+        self.assertEqual(self.db.session.query(Problem).count(), 3)
+
+        # E-E-Everyday I'm shufflin'
+        for i in range(50):
+            self.save_report_dict(self.randomize_ureport(ureport_core1, rnd, 2))
+        self.call_action("create-problems")
+        self.assertEqual(self.db.session.query(Problem).count(), 53)
+
+        ureport_s = self.randomize_ureport(ureport_core1, rnd, 2)
+        self.save_report_dict(ureport_s)
+        self.save_report_dict(self.randomize_ureport(ureport_s, rnd, 0, 2))
+        self.save_report_dict(self.randomize_ureport(ureport_s, rnd, 1, 2))
+        self.save_report_dict(self.randomize_ureport(ureport_s, rnd, 1, 2))
+        self.call_action("create-problems")
+        self.assertEqual(self.db.session.query(Problem).count(), 54)
 
 
 if __name__ == "__main__":

--- a/tests/faftests/__init__.py
+++ b/tests/faftests/__init__.py
@@ -190,23 +190,29 @@ class DatabaseCase(TestCase):
         if flush:
             self.db.session.flush()
 
-    def save_report(self, filename):
-        """
-        Save report located in sample_reports directory
-        with `filename`.
-        """
-
-        path = os.path.join(self.reports_path, filename)
-
-        with open(path) as file:
-            report = json.load(file)
-
+    def save_report_dict(self, report):
         ureport.validate(report)
 
         mtime = datetime.datetime.utcnow()
         ureport.save(self.db, report, timestamp=mtime)
 
         self.db.session.flush()
+
+    def load_report(self, filename):
+        path = os.path.join(self.reports_path, filename)
+
+        with open(path) as file:
+            report = json.load(file)
+
+        return report
+
+    def save_report(self, filename):
+        """
+        Save report located in sample_reports directory
+        with `filename`.
+        """
+
+        self.save_report_dict(self.load_report(filename))
 
     def call_action(self, action_name, args_dict=None):
         """

--- a/tests/sample_reports/Makefile.am
+++ b/tests/sample_reports/Makefile.am
@@ -1,6 +1,6 @@
 EXTRA_DIST = bugzilla_attachment comment_attachment contact_email_attachment \
              tainted_kernel ureport1 ureport2 ureport_f20 low_quality1 \
-             ureport_core ureport_core_invalid \
+             ureport_core ureport_core1 ureport_core_invalid \
              ureport_java ureport_kerneloops ureport_kerneloops2 \
              ureport_python ureport_ruby \
              ureport_systemd2 ureport_systemd77

--- a/tests/sample_reports/ureport_core1
+++ b/tests/sample_reports/ureport_core1
@@ -1,0 +1,151 @@
+{   "ureport_version": 2
+,   "reason": "Program /usr/bin/will_abort was terminated by signal 6"
+,   "reporter": {   "name": "satyr"
+                ,   "version": "0.16.0"
+                }
+,   "os": {   "name": "fedora"
+          ,   "version": "20"
+          ,   "architecture": "x86_64"
+          ,   "cpe": "cpe:/o:fedoraproject:fedora:20"
+          }
+,   "problem": {   "type": "core"
+               ,   "component": "will-crash"
+               ,   "user": {   "root": false
+                           ,   "local": true
+                           }
+               ,   "signal": 6
+               ,   "executable": "/usr/bin/will_abort"
+               ,   "stacktrace":
+                     [ {   "crash_thread": true
+                       ,   "frames":
+                             [ {   "address": 261175331031
+                               ,   "build_id": "3df5385c6be529423a8ae3dd39a3deb9425201cc"
+                               ,   "build_id_offset": 215255
+                               ,   "function_name": "raise"
+                               ,   "file_name": "/lib64/libc.so.6"
+                               }
+                             , {   "address": 261175338298
+                               ,   "build_id": "3df5385c6be529423a8ae3dd39a3deb9425201cc"
+                               ,   "build_id_offset": 222522
+                               ,   "function_name": "abort"
+                               ,   "file_name": "/lib64/libc.so.6"
+                               }
+                             , {   "address": 4196666
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2362
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4197053
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2749
+                               ,   "function_name": "j"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4197373
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 3069
+                               ,   "function_name": "n"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4196333
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2029
+                               ,   "function_name": "a"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4196413
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2109
+                               ,   "function_name": "b"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4197053
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2749
+                               ,   "function_name": "j"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4198333
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 4029
+                               ,   "function_name": "z"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4197133
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2829
+                               ,   "function_name": "k"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4197213
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2909
+                               ,   "function_name": "l"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4196413
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2109
+                               ,   "function_name": "b"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4196893
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2589
+                               ,   "function_name": "h"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4196493
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2189
+                               ,   "function_name": "c"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4196333
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2029
+                               ,   "function_name": "a"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4196893
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2589
+                               ,   "function_name": "h"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4197453
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 3149
+                               ,   "function_name": "o"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4196733
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 2429
+                               ,   "function_name": "f"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               }
+                             , {   "address": 4195864
+                               ,   "build_id": "aa1b5c4f9b8f22d9744693b0cdbf5b3e5edf937a"
+                               ,   "build_id_offset": 1560
+                               ,   "function_name": "main"
+                               ,   "file_name": "/usr/bin/will_abort"
+                               } ]
+                       } ]
+               }
+,   "packages": [ {   "name": "glibc"
+                  ,   "epoch": 0
+                  ,   "version": "2.20"
+                  ,   "release": "8.fc20"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1426258140
+                  }
+                , {   "name": "will-crash"
+                  ,   "epoch": 0
+                  ,   "version": "0.9"
+                  ,   "release": "1.fc20"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1418715334
+                  ,   "package_role": "affected"
+                  } ]
+}


### PR DESCRIPTION
Previously an old problem had to match in at least a half of
its reports to be reused. This methods reuses the old problem
if at least one report matches. Also properly connects the best
matches together.
This should reduce the number of empty problems left after a run
of create-problems.