### PR TITLE
WebUI actions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,20 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = config src tests
 
-EXTRA_DIST = autogen.sh gen-version faf-version faf.spec.in
+EXTRA_DIST = autogen.sh gen-version faf-version faf.spec.in \
+             init-scripts/faf-celery-beat.service \
+             init-scripts/faf-celery-worker.service \
+             init-scripts/faf-celery-tmpfiles.conf
+
+
+
+if HAVE_SYSTEMD
+systemdsystemunitdir=/usr/lib/systemd/system/
+systemdsystemunit_DATA = init-scripts/faf-celery-beat.service \
+                         init-scripts/faf-celery-worker.service
+tmpfilesddir=/usr/lib/tmpfiles.d/
+tmpfilesd_DATA = init-scripts/faf-celery-tmpfiles.conf
+endif
 
 RPM_DIRS = --define "_sourcedir `pwd`" \
            --define "_rpmdir `pwd`" \

--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -5,6 +5,12 @@
 SUBDIRS = plugins templates
 
 config_DATA = faf.conf
+
+if HAVE_SYSTEMD
+  config_DATA += celery-beat-env.conf
+  config_DATA += celery-worker-env.conf
+endif
+
 configdir = $(sysconfdir)/faf
 
 faf.conf: faf.conf.in
@@ -20,6 +26,8 @@ faf-web.conf: faf-web.conf.in
 faf-web2.conf: faf-web2.conf.in
 	sed -e "s|@PYTHONDIR@|$(pythondir)|g" $< > $@
 
-EXTRA_DIST = faf.conf.in \
+EXTRA_DIST = celery-beat-env.conf \
+             celery-worker-env.conf \
+             faf.conf.in \
              faf-web.conf.in \
              faf-web2.conf.in

--- a/config/celery-beat-env.conf
+++ b/config/celery-beat-env.conf
@@ -1,0 +1,6 @@
+CELERY_APP="pyfaf.celery_tasks.celery_app"
+CELERYD_NODES="beat"
+CELERYD_OPTS="-C -S pyfaf.celery_tasks.schedulers.DBScheduler"
+CELERYD_PID_FILE="/run/faf-celery/faf-celery-beat.pid"
+CELERYD_LOG_FILE="/var/log/faf/faf-celery-beat.log"
+CELERYD_LOG_LEVEL="INFO"

--- a/config/celery-worker-env.conf
+++ b/config/celery-worker-env.conf
@@ -1,0 +1,6 @@
+CELERY_APP="pyfaf.celery_tasks.celery_app"
+CELERYD_NODES="worker"
+CELERYD_OPTS="-C"
+CELERYD_PID_FILE="/run/faf-celery/faf-celery-%n.pid"
+CELERYD_LOG_FILE="/var/log/faf/faf-celery-%n.log"
+CELERYD_LOG_LEVEL="INFO"

--- a/config/plugins/Makefile.am
+++ b/config/plugins/Makefile.am
@@ -2,6 +2,7 @@ pluginconf_DATA = \
     centos.conf \
     clonebz.conf \
     centosmantisbt.conf \
+    celery_tasks.conf \
     coredump.conf \
     create-problems.conf \
     fedora.conf \

--- a/config/plugins/celery_tasks.conf
+++ b/config/plugins/celery_tasks.conf
@@ -1,0 +1,3 @@
+[celery_tasks]
+broker = redis://localhost:6379/0
+backend = redis://localhost:6379/0

--- a/config/plugins/web2.conf
+++ b/config/plugins/web2.conf
@@ -15,6 +15,10 @@ brand_subtitle = Fedora Analysis Framework
 # checks and make everyone a package maintainer.
 # In that case no login is necessary to access maintainer-only actions.
 everyone_is_maintainer = false
