### PR TITLE
pyfaf: add retrace --max-fail-count

### DIFF
--- a/src/pyfaf/actions/retrace.py
+++ b/src/pyfaf/actions/retrace.py
@@ -96,7 +96,8 @@ class Retrace(Action):
             self.log_info("Processing '{0}' problem type"
                           .format(problemplugin.nice_name))
 
-            db_ssources = problemplugin.get_ssources_for_retrace(db)
+            db_ssources = problemplugin.get_ssources_for_retrace(
+                db, cmdline.max_fail_count)
             if len(db_ssources) < 1:
                 continue
 
@@ -161,3 +162,7 @@ class Retrace(Action):
         parser.add_argument("--workers", type=int,
                             default=multiprocessing.cpu_count(),
                             help="Number of threads unpacking RPMs")
+        parser.add_argument("--max-fail-count", type=int,
+                            default=-1,
+                            help="Only retrace symbols which failed at most this"
+                                 " number of times")

--- a/src/pyfaf/problemtypes/__init__.py
+++ b/src/pyfaf/problemtypes/__init__.py
@@ -94,7 +94,7 @@ class ProblemType(Plugin):
         raise NotImplementedError("get_component_name is not implemented for "
                                   "{0}".format(self.__class__.__name__))
 
-    def get_ssources_for_retrace(self, db):
+    def get_ssources_for_retrace(self, db, max_fail_count=-1):
         """
         Return a list of pyfaf.storage.SymbolSource objects of given
         problem type that need retracing.

--- a/src/pyfaf/problemtypes/java.py
+++ b/src/pyfaf/problemtypes/java.py
@@ -332,7 +332,7 @@ class JavaProblem(ProblemType):
     def save_ureport_post_flush(self):
         self.log_debug("save_ureport_post_flush is not required for java")
 
-    def get_ssources_for_retrace(self, db):
+    def get_ssources_for_retrace(self, db, max_fail_count=-1):
         return []
 
     def find_packages_for_ssource(self, db, db_ssource):

--- a/src/pyfaf/problemtypes/python.py
+++ b/src/pyfaf/problemtypes/python.py
@@ -286,7 +286,7 @@ class PythonProblem(ProblemType):
     def save_ureport_post_flush(self):
         self.log_debug("save_ureport_post_flush is not required for python")
 
-    def get_ssources_for_retrace(self, db):
+    def get_ssources_for_retrace(self, db, max_fail_count=-1):
         return []
 
     def find_packages_for_ssource(self, db, db_ssource):

--- a/src/pyfaf/problemtypes/ruby.py
+++ b/src/pyfaf/problemtypes/ruby.py
@@ -278,7 +278,7 @@ class RubyProblem(ProblemType):
     def save_ureport_post_flush(self):
         self.log_debug("save_ureport_post_flush is not required for ruby")
 
-    def get_ssources_for_retrace(self, db):
+    def get_ssources_for_retrace(self, db, max_fail_count=-1):
         return []
 
     def find_packages_for_ssource(self, db, db_ssource):

--- a/src/pyfaf/storage/migrations/versions/48550f308625_add_symbolsource_retrace_fail_count.py
+++ b/src/pyfaf/storage/migrations/versions/48550f308625_add_symbolsource_retrace_fail_count.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2014  ABRT Team
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Add SymbolSource retrace_fail_count
+
+Revision ID: 48550f308625
+Revises: 1c7edfbf8941
+Create Date: 2015-04-27 10:26:28.975738
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '48550f308625'
+down_revision = '1c7edfbf8941'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('symbolsources', sa.Column('retrace_fail_count', sa.Integer(),
+                  nullable=False, server_default="0"))
+
+
+def downgrade():
+    op.drop_column('symbolsources', 'retrace_fail_count')

--- a/src/pyfaf/storage/migrations/versions/Makefile.am
+++ b/src/pyfaf/storage/migrations/versions/Makefile.am
@@ -8,6 +8,7 @@ versions_PYTHON = \
     31d0249e8d4c_create_users_table.py \
     43bd2d59838e_add_mantisbt.py \
     47cf82727ed1_acl_permissions.py \
+    48550f308625_add_symbolsource_retrace_fail_count.py \
     4ff13674a015_add_semver_to_build.py \
     5695a1c595c3_reportreleasedesktops.py \
     58f44afc3a3a_drop_running_package_from_reportpackages.py \

--- a/src/pyfaf/storage/symbol.py
+++ b/src/pyfaf/storage/symbol.py
@@ -53,4 +53,5 @@ class SymbolSource(GenericTable):
     presrcline = Column(String(1024), nullable=True)
     srcline = Column(String(1024), nullable=True)
     postsrcline = Column(String(1024), nullable=True)
+    retrace_fail_count = Column(Integer, nullable=False, default=0)
     symbol = relationship(Symbol, backref="sources")


### PR DESCRIPTION
This option allows to stop retracing a symbol after a given count of failed runs. In the production DB there are many symbols that fail over and over and eat the majority of processing time. The action should still be run occasionally without this option to to retry retracing of all symbols.