### PR TITLE
pyfaf: realtime fedmsg notifications

### DIFF
--- a/config/plugins/fedmsg.conf
+++ b/config/plugins/fedmsg.conf
@@ -3,3 +3,6 @@
 name = fedora-infrastructure
 # enviroment can be one of "prod", "stg" or "dev"
 environment = dev
+# Realtime notifications
+realtime_reports = false
+realtime_problems = false

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -410,9 +410,9 @@ Requires: %{name}-bugtracker-centos-mantis = %{faf_version}
 A plugin for %{name} implementing attaching of bugs from CentOS Mantis bugtracker
 
 %package action-fedmsg-notify
-Summary: %{name}'s fedmsf-notify plugin
+Summary: %{name}'s fedmsg-notify plugin
 Requires: %{name} = %{faf_version}
-Requires: fedmsg
+Requires: %{name}-fedmsg = %{faf_version}
 
 %description action-fedmsg-notify
 A plugin for %{name} implementing notification into Fedmsg
@@ -487,6 +487,22 @@ Requires: %{name}-bugtracker-mantis = %{faf_version}
 
 %description bugtracker-centos-mantis
 A plugin adding support for Mantis used by CentOS
+
+%package fedmsg
+Summary: %{name}'s Fedmsg support
+Requires: %{name} = %{faf_version}
+Requires: fedmsg
+
+%description fedmsg
+Base for Fedmsg support.
+
+%package fedmsg-realtime
+Summary: %{name}'s support for realtime Fedmsg notification sending
+Requires: %{name} = %{faf_version}
+Requires: %{name}-fedmsg = %{faf_version}
+
+%description fedmsg-realtime
+Support for sending Fedmsg notifications as reports are saved.
 
 %prep
 %setup -q
@@ -1074,7 +1090,6 @@ fi
 
 %files action-fedmsg-notify
 %{python_sitelib}/pyfaf/actions/fedmsg_notify.py*
-%config(noreplace) %{_sysconfdir}/faf/plugins/fedmsg.conf
 
 %files bugtracker-bugzilla
 %{python_sitelib}/pyfaf/bugtrackers/bugzilla.py*
@@ -1111,6 +1126,12 @@ fi
 %files bugtracker-centos-mantis
 %{python_sitelib}/pyfaf/bugtrackers/centosmantisbt.py*
 %config(noreplace) %{_sysconfdir}/faf/plugins/centosmantisbt.conf
+
+%files fedmsg
+%config(noreplace) %{_sysconfdir}/faf/plugins/fedmsg.conf
+
+%files fedmsg-realtime
+%{python_sitelib}/pyfaf/storage/events_fedmsg.py*
 
 %changelog
 * Mon Apr 15 2013 Michal Toman <mtoman@redhat.com> 0.9-1

--- a/src/pyfaf/storage/Makefile.am
+++ b/src/pyfaf/storage/Makefile.am
@@ -9,6 +9,7 @@ storage_PYTHON = \
     custom_types.py \
     debug.py \
     events.py \
+    events_fedmsg.py \
     externalfaf.py \
     llvm.py \
     opsys.py \

--- a/src/pyfaf/storage/__init__.py
+++ b/src/pyfaf/storage/__init__.py
@@ -231,3 +231,8 @@ class Database(object):
         self.session.close()
 
 import events
+# Optional fedmsg-realtime plugin
+try:
+    import events_fedmsg
+except ImportError:
+    pass

--- a/src/pyfaf/storage/events_fedmsg.py
+++ b/src/pyfaf/storage/events_fedmsg.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2015  ABRT Team
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyfaf.config import config
+from pyfaf.utils.parse import str2bool
+
+fedmsg_name = config.get("fedmsg.name", "fedora-infrastructure")
+fedmsg_environment = config.get("fedmsg.environment", "dev")
+notify_reports = str2bool(config.get("fedmsg.realtime_reports", "false"))
+notify_problems = str2bool(config.get("fedmsg.realtime_problems", "false"))
+
+if notify_reports or notify_problems:
+    from sqlalchemy import event
+    from . import Report
+    import fedmsg
+    from pyfaf.utils import web
+    from pyfaf.common import log
+    logger = log.getChildLogger(__name__)
+
+    levels = tuple(10**n for n in range(7))
+    fedmsg.init(name=fedmsg_name, environment=fedmsg_environment)
+
+    @event.listens_for(Report.count, "set")
+    def fedmsg_report(target, value, oldvalue, initiator):
+        """
+        Send fedmsg notifications when Report.count reaches specified threshold.
+        """
+        try:
+            db_report = target
+            if notify_reports:
+                oldcount = oldvalue
+                newcount = value
+                for level in levels:
+                    if oldcount < level and newcount >= level:
+                        logger.info("Notifying about report #{0} level {1}"
+                                    .format(db_report.id, level))
+                        msg = {
+                            "report_id": db_report.id,
+                            "function": db_report.crash_function,
+                            "components": [db_report.component.name],
+                            "first_occurrence": db_report.first_occurrence
+                                                .strftime("%Y-%m-%d"),
+                            "count": newcount,
+                            "type": db_report.type,
+                            "level": level,
+                        }
+                        if web.webfaf_installed():
+                            msg["url"] = web.reverse("reports.item",
+                                                     report_id=db_report.id)
+                        if db_report.problem_id:
+                            msg["problem_id"] = db_report.problem_id
+
+                        fedmsg.publish(
+                            topic="report.threshold{0}".format(level),
+                            modname='faf',
+                            msg=msg)
+
+            if notify_problems and db_report.problem is not None:
+                oldcount = db_report.problem.reports_count
+                newcount = oldcount + value - oldvalue
+                for level in levels:
+                    if oldcount < level and newcount >= level:
+                        logger.info("Notifying about problem #{0} level {1}"
+                                    .format(db_report.problem.id, level))
+                        msg = {
+                            "problem_id": db_report.problem.id,
+                            "function": db_report.problem.crash_function,
+                            "components": db_report.problem.unique_component_names,
+                            "first_occurrence": db_report.problem.first_occurrence
+                                                .strftime("%Y-%m-%d"),
+                            "count": newcount,
+                            "type": db_report.type,
+                            "level": level,
+                        }
+                        if web.webfaf_installed():
+                            msg["url"] = web.reverse("problems.item",
+                                                     problem_id=db_report.problem.id)
+                        fedmsg.publish(
+                            topic="problem.threshold{0}".format(level),
+                            modname='faf',
+                            msg=msg)
+        # Catch any exception. This is non-critical and mustn't break stuff
+        # elsewhere.
+        except Exception as e:
+            logger.exception(e, exc_info=True)

--- a/src/pyfaf/storage/report.py
+++ b/src/pyfaf/storage/report.py
@@ -53,6 +53,8 @@ class Report(GenericTable):
     type = Column(String(64), nullable=False, index=True)
     first_occurrence = Column(DateTime)
     last_occurrence = Column(DateTime)
+    # Watch out, there's a "set" event handler on count that can send out fedmsg
+    # notifications.
     count = Column(Integer, nullable=False)
     errname = Column(String(256), nullable=True)
     component_id = Column(Integer, ForeignKey("{0}.id".format(OpSysComponent.__tablename__)), nullable=False, index=True)


### PR DESCRIPTION
The plugins adds a "set" handler on Report.count. Whenever the
count goes over one of the thresholds, a fedmsg notification is
sent immediately.
If the package is not installed or disables in configuration,
there is zero overhead in report saving.