+# When OpenID login is disabled, this option can be used to override permission
+# checks and make everyone an admin.
+# In that case no login is necessary to access admin-only actions.
+everyone_is_admin = false
 
 [DumpDir]
 CacheDirectory = /var/spool/faf/dumpdirs

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AC_CONFIG_FILES([
     src/pyfaf/Makefile
     src/pyfaf/actions/Makefile
     src/pyfaf/bugtrackers/Makefile
+    src/pyfaf/celery_tasks/Makefile
     src/pyfaf/opsys/Makefile
     src/pyfaf/problemtypes/Makefile
     src/pyfaf/repos/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,14 @@
+AC_DEFUN([FAF_PARSE_WITH],
+    [m4_pushdef([FAF_UC_PACKAGE], m4_toupper([$1]))dnl
+    if test "$withval" = "no"; then
+        NO_[]FAF_UC_PACKAGE=YesPlease
+    elif test "$withval" = "yes"; then
+        NO_[]FAF_UC_PACKAGE=
+    else
+        NO_[]FAF_UC_PACKAGE=
+    fi
+    m4_popdef([FAF_UC_PACKAGE])])
+
 AC_INIT([faf],
     m4_esyscmd([cat ./faf-version]),
     [crash-catcher@fedorahosted.org])
@@ -15,6 +26,14 @@ AC_PROG_LIBTOOL
 AM_PATH_PYTHON([2.6])
 
 AC_PATH_PROGS(BASH, sh bash)
+
+AC_ARG_WITH(systemd,
+AS_HELP_STRING([--with-systemd],[use Systemd (default is YES)]),
+FAF_PARSE_WITH([systemd]))
+if test -z "$YES_SYSTEMD"
+then
+AM_CONDITIONAL(HAVE_SYSTEMD, true)
+fi
 
 AC_CONFIG_FILES([
     faf.spec

--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,7 @@ AC_CONFIG_FILES([
     src/webfaf2/static/fonts/Makefile
     src/webfaf2/static/css/Makefile
     src/webfaf2/templates/Makefile
+    src/webfaf2/templates/celery_tasks/Makefile
     src/webfaf2/templates/dumpdirs/Makefile
     src/webfaf2/templates/problems/Makefile
     src/webfaf2/templates/reports/Makefile

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -473,6 +473,17 @@ Requires: %{name}-webui2 = %{faf_version}
 %description blueprint-symbol-transfer
 A plugin for %{name} implementing symbol transfer plugin.
 
+%package blueprint-celery-tasks
+Summary: %{name}'s Celery tasks blueprint
+Requires: faf = %{faf_version}
+Requires: %{name} = %{faf_version}
+Requires: %{name}-webui2 = %{faf_version}
+Requires: %{name}-celery-tasks = %{faf_version}
+Requires: python-bunch
+
+%description blueprint-celery-tasks
+A plugin for %{name} implementing Celery tasks blueprint plugin.
+
 %package migrations
 Summary: %{name}'s database migrations
 Requires: %{name} = %{faf_version}
@@ -1133,6 +1144,14 @@ fi
 %files blueprint-symbol-transfer
 %config(noreplace) %{_sysconfdir}/faf/plugins/symbol-transfer.conf
 %{python_sitelib}/webfaf2/blueprints/symbol_transfer.py*
+
+%files blueprint-celery-tasks
+%{python_sitelib}/webfaf2/blueprints/celery_tasks.py*
+%{python_sitelib}/webfaf2/templates/celery_tasks/action_run.html
+%{python_sitelib}/webfaf2/templates/celery_tasks/index.html
+%{python_sitelib}/webfaf2/templates/celery_tasks/results_item.html
+%{python_sitelib}/webfaf2/templates/celery_tasks/results_list.html
+%{python_sitelib}/webfaf2/templates/celery_tasks/schedule_item.html
 
 %files migrations
 %{python_sitelib}/pyfaf/storage/migrations/alembic.ini

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -5,6 +5,12 @@
 %define jquery_version 1.7.2
 %define select2_version 2.1
 
+%if 0%{?fedora:%{fedora} < 14}%{?rhel:%{rhel} < 7}
+    %bcond_with systemd
+%else
+    %bcond_without systemd
+%endif
+
 Name: faf
 Version: %{faf_version}
 Release: 1%{?dist}
@@ -532,13 +538,38 @@ Requires: python-celery >= 3.1
 %description celery-tasks
 Task queue using Celery.
 
+%if %{with systemd}
+%package celery-tasks-systemd-services
+Summary: %{name}'s Celery task queue systemd services
+Requires: %{name} = %{faf_version}
+Requires: systemd-units
+
+%description celery-tasks-systemd-services
+systemd services for the Celery task queue.
+
+%post celery-tasks-systemd-services
+%systemd_post faf-celery-beat.service
+%systemd_post faf-celery-worker.service
+
+%preun celery-tasks-systemd-services
+%systemd_preun faf-celery-beat.service
+%systemd_preun faf-celery-worker.service
+
+%postun celery-tasks-systemd-services
+%systemd_postun_with_restart faf-celery-beat.service
+%systemd_postun_with_restart faf-celery-worker.service
+%endif
 
 %prep
 %setup -q
 ./autogen.sh
 
 %build
+%if %{with systemd}
+%configure --with-systemd
+%else
 %configure
+%endif
 make %{?_smp_mflags}
 
 %install
@@ -577,6 +608,11 @@ mkdir -p %{buildroot}%{_localstatedir}/spool/faf/web/upload
 
 # /var/log
 mkdir -p %{buildroot}%{_localstatedir}/log/faf/
+
+%if %{with systemd}
+mkdir -p %{buildroot}%{_tmpfilesdir}
+mkdir -p %{buildroot}/run/faf-celery
+%endif
 
 %check
 make check || ( cat tests/test-suite.log ; cat tests/webfaf/test-suite.log ; exit 1 ) 
@@ -1179,6 +1215,16 @@ fi
 %{python_sitelib}/pyfaf/storage/task.py*
 %{python_sitelib}/pyfaf/celery_tasks/__init__.py*
 %{python_sitelib}/pyfaf/celery_tasks/schedulers.py*
+
+%if %{with systemd}
+%files celery-tasks-systemd-services
+%{_unitdir}/faf-celery-beat.service
+%{_unitdir}/faf-celery-worker.service
+%config(noreplace) %{_sysconfdir}/faf/celery-beat-env.conf
+%config(noreplace) %{_sysconfdir}/faf/celery-worker-env.conf
+%{_tmpfilesdir}/faf-celery-tmpfiles.conf
+%dir /run/faf-celery/
+%endif
 
 %changelog
 * Mon Apr 15 2013 Michal Toman <mtoman@redhat.com> 0.9-1

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -419,6 +419,13 @@ Requires: %{name}-fedmsg = %{faf_version}
 %description action-fedmsg-notify
 A plugin for %{name} implementing notification into Fedmsg
 
+%package action-cleanup-task-results
+Summary: %{name}'s cleanup-task-results plugin
+Requires: %{name} = %{faf_version}
+
+%description action-cleanup-task-results
+A plugin for %{name} implementing cleanup of old task results.
+
 %package bugtracker-bugzilla
 Summary: %{name}'s bugzilla support
 Requires: %{name} = %{faf_version}
@@ -1101,6 +1108,9 @@ fi
 
 %files action-fedmsg-notify
 %{python_sitelib}/pyfaf/actions/fedmsg_notify.py*
+
+%files action-cleanup-task-results
+%{python_sitelib}/pyfaf/actions/cleanup_task_results.py*
 
 %files bugtracker-bugzilla
 %{python_sitelib}/pyfaf/bugtrackers/bugzilla.py*

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -506,6 +506,15 @@ Requires: %{name}-fedmsg = %{faf_version}
 %description fedmsg-realtime
 Support for sending Fedmsg notifications as reports are saved.
 
+%package celery-tasks
+Summary: %{name}'s task queue based on Celery
+Requires: %{name} = %{faf_version}
+Requires: python-celery >= 3.1
+
+%description celery-tasks
+Task queue using Celery.
+
+
 %prep
 %setup -q
 ./autogen.sh
@@ -1134,6 +1143,13 @@ fi
 
 %files fedmsg-realtime
 %{python_sitelib}/pyfaf/storage/events_fedmsg.py*
+
+%files celery-tasks
+%config(noreplace) %{_sysconfdir}/faf/plugins/celery_tasks.conf
+%{python_sitelib}/pyfaf/storage/jsontype.py*
+%{python_sitelib}/pyfaf/storage/task.py*
+%{python_sitelib}/pyfaf/celery_tasks/__init__.py*
+%{python_sitelib}/pyfaf/celery_tasks/schedulers.py*
 
 %changelog
 * Mon Apr 15 2013 Michal Toman <mtoman@redhat.com> 0.9-1

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -64,6 +64,7 @@ BuildRequires: python-flask-openid
 BuildRequires: python-flask-rstpages
 BuildRequires: python-flask-sqlalchemy
 BuildRequires: python-jinja2 >= 2.7
+BuildRequires: python-bunch
 
 %description
 faf is a programmable tool for analysis of packages, packaging
@@ -157,6 +158,7 @@ Requires: python-flask-rstpages
 Requires: python-flask-sqlalchemy
 Requires: python-flask-openid
 Requires: python-jinja2 >= 2.7
+Requires: python-bunch
 
 %description webui2
 A WebUI rewrite

--- a/init-scripts/faf-celery-beat.service
+++ b/init-scripts/faf-celery-beat.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=FAF Celery beat
+After=network.target
+
+[Service]
+User=faf
+Group=faf
+EnvironmentFile=/etc/faf/celery-beat-env.conf
+WorkingDirectory=/etc/faf
+ExecStart=/usr/bin/python -m celery beat \
+    -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
+    --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} \
+    $CELERYD_OPTS
+PIDFile=${CELERYD_PID_FILE}
+
+[Install]
+WantedBy=multi-user.target

--- a/init-scripts/faf-celery-tmpfiles.conf
+++ b/init-scripts/faf-celery-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /run/faf-celery 0755 faf faf -

--- a/init-scripts/faf-celery-worker.service
+++ b/init-scripts/faf-celery-worker.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=FAF Celery worker
+After=network.target
+
+[Service]
+Type=forking
+User=faf
+Group=faf
+EnvironmentFile=/etc/faf/celery-worker-env.conf
+WorkingDirectory=/etc/faf
+ExecStart=/usr/bin/python -m celery multi start $CELERYD_NODES \
+    -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
+    --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+    $CELERYD_OPTS
+ExecStop=/usr/bin/python -m celery multi stopwait $CELERYD_NODES \
+    --pidfile=${CELERYD_PID_FILE}
+ExecReload=/usr/bin/python -m celery multi restart $CELERYD_NODES \
+    -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
+    --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+    $CELERYD_OPTS
+
+[Install]
+WantedBy=multi-user.target

--- a/src/pyfaf/Makefile.am
+++ b/src/pyfaf/Makefile.am
@@ -1,6 +1,7 @@
 SUBDIRS = \
     actions \
     bugtrackers \
+    celery_tasks \
     opsys \
     problemtypes \
     repos \

--- a/src/pyfaf/actions/Makefile.am
+++ b/src/pyfaf/actions/Makefile.am
@@ -10,6 +10,7 @@ actions_PYTHON = \
     pull_bug.py \
     update_bugs.py \
     c2p.py \
+    cleanup_task_results.py \
     componentadd.py \
     create_problems.py \
     extfafadd.py \

--- a/src/pyfaf/actions/__init__.py
+++ b/src/pyfaf/actions/__init__.py
@@ -33,6 +33,8 @@ class Action(Plugin):
     """
     A common superclass for action plugins.
     """
+    # cmdline_only actions are not available in the Web UI
+    cmdline_only = False
 
     def __init__(self, *args, **kwargs):
         """

--- a/src/pyfaf/actions/c2p.py
+++ b/src/pyfaf/actions/c2p.py
@@ -29,6 +29,7 @@ from pyfaf.utils.proc import safe_popen
 
 class Coredump2Packages(Action):
     name = "c2p"
+    cmdline_only = True
 
     UNSTRIP_LINE_PARSER = re.compile(r"^0x[0-9a-f]+\+0x[0-9a-f]+ "
                                      r"(([0-9a-f]+)@0x[0-9a-f]+|\-) "

--- a/src/pyfaf/actions/cleanup_task_results.py
+++ b/src/pyfaf/actions/cleanup_task_results.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2015  ABRT Team
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyfaf.actions import Action
+from pyfaf.storage.task import TaskResult
+from datetime import datetime, timedelta
+
+
+class CleanupTaskResults(Action):
+    name = "cleanup-task-results"
+
+    def run(self, cmdline, db):
+        if cmdline.keep_days >= 0:
+            q = (db.session.query(TaskResult)
+                           .filter(TaskResult.finished_time <
+                                   datetime.now()-timedelta(days=cmdline.keep_days)))
+            self.log_info("About to delete {0} task results older than {1} days."
+                          .format(q.count(), cmdline.keep_days))
+            q.delete()
+            db.session.flush()
+            self.log_info("Task results deleted".format(q.count()))
+        else:
+            self.log_warn("--keep-days must be greater or equal to 0.")
+
+    def tweak_cmdline_parser(self, parser):
+        parser.add_argument("--keep-days", help="keep results for the last D days",
+                            default=14, type=int)

--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -210,7 +210,7 @@ class RepoSync(Action):
                 yield repo_types[repo.type](name, url)
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", nargs="*", help="repository to sync")
+        parser.add_repo(multiple=True)
         parser.add_argument("--no-download-rpm", action="store_true",
                             help="Don't download the RPM. Cannot create "
                                  "dependencies.")

--- a/src/pyfaf/actions/shell.py
+++ b/src/pyfaf/actions/shell.py
@@ -35,6 +35,7 @@ from sqlalchemy.sql.expression import func
 
 class Shell(Action):
     name = "shell"
+    cmdline_only = True
 
     def __init__(self):
         super(Shell, self).__init__()

--- a/src/pyfaf/celery_tasks/Makefile.am
+++ b/src/pyfaf/celery_tasks/Makefile.am
@@ -1,0 +1,5 @@
+celery_tasks_PYTHON = \
+    __init__.py \
+    schedulers.py
+
+celery_tasksdir = $(pythondir)/pyfaf/celery_tasks

--- a/src/pyfaf/celery_tasks/__init__.py
+++ b/src/pyfaf/celery_tasks/__init__.py
@@ -1,0 +1,71 @@
+import bunch
+import datetime
+import logging
+
+from celery import Celery
+from celery.signals import task_postrun
+from pyfaf.actions import actions
+from pyfaf.config import config
+from pyfaf.storage import DatabaseFactory, TaskResult
+from pyfaf.utils.contextmanager import captured_output_combined
+
+
+celery_app = Celery("pyfaf_tasks",
+                    broker=config.get("celery_tasks.broker", ""),
+                    backend=config.get("celery_tasks.backend", ""))
+
+db_factory = DatabaseFactory(autocommit=True)
+
+
+class ActionError(Exception):
+    def __init__(self, output):
+        self.output = output
+        Exception.__init__(self, output)
+
+    def __str__(self):
+        return self.output
+
+
+@task_postrun.connect
+def task_postrun_handler(signal, sender, **named):
+    db = db_factory.get_database()
+    tr = TaskResult()
+    tr.id = named["task_id"]
+    tr.task = named["task"].name
+    tr.finished_time = datetime.datetime.now()
+    tr.state = named["state"]
+    tr.retval = named["retval"]
+    tr.args = named["args"]
+    tr.kwargs = named["kwargs"]
+    db.session.add(tr)
+    db.session.flush()
+
+
+@celery_app.task()
+def run_action(name, params={}, log_level=logging.DEBUG, output_length=1000):
+    db = db_factory.get_database()
+    action = actions[name]
+    cmdline = bunch.Bunch(params)
+
+    with captured_output_combined() as cap_stdout:
+        # Logger and fake stdout to capture the output of the action
+        root = logging.getLogger()
+        ch = logging.StreamHandler(cap_stdout)
+        ch.setLevel(log_level)
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        ch.setFormatter(formatter)
+        root.addHandler(ch)
+        try:
+            action.run(cmdline, db)
+        except Exception as e:
+            logging.exception(e)
+            db.session.rollback()
+            output = cap_stdout.getvalue()
+            # There seems to be no way to pass a FAILURE status other than raising
+            # an exception. self.update_status(status="FAILURE") didn't work.
+            raise ActionError(output[-output_length:])
+
+        db.session.rollback()
+        output = cap_stdout.getvalue()
+        return output[-output_length:]

--- a/src/pyfaf/celery_tasks/schedulers.py
+++ b/src/pyfaf/celery_tasks/schedulers.py
@@ -1,0 +1,111 @@
+# Based on code by Kong Luoxing 2014
+
+import datetime
+
+from celery.beat import Scheduler, ScheduleEntry
+from celery import current_app
+import celery.schedules
+
+from pyfaf.storage.task import PeriodicTask
+from pyfaf.storage import DatabaseFactory
+
+db_factory = DatabaseFactory()
+
+
+class DBScheduleEntry(ScheduleEntry):
+    def __init__(self, db_task):
+        self.db_task = db_task
+        self.app = current_app._get_current_object()
+        self.name = db_task.name
+        self.task = db_task.task
+        self.enabled = db_task.enabled
+
+        self.schedule = celery.schedules.crontab(minute=db_task.crontab_minute,
+                                                 hour=db_task.crontab_hour,
+                                                 day_of_week=db_task.crontab_day_of_week,
+                                                 day_of_month=db_task.crontab_day_of_month,
+                                                 month_of_year=db_task.crontab_month_of_year)
+
+        self.args = db_task.args
+        self.kwargs = db_task.kwargs
+
+        self.options = {}
+
+        if not self.db_task.last_run_at:
+            self.db_task.last_run_at = self._default_now()
+        self.last_run_at = self.db_task.last_run_at
+
+    def _default_now(self):
+        return self.app.now()
+
+    def next(self):
+        self.db_task.last_run_at = self.app.now()
+        return self.__class__(self.db_task)
+
+    __next__ = next
+
+    def is_due(self):
+        if not self.enabled:
+            return False, 60.0  # 60 second delay for re-enable.
+        return self.schedule.is_due(self.last_run_at)
+
+    def __repr__(self):
+        return '<DBScheduleEntry ({0} {1}(*{2}, **{3}) {{4}})>'.format(
+            self.name, self.task, self.args,
+            self.kwargs, self.schedule,
+        )
+
+    def reserve(self, entry):
+        new_entry = Scheduler.reserve(self, entry)
+        return new_entry
+
+    def save(self):
+        if self.last_run_at and self.db_task.last_run_at and self.last_run_at > self.db_task.last_run_at:
+            self.db_task.last_run_at = self.last_run_at
+
+
+class DBScheduler(Scheduler):
+    # how often should we sync in schedule information
+    # from the backend DB
+    UPDATE_INTERVAL = datetime.timedelta(seconds=30)
+
+    Entry = DBScheduleEntry
+
+    def __init__(self, *args, **kwargs):
+        self._schedule = {}
+        self._last_updated = None
+        Scheduler.__init__(self, *args, **kwargs)
+        self.max_interval = (kwargs.get('max_interval')
+                             or self.app.conf.CELERYBEAT_MAX_LOOP_INTERVAL or 300)
+        self.db = db_factory.get_database()
+
+    def setup_schedule(self):
+        pass
+
+    def requires_update(self):
+        # check whether we should pull an updated schedule from the backend
+        # database
+        if not self._last_updated:
+            return True
+        return self._last_updated + self.UPDATE_INTERVAL < datetime.datetime.now()
+
+    def get_from_database(self):
+        d = {}
+        for task in self.db.session.query(PeriodicTask):
+            d[task.name] = DBScheduleEntry(task)
+        return d
+
+    @property
+    def schedule(self):
+        if self.requires_update():
+            self._schedule = self.get_from_database()
+            self._last_updated = datetime.datetime.now()
+        return self._schedule
+
+    def sync(self):
+        for entry in self.schedule.values():
+            entry.save()
+        self.db.session.commit()
+
+    def close(self):
+        self.sync()

--- a/src/pyfaf/storage/Makefile.am
+++ b/src/pyfaf/storage/Makefile.am
@@ -11,6 +11,7 @@ storage_PYTHON = \
     events.py \
     events_fedmsg.py \
     externalfaf.py \
+    jsontype.py \
     llvm.py \
     opsys.py \
     mantisbt.py \
@@ -19,6 +20,7 @@ storage_PYTHON = \
     report.py \
     sf_prefilter.py \
     symbol.py \
+    task.py \
     user.py
 
 storagedir = $(pythondir)/pyfaf/storage

--- a/src/pyfaf/storage/__init__.py
+++ b/src/pyfaf/storage/__init__.py
@@ -180,6 +180,7 @@ from llvm import *
 from sf_prefilter import *
 from debug import *
 from user import *
+from task import *
 
 
 def column_len(cls, name):

--- a/src/pyfaf/storage/__init__.py
+++ b/src/pyfaf/storage/__init__.py
@@ -230,6 +230,21 @@ class Database(object):
     def close(self):
         self.session.close()
 
+
+class TemporaryDatabase(object):
+    def __init__(self, session):
+        self.session = session
+
+
+class DatabaseFactory(object):
+    def __init__(self, autocommit=False):
+        self.engine = create_engine(config["storage.connectstring"], echo=False)
+        self.sessionmaker = sessionmaker(bind=self.engine, autocommit=autocommit)
+
+    def get_database(self):
+        return TemporaryDatabase(self.sessionmaker())
+
+
 import events
 # Optional fedmsg-realtime plugin
 try:

--- a/src/pyfaf/storage/jsontype.py
+++ b/src/pyfaf/storage/jsontype.py
@@ -1,0 +1,17 @@
+import sqlalchemy as sa
+
+import json
+
+
+class JSONType(sa.types.TypeDecorator):
+    impl = sa.UnicodeText
+
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            value = json.dumps(value)
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None:
+            value = json.loads(value)
+        return value

--- a/src/pyfaf/storage/migrations/versions/Makefile.am
+++ b/src/pyfaf/storage/migrations/versions/Makefile.am
@@ -13,7 +13,8 @@ versions_PYTHON = \
     5695a1c595c3_reportreleasedesktops.py \
     58f44afc3a3a_drop_running_package_from_reportpackages.py \
     7fa8b3134f0_probable_fix_by_opsy.py \
-    82081a3c76b_rename_kb_to_sf_prefilter.py
+    82081a3c76b_rename_kb_to_sf_prefilter.py \
+    cef2fcd69ef_celery_tasks.py
 
 
 versionsdir = $(pythondir)/pyfaf/storage/migrations/versions

--- a/src/pyfaf/storage/migrations/versions/cef2fcd69ef_celery_tasks.py
+++ b/src/pyfaf/storage/migrations/versions/cef2fcd69ef_celery_tasks.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2014  ABRT Team
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Celery tasks
+
+Revision ID: cef2fcd69ef
+Revises: 48550f308625
+Create Date: 2015-06-01 12:22:13.499460
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'cef2fcd69ef'
+down_revision = '48550f308625'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    op.create_table('periodictasks',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('name', sa.String(length=100), nullable=False),
+    sa.Column('task', sa.String(length=100), nullable=False),
+    sa.Column('enabled', sa.Boolean(), nullable=False),
+    sa.Column('crontab_minute', sa.String(length=20), nullable=False),
+    sa.Column('crontab_hour', sa.String(length=20), nullable=False),
+    sa.Column('crontab_day_of_week', sa.String(length=20), nullable=False),
+    sa.Column('crontab_day_of_month', sa.String(length=20), nullable=False),
+    sa.Column('crontab_month_of_year', sa.String(length=20), nullable=False),
+    sa.Column('last_run_at', sa.DateTime(), nullable=True),
+    sa.Column('args', sa.Text(), nullable=False),
+    sa.Column('kwargs', sa.Text(), nullable=False),
+    sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table('taskresult',
+    sa.Column('id', sa.String(length=50), nullable=False),
+    sa.Column('task', sa.String(length=100), nullable=False),
+    sa.Column('finished_time', sa.DateTime(), nullable=True),
+    sa.Column('state', sa.String(length=20), nullable=False),
+    sa.Column('retval', sa.Text(), nullable=False),
+    sa.Column('args', sa.Text(), nullable=False),
+    sa.Column('kwargs', sa.Text(), nullable=False),
+    sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade():
+    op.drop_table('taskresult')
+    op.drop_table('periodictasks')

--- a/src/pyfaf/storage/task.py
+++ b/src/pyfaf/storage/task.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2015  ABRT Team
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+from . import Boolean
+from . import Column
+from . import GenericTable
+from . import String
+from . import Text
+from . import Integer
+from . import DateTime
+from pyfaf.storage.jsontype import JSONType
+import json
+
+
+class PeriodicTask(GenericTable):
+    __tablename__ = "periodictasks"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), nullable=False)
+    task = Column(String(100), nullable=False)
+    enabled = Column(Boolean, nullable=False, default=True)
+    crontab_minute = Column(String(20), nullable=False, default="*")
+    crontab_hour = Column(String(20), nullable=False, default="*")
+    crontab_day_of_week = Column(String(20), nullable=False, default="*")
+    crontab_day_of_month = Column(String(20), nullable=False, default="*")
+    crontab_month_of_year = Column(String(20), nullable=False, default="*")
+    last_run_at = Column(DateTime, nullable=True)
+    args = Column(JSONType, nullable=False, default=[])
+    kwargs = Column(JSONType, nullable=False, default={})
+
+    @property
+    def is_run_action(self):
+        return self.task == "pyfaf.celery_tasks.run_action"
+
+    @property
+    def args_parsed(self):
+
+        return self._foo
+
+    @property
+    def nice_name(self):
+        return self.name
+
+    @property
+    def nice_task(self):
+        if self.is_run_action and len(self.args) > 0:
+            return "Action {0}".format(self.args[0])
+        return self.task
+
+
+class TaskResult(GenericTable):
+    __tablename__ = "taskresult"
+    id = Column(String(50), primary_key=True)
+    task = Column(String(100), nullable=False)
+    finished_time = Column(DateTime, nullable=True)
+    state = Column(String(20), nullable=False)
+    retval = Column(Text, nullable=False, default="")
+    args = Column(JSONType, nullable=False, default=[])
+    kwargs = Column(JSONType, nullable=False, default={})
+
+    @property
+    def is_run_action(self):
+        return self.task == "pyfaf.celery_tasks.run_action"
+
+    @property
+    def nice_task(self):
+        if self.is_run_action and len(self.args) > 0:
+            return "Action {0}".format(self.args[0])
+        return self.task
+
+    @property
+    def nice_args(self):
+        return json.dumps(self.args, indent=4)

--- a/src/pyfaf/utils/contextmanager.py
+++ b/src/pyfaf/utils/contextmanager.py
@@ -21,3 +21,23 @@ def captured_output():
         yield sys.stdout, sys.stderr
     finally:
         sys.stdout, sys.stderr = old_out, old_err
+
+
+@contextmanager
+def captured_output_combined():
+    """
+    Capture stdout and stderr combined output of the executed block
+
+    Example:
+
+    with captured_output_combined() as out:
+        foo()
+    """
+
+    new_out = StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_out
+        yield sys.stdout
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err

--- a/src/webfaf2/blueprints/Makefile.am
+++ b/src/webfaf2/blueprints/Makefile.am
@@ -1,3 +1,6 @@
-blueprints_PYTHON = __init__.py symbol_transfer.py
+blueprints_PYTHON = \
+    __init__.py \
+    celery_tasks.py \
+    symbol_transfer.py
 
 blueprintsdir = $(pythondir)/webfaf2/blueprints

--- a/src/webfaf2/blueprints/__init__.py
+++ b/src/webfaf2/blueprints/__init__.py
@@ -35,4 +35,10 @@ def hello():
 
 blueprint = example_blueprint
 
+blueprint_menu = [{
+    "title": "Example",
+    "route": "example.hello",
+    "admin_required": False,
+}, ]
+
 """

--- a/src/webfaf2/blueprints/celery_tasks.py
+++ b/src/webfaf2/blueprints/celery_tasks.py
@@ -1,0 +1,366 @@
+import json
+
+from flask import (Blueprint, request, abort, Response, render_template, flash,
+                   redirect, url_for)
+from pyfaf.storage import (PeriodicTask, TaskResult, OpSysRelease, Repo)
+from webfaf2_main import db
+
+from pyfaf.celery_tasks import run_action, celery_app
+from pyfaf.actions import actions as actions_all
+from pyfaf.problemtypes import problemtypes
+from pyfaf.opsys import systems
+from pyfaf.bugtrackers import bugtrackers
+from pyfaf.solutionfinders import solution_finders
+
+from wtforms import (Form,
+                     IntegerField,
+                     validators,
+                     SelectMultipleField,
+                     TextField,
+                     SelectField,
+                     FileField,
+                     BooleanField,
+                     TextAreaField,
+                     ValidationError)
+
+from webfaf2.forms import TagListField
+from webfaf2.utils import Pagination, admin_required
+
+url_prefix = "/celery_tasks"
+
+celery_tasks = Blueprint("celery_tasks", __name__)
+
+# Filter actions to exclude cmdline_only ones
+actions = {n: a for (n, a) in actions_all.items() if not a.cmdline_only}
+
+
+@celery_tasks.route("/")
+@admin_required
+def index():
+    inspect = celery_app.control.inspect()
+    pts = db.session.query(PeriodicTask).order_by(PeriodicTask.id).all()
+    trs = (db.session.query(TaskResult)
+                     .order_by(TaskResult.finished_time.desc())
+                     .limit(20).all())
+    return render_template("celery_tasks/index.html",
+                           periodic_tasks=pts,
+                           task_results=trs,
+                           inspect_active=inspect.active() or {},
+                           inspect_scheduled=inspect.scheduled() or {},
+                           actions=sorted(actions.keys()))
+
+
+@celery_tasks.route("/results/<result_id>/")
+@admin_required
+def results_item(result_id):
+    tr = db.session.query(TaskResult).get(result_id)
+    if tr is None:
+        raise abort(404)
+
+    return render_template("celery_tasks/results_item.html",
+                           task_result=tr)
+
+
+class ActionFormArgparser(object):
+    def __init__(self, F):
+        self.F = F
+        self.prefix_chars = "-"
+
+    # Adapted from argparse._ActionsContainer
+    # Steven J. Bethard <steven.bethard@gmail.com>
+    # Licensed under the Python license
+    def _get_positional_kwargs(self, dest, **kwargs):
+        # make sure required is not specified
+        if 'required' in kwargs:
+            msg = "'required' is an invalid argument for positionals"
+            raise TypeError(msg)
+
+        # return the keyword arguments with no option strings
+        return dict(kwargs, dest=dest, option_strings=[])
+
+    # Adapted from argparse._ActionsContainer
+    # Steven J. Bethard <steven.bethard@gmail.com>
+    # Licensed under the Python license
+    def _get_optional_kwargs(self, *args, **kwargs):
+        # determine short and long option strings
+        option_strings = []
+        long_option_strings = []
+        for option_string in args:
+            # error on strings that don't start with an appropriate prefix
+            if not option_string[0] in self.prefix_chars:
+                msg = 'invalid option string %r: must start with a character %r'
+                tup = option_string, self.prefix_chars
+                raise ValueError(msg % tup)
+
+            # strings starting with two prefix characters are long options
+            option_strings.append(option_string)
+            if option_string[0] in self.prefix_chars:
+                if len(option_string) > 1:
+                    if option_string[1] in self.prefix_chars:
+                        long_option_strings.append(option_string)
+
+        # infer destination, '--foo-bar' -> 'foo_bar' and '-x' -> 'x'
+        dest = kwargs.pop('dest', None)
+        if dest is None:
+            if long_option_strings:
+                dest_option_string = long_option_strings[0]
+            else:
+                dest_option_string = option_strings[0]
+            dest = dest_option_string.lstrip(self.prefix_chars)
+            if not dest:
+                msg = 'dest= is required for options like %r'
+                raise ValueError(msg % option_string)
+            dest = dest.replace('-', '_')
+
+        # return the updated keyword arguments
+        return dict(kwargs, dest=dest, option_strings=option_strings)
+
+    def add_argument(self, *args, **kwargs):
+        if not args or len(args) == 1 and args[0][0] not in self.prefix_chars:
+            kwargs = self._get_positional_kwargs(*args, **kwargs)
+        else:
+            kwargs = self._get_optional_kwargs(*args, **kwargs)
+
+        action = kwargs.get("action", "store")
+        field_args = (kwargs["dest"],)
+        field_kwargs = dict(
+            description=kwargs.get("help"),
+            default=kwargs.get("default")
+        )
+        if action == "store_true":
+            setattr(self.F, kwargs["dest"],
+                    BooleanField(*field_args, **field_kwargs))
+        else:
+            if kwargs.get("nargs", "?") in "+*" or action == "append":
+                field_kwargs["description"] = ((field_kwargs.get("description") or "") +
+                                               " Separate multiple values by comma ','.")
+                setattr(self.F, kwargs["dest"],
+                        TagListField(*field_args, **field_kwargs))
+            else:
+                setattr(self.F, kwargs["dest"],
+                        TextField(*field_args, **field_kwargs))
+
+        self.F.argparse_fields[kwargs["dest"]] = kwargs
+
+    def add_opsys(self, multiple=False, required=False):
+        Field = SelectField
+        if multiple:
+            Field = SelectMultipleField
+        field = Field(
+            "Operating System",
+            choices=((osplugin.name, osplugin.nice_name)
+                     for osplugin in systems.values()))
+        setattr(self.F, "opsys", field)
+        self.F.argparse_fields["opsys"] = {}
+
+    def add_problemtype(self, multiple=False):
+        Field = SelectField
+        if multiple:
+            Field = SelectMultipleField
+        field = Field(
+            "Problem type",
+            choices=[(a, a) for a in sorted(problemtypes.keys())])
+        setattr(self.F, "problemtype", field)
+        self.F.argparse_fields["problemtype"] = {}
+
+    def add_opsys_release(self, multiple=False, required=False):
+        Field = SelectField
+        if multiple:
+            Field = SelectMultipleField
+        field = Field(
+            "OS Release",
+            choices=[(a[0], a[0]) for a in db.session.query(OpSysRelease.version).order_by(OpSysRelease.version)])
+        setattr(self.F, "opsys_release", field)
+        self.F.argparse_fields["opsys_release"] = {}
+
+    def add_bugtracker(self, *args, **kwargs):
+        field = SelectField(
+            "Bugtracker",
+            choices=((bt, bt) for bt in bugtrackers.keys()))
+        setattr(self.F, "bugtracker", field)
+        self.F.argparse_fields["bugtracker"] = {}
+
+    def add_solutionfinder(self, *args, **kwargs):
+        field = SelectField(
+            "Solution finder",
+            choices=((sf, sf) for sf in solution_finders.keys()))
+        setattr(self.F, "solution_finder", field)
+        self.F.argparse_fields["solution_finder"] = {}
+
+    def add_repo(self, multiple=False):
+        Field = SelectField
+        if multiple:
+            Field = SelectMultipleField
+        field = Field(
+            "Package repository",
+            choices=[(a[0], a[0]) for a in db.session.query(Repo.name).order_by(Repo.name)])
+        setattr(self.F, "NAME", field)
+        self.F.argparse_fields["NAME"] = {}
+
+
+class ActionFormBase(Form):
+    argparse_fields = {}
+
+    def to_cmdline_dict(self):
+        res = {}
+        for name, kwargs in self.argparse_fields.iteritems():
+            data = getattr(self, name).data
+            if kwargs.get("type"):
+                # Call the optional type processor, e.g. int
+                data = kwargs["type"](data)
+            res[name] = data
+        return res
+
+    def from_cmdline_dict(self, cmdline):
+        for name, kwargs in self.argparse_fields.iteritems():
+            getattr(self, name).process_data(cmdline.get(name))
+
+
+def create_action_form(action):
+    # Creates a new ActionForm class based on the action cmdline
+    class ActionForm(ActionFormBase):
+        # to override ActionFormBase
+        argparse_fields = {}
+
+    # Mock argparser modifies the ActionForm class
+    parser = ActionFormArgparser(ActionForm)
+    action.tweak_cmdline_parser(parser)
+
+    return ActionForm
+
+
+class PeriodicTaskForm(Form):
+    name = TextField("Name", [validators.Length(min=1, max=80)])
+    enabled = BooleanField("Enabled", default=True)
+    crontab_minute = TextField("Minute", [validators.Length(min=1, max=20)], description="Crontab format", default="*")
+    crontab_hour = TextField("Hour", [validators.Length(min=1, max=20)], default="*")
+    crontab_day_of_week = TextField("Day of week", [validators.Length(min=1, max=20)], default="*")
+    crontab_day_of_month = TextField("Day of month", [validators.Length(min=1, max=20)], default="*")
+    crontab_month_of_year = TextField("Month of year", [validators.Length(min=1, max=20)], default="*")
+
+
+class JSONField(TextAreaField):
+    def process_formdata(self, valuelist):
+        if valuelist:
+            try:
+                self.data = json.loads(valuelist[0])
+            except:
+                self.data = None
+                raise ValidationError("Not valid JSON data")
+        else:
+            self.data = None
+
+    def _value(self):
+        if self.data:
+            try:
+                return json.dumps(self.data, indent=2)
+            except:
+                pass
+        return self.default
+
+
+class PeriodicTaskFullForm(PeriodicTaskForm):
+    task = TextField("Celery task", [validators.Length(min=1, max=80)])
+    args = JSONField("Args", default=[])
+    kwargs = JSONField("KW args", default={})
+
+
+@celery_tasks.route("/action/<action_name>/", methods=("GET", "POST"))
+@admin_required
+def action_run(action_name):
+    action = actions.get(action_name)
+    if action is None:
+        abort(404)
+    action_form = create_action_form(action)(request.form)
+    pt_form = PeriodicTaskForm(request.form)
+    if request.method == "POST":
+        if request.values.get("run") and action_form.validate():
+            run_action.delay(action_name, action_form.to_cmdline_dict())
+            flash("Action {0} started successfully.".format(action_name), "success")
+            return redirect(url_for("celery_tasks.index"))
+        if request.values.get("schedule") and action_form.validate() and pt_form.validate():
+            pt = PeriodicTask()
+            pt.task = "pyfaf.celery_tasks.run_action"
+            pt.args = (action_name, action_form.to_cmdline_dict())
+            pt_form.populate_obj(pt)
+            db.session.add(pt)
+            db.session.commit()
+            flash("Action {0} scheduled successfully.".format(action_name), "success")
+            return redirect(url_for("celery_tasks.index"))
+    return render_template("celery_tasks/action_run.html",
+                           action_name=action_name,
+                           action_form=action_form,
+                           schedule_form=pt_form)
+
+
+@celery_tasks.route("/schedule/<int:pt_id>/", methods=("GET", "POST"))
+@admin_required
+def schedule_item(pt_id):
+    pt = db.session.query(PeriodicTask).get(pt_id)
+    if pt is None:
+        abort(404)
+    action = None
+    action_name = None
+    if pt.task == "pyfaf.celery_tasks.run_action":
+        try:
+            action_name = pt.args[0]
+            action = actions.get(action_name)
+        except:
+            pass
+    if action is None:
+        pt_form = PeriodicTaskFullForm(request.form, pt)
+        action_form = None
+    else:
+        pt_form = PeriodicTaskForm(request.form, pt)
+        action_form = create_action_form(action)(request.form)
+
+    if request.method == "POST":
+        if request.values.get("schedule") and (action_form is None or action_form.validate()) and pt_form.validate():
+            if action:
+                pt.args = (action_name, action_form.to_cmdline_dict())
+            pt_form.populate_obj(pt)
+            db.session.commit()
+            flash("Schedule item {0} saved successfully.".format(pt.name), "success")
+            return redirect(url_for("celery_tasks.index"))
+        elif request.values.get("delete"):
+            db.session.delete(pt)
+            db.session.commit()
+            flash("Schedule item {0} deleted successfully.".format(pt.name), "success")
+            return redirect(url_for("celery_tasks.index"))
+    elif action_form is not None:
+        try:
+            action_form.from_cmdline_dict(pt.args[1])
+        except:
+            pass
+    return render_template("celery_tasks/schedule_item.html",
+                           pt_name=pt.name,
+                           action_form=action_form,
+                           schedule_form=pt_form)
+
+
+@celery_tasks.route("/results/")
+@admin_required
+def results_list():
+    pagination = Pagination(request)
+    trs = (db.session.query(TaskResult)
+                     .order_by(TaskResult.finished_time.desc()))
+
+    if request.args.get("unsuccessful_only", "") == "true":
+        trs = trs.filter(TaskResult.state != "SUCCESS")
+
+    if pagination.limit > 0:
+        trs = trs.limit(pagination.limit)
+    if pagination.offset >= 0:
+        trs = trs.offset(pagination.offset)
+
+    return render_template("celery_tasks/results_list.html",
+                           task_results=trs.all(),
+                           pagination=pagination)
+
+
+blueprint = celery_tasks
+blueprint_menu = [{
+    "title": "Tasks",
+    "route": "celery_tasks.index",
+    "admin_required": True,
+}, ]

--- a/src/webfaf2/config.py
+++ b/src/webfaf2/config.py
@@ -30,6 +30,7 @@ class Config(object):
     MEMCACHED_PORT = config.get("cache.memcached_port", None)
     MEMCACHED_KEY_PREFIX = config.get("cache.memcached_key_prefix", None)
     EVERYONE_IS_MAINTAINER = str2bool(config.get("hub2.everyone_is_maintainer", "false"))
+    EVERYONE_IS_ADMIN = str2bool(config.get("hub2.everyone_is_admin", "false"))
     FEDMENU_URL = config.get("hub2.fedmenu_url", None)
     FEDMENU_DATA_URL = config.get("hub2.fedmenu_data_url", None)
 

--- a/src/webfaf2/static/css/style.css
+++ b/src/webfaf2/static/css/style.css
@@ -99,3 +99,9 @@ tr.stripe {
 }
 
 table.counts-table th:nth-child(2) { width: 150px; }
+
+.three-columns {
+  -webkit-column-count: 3; /* Chrome, Safari, Opera */
+  -moz-column-count: 3; /* Firefox */
+  column-count: 3;
+}

--- a/src/webfaf2/templates/Makefile.am
+++ b/src/webfaf2/templates/Makefile.am
@@ -1,4 +1,10 @@
-SUBDIRS = dumpdirs problems reports stats summary
+SUBDIRS = \
+  celery_tasks \
+  dumpdirs \
+  problems \
+  reports \
+  stats \
+  summary
 
 template_DATA = \
   _helpers.html \

--- a/src/webfaf2/templates/_helpers.html
+++ b/src/webfaf2/templates/_helpers.html
@@ -231,7 +231,11 @@ FORM RENDERING
         {{ field(class_='form-control', **kwargs) }}
 
         </div>
-
+        {% if field.description %}
+          <p class="help-block">
+            {{field.description}}
+          </p>
+        {% endif %}
         {% if field.errors %}
             {% for e in field.errors %}
                 <p class="help-block">{{ e }}</p>
@@ -255,6 +259,11 @@ FORM RENDERING
             {{ field(type='checkbox', **kwargs) }} {{ field.label }}
         </label>
     </div>
+    {% if field.description %}
+      <p class="help-block">
+        {{field.description}}
+      </p>
+    {% endif %}
 {%- endmacro %}
 
 {# Renders radio field
@@ -274,6 +283,11 @@ FORM RENDERING
             </label>
         </div>
     {% endfor %}
+    {% if field.description %}
+      <p class="help-block">
+        {{field.description}}
+      </p>
+    {% endif %}
 {%- endmacro %}
 
 {% macro render_field(f) -%}

--- a/src/webfaf2/templates/base.html
+++ b/src/webfaf2/templates/base.html
@@ -53,8 +53,14 @@
                   <li><a href="{{ url_for('stats.last_year') }}">Last year</a></li>
                 </ul>
               </li>
+              {% for menu_item in current_menu["public"] %}
+                  <li {% if request.url_rule and request.url_rule.endpoint.startswith(menu_item['route']) %}class="active" {% endif %}><a href="{{ url_for(menu_item['route']) }}">{{menu_item["title"]}}</a></li>
+                {% endfor %}
               {% if g.user.admin %}
-                <li {% if request.url_rul and request.url_rule.endpoint.startswith('dumpdirs.') %}class="active" {% endif %}><a href="{{ url_for('dumpdirs.list') }}">Dumpdirs</a></li>
+                <li {% if request.url_rule and request.url_rule.endpoint.startswith('dumpdirs.') %}class="active" {% endif %}><a href="{{ url_for('dumpdirs.list') }}"><i class="fa fa-gear"></i> Dumpdirs</a></li>
+                {% for menu_item in current_menu["admin"] %}
+                  <li {% if request.url_rule and request.url_rule.endpoint.startswith(menu_item['route']) %}class="active" {% endif %}><a href="{{ url_for(menu_item['route']) }}"><i class="fa fa-gear"></i> {{menu_item["title"]}}</a></li>
+                {% endfor %}
               {% endif %}
             </ul>
             {% if config['OPENID_ENABLED'] %}

--- a/src/webfaf2/templates/celery_tasks/Makefile.am
+++ b/src/webfaf2/templates/celery_tasks/Makefile.am
@@ -1,0 +1,10 @@
+celery_tasks_templ_DATA = \
+  action_run.html \
+  index.html \
+  results_item.html \
+  results_list.html \
+  schedule_item.html
+
+celery_tasks_templdir = $(pythondir)/webfaf2/templates/celery_tasks
+
+EXTRA_DIST = $(celery_tasks_templ_DATA)

--- a/src/webfaf2/templates/celery_tasks/action_run.html
+++ b/src/webfaf2/templates/celery_tasks/action_run.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% from "_helpers.html" import render_field %}
+
+{% block title %}Run or schedule action {{action_name}}{% endblock %}
+
+{% block body %}
+  <div class="row">
+    <div class="col-md-12">
+      <h2>Run or schedule action {{action_name}}</h2>
+    </div>
+  </div>
+  <div class="row">
+    <form class="form" enctype="multipart/form-data" action="" method="POST">
+      <div class="col-md-6">
+        {% for field in action_form %}
+            {{ render_field(field) }}
+        {% else %}
+          <p>This action requires no parameters.</p>
+        {% endfor %}
+        <p><button type="submit" class="btn btn-primary" name="run" value="run"><i class="fa fa-play-circle"></i>
+ Run once</button></p>
+      </div>
+      <div class="col-md-6">
+        {% for field in schedule_form %}
+            {{ render_field(field) }}
+        {% endfor %}
+        <p><button type="submit" class="btn btn-primary" name="schedule" value="schedule"><i class="fa fa-plus"></i> Add to schedule</button></p>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/src/webfaf2/templates/celery_tasks/index.html
+++ b/src/webfaf2/templates/celery_tasks/index.html
@@ -1,0 +1,98 @@
+{% extends "base.html" %}
+
+{% block title %}Tasks{% endblock %}
+
+{% block js %}
+{% endblock %}
+
+{% block body %}
+<div class="row">
+  <div class="col-md-12">
+    <h2>Run or schedule action</h2>
+    <div class="three-columns">
+      {% for a in actions %}
+        <a href="{{url_for('celery_tasks.action_run', action_name=a)}}">{{a}}</a><br/>
+      {% endfor %}
+    </div>
+    <h2>Running</h2>
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>ID</th><th>Task</th><th>Arguments</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for host,tasks in inspect_active.iteritems() %}
+          {% for task in tasks %}
+            <tr>
+              <td>{{task["id"]}}</td>
+              <td>{{task["name"]}}</td>
+              <td>{{task["args"]}}</td>
+            </tr>  
+          {% endfor %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <h2>Queued</h2>
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>ID</th><th>Task</th><th>Arguments</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for host,tasks in inspect_scheduled.iteritems() %}
+          {% for task in tasks %}
+            <tr>
+              <td>{{task["id"]}}</td>
+              <td>{{task["name"]}}</td>
+              <td>{{task["args"]}}</td>
+            </tr>  
+          {% endfor %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <h2>Schedule</h2>
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>ID</th><th>Name</th><th>Task</th><th>M</th><th>H</th><th>DoW</th><th>DoM</th><th>MoY</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for pt in periodic_tasks %}
+          <tr>
+            <td><a href="{{url_for('celery_tasks.schedule_item', pt_id=pt.id)}}">{{pt.id}}</a> {% if pt.enabled %}<i class="fa fa-check"></i>{% else %}<i class="fa fa-ban"></i>{% endif %}</td>
+            <td>{{pt.nice_name}}</td>
+            <td>{{pt.nice_task}}</td>
+            <td>{{pt.crontab_minute}}</td>
+            <td>{{pt.crontab_hour}}</td>
+            <td>{{pt.crontab_day_of_week}}</td>
+            <td>{{pt.crontab_day_of_month}}</td>
+            <td>{{pt.crontab_month_of_year}}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <h2>Results</h2>
+      <a href="{{url_for('celery_tasks.results_list')}}">All results</a>
+      <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>ID</th><th>Task</th><th>Time</th><th>State</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in task_results %}
+          <tr>
+            <td><a href="{{url_for('celery_tasks.results_item', result_id=r.id)}}">{{r.id}}</a></td>
+            <td>{{r.nice_task}}</td>
+            <td>{{r.finished_time.strftime("%Y-%m-%d %H:%M:%S")}}</td>
+            <td>{{r.state}}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/src/webfaf2/templates/celery_tasks/results_item.html
+++ b/src/webfaf2/templates/celery_tasks/results_item.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}Tasks{% endblock %}
+
+{% block js %}
+{% endblock %}
+
+{% block body %}
+<div class="row">
+  <div class="col-md-12">
+    <h2>Result {{task_result.id}}</h2>
+    <dl class="dl-horizontal">
+      <dt>Task</dt>
+      <dd>{{task_result.nice_task}}</dd>
+      <dt>Arguments</dt>
+      <dd><pre>{{task_result.nice_args}}</pre></dd>
+      <dt>Finished</dt>
+      <dd>{{task_result.finished_time.strftime("%Y-%m-%d %H:%M:%S")}}</dd>
+      <dt>State</dt>
+      <dd>{{task_result.state}}</dd>
+    </dl>
+    <dl>
+      <dt>Output</dt>
+      <dd><pre>{{task_result.retval}}</pre><p>Only the last 1000 characters are saved.</p></dd>
+    </dl>
+  </div>
+</div>
+{% endblock %}

--- a/src/webfaf2/templates/celery_tasks/results_list.html
+++ b/src/webfaf2/templates/celery_tasks/results_list.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% from "_helpers.html" import paginator %}
+
+{% block title %}Task results{% endblock %}
+
+{% block js %}
+{% endblock %}
+
+{% block body %}
+<div class="row">
+  <div class="col-md-12">
+    <h2>Task results</h2>
+      <a href="{{url_for('celery_tasks.results_list')}}?unsuccessful_only=true">Show only unsuccessful results</a>
+      <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>ID</th><th>Task</th><th>Time</th><th>State</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in task_results %}
+          <tr>
+            <td><a href="{{url_for('celery_tasks.results_item', result_id=r.id)}}">{{r.id}}</a></td>
+            <td>{{r.nice_task}}</td>
+            <td>{{r.finished_time.strftime("%Y-%m-%d %H:%M:%S")}}</td>
+            <td>{{r.state}}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {{ paginator(pagination, task_results|length) }}
+  </div>
+</div>
+{% endblock %}

--- a/src/webfaf2/templates/celery_tasks/schedule_item.html
+++ b/src/webfaf2/templates/celery_tasks/schedule_item.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% from "_helpers.html" import render_field %}
+
+{% block title %}Schedule item {{pt_name}}{% endblock %}
+
+{% block body %}
+  <div class="row">
+    <div class="col-md-12">
+      <h2>Schedule item {{pt_name}}</h2>
+    </div>
+  </div>
+  <div class="row">
+    <form class="form" enctype="multipart/form-data" action="" method="POST">
+      {% if action_form %}
+        <div class="col-md-6">
+        {% for field in action_form %}
+            {{ render_field(field) }}
+        {% else %}
+          <p>This action requires no parameters.</p>
+        {% endfor %}
+      </div>  
+      {% endif %}
+      <div class="col-md-6">
+        {% for field in schedule_form %}
+            {{ render_field(field) }}
+        {% endfor %}
+        <p>
+          <button type="submit" class="btn btn-primary" name="schedule" value="schedule"><i class="fa fa-check"></i> Save</button>
+          <button type="submit" class="btn btn-sm btn-danger pull-right" name="delete" value="delete"><i class="fa fa-trash-o"></i> Delete</button>
+        </p>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/src/webfaf2/utils.py
+++ b/src/webfaf2/utils.py
@@ -15,6 +15,8 @@ from pyfaf.storage.report import (Report,
                                   ReportHistoryDaily,
                                   ReportHistoryWeekly,
                                   ReportHistoryMonthly)
+from webfaf2.webfaf2_main import app
+import bunch
 
 
 class Pagination(object):
@@ -297,7 +299,14 @@ def login_required(func):
     @wraps(func)
     def decorated_view(*args, **kwargs):
         if g.user is None:
-            return redirect(url_for('login.do_login', next=request.url))
+            if app.config["EVERYONE_IS_ADMIN"]:
+                g.user = bunch.Bunch({
+                    "username": "admin",
+                    "email": "admin@localhost",
+                    "admin": True
+                    })
+            else:
+                return redirect(url_for('login.do_login', next=request.url))
 
         return func(*args, **kwargs)
     return decorated_view
@@ -307,7 +316,14 @@ def admin_required(func):
     @wraps(func)
     def decorated_view(*args, **kwargs):
         if g.user is None:
-            return redirect(url_for('login.do_login', next=request.url))
+            if app.config["EVERYONE_IS_ADMIN"]:
+                g.user = bunch.Bunch({
+                    "username": "admin",
+                    "email": "admin@localhost",
+                    "admin": True
+                    })
+            else:
+                return redirect(url_for('login.do_login', next=request.url))
 
         if not g.user.admin:
             abort(403)


### PR DESCRIPTION
Closes #436.

How to test:
* `# dnf install redis`
* `# systemctl start redis`
* Build and install FAF including `faf-celery-tasks` and `faf-blueprint-celery-tasks`
* `# sudo -u faf faf-migrate-db`
* `# systemctl start faf-celery-worker` (the worker)
* `# systemctl start faf-celery-beat` (the scheduler)
* Set `everyone_is_admin = true` in `/etc/faf/plugins/web2.conf`
* Restart `httpd`
* Go to `http://localhost/faf2/celery_tasks/` (or wherever FAF is running)

Alternatively use `zeromq` instead of Redis. In that case `/etc/faf/plugins/celery_tasks.conf` needs to be reconfigured.