### PR TITLE
webfaf2: fix saving of invalid uReports

### DIFF
--- a/src/webfaf2/reports.py
+++ b/src/webfaf2/reports.py
@@ -528,7 +528,7 @@ def _save_invalid_ureport(db, ureport, errormsg, reporter=None):
         new.date = datetime.datetime.utcnow()
         new.reporter = reporter
         db.session.add(new)
-        db.session.flush()
+        db.session.commit()
 
         new.save_lob("ureport", ureport)
     except Exception as ex:
@@ -549,7 +549,7 @@ def _save_unknown_opsys(db, opsys):
             db.session.add(db_unknown_opsys)
 
         db_unknown_opsys.count += 1
-        db.session.flush()
+        db.session.commit()
     except Exception as ex:
         logging.error(str(ex))
 

--- a/tests/webfaf/reports
+++ b/tests/webfaf/reports
@@ -8,6 +8,7 @@ except ImportError:
     import unittest
 from StringIO import StringIO
 from webfaftests import WebfafTestCase
+from pyfaf.storage import InvalidUReport
 
 
 class ReportTestCase(WebfafTestCase):
@@ -102,6 +103,11 @@ class ReportTestCase(WebfafTestCase):
 
         r = self.post_report("invalid")
         self.assertEqual(json.loads(r.data)["error"], u"Couldn't parse JSON data.")
+        self.assertEqual(self.db.session.query(InvalidUReport).count(), 1)
+
+        r = self.post_report('{"invalid":"json"}')
+        self.assertEqual(json.loads(r.data)["error"], u"uReport data is invalid.")
+        self.assertEqual(self.db.session.query(InvalidUReport).count(), 2)
 
     def test_attach(self):
         """


### PR DESCRIPTION
`commit` must be used insted of `flush` to save the DB session
inside a web request.