### PR TITLE
Add fedmenu but display it only if configured for FAF

### DIFF
--- a/src/webfaf2/templates/base.html
+++ b/src/webfaf2/templates/base.html
@@ -91,5 +91,23 @@
           </a>
         </div>
       </div>
+      {%- if config['FEDMENU_URL'] and config['FEDMENU_DATA_URL'] %}
+      <script src="{{ config['FEDMENU_URL'] }}/js/fedmenu.js"></script>
+      <script>
+        fedmenu({
+          'url': '{{ config["FEDMENU_DATA_URL"] }}',
+          'mimeType': 'application/javascript',
+          'position': 'bottom-right',
+          {%- if component %}
+          'package': '{{ component.name }}',
+          {%- elif problem %}
+            {%- if problem.unique_component_names | length == 1 %}
+            {#- unique_component_names is a set, this gets the one item #}
+            'package': '{{ problem.unique_component_names|first }}'
+            {%- endif %}
+          {%- endif %}
+        });
+     </script>
+     {%- endif %}
   </body>
 </html>


### PR DESCRIPTION
With this change, we are adding on the bottom right side of the screen
a small menu, specific to Fedora that provides a way for Fedora users
to quickly navigate through our applications.