### PR TITLE
webfaf2: replace problem.item url with permalink in browser url bar

### DIFF
--- a/src/webfaf2/templates/problems/item.html
+++ b/src/webfaf2/templates/problems/item.html
@@ -18,6 +18,13 @@ Problem #{{ problem.id }} -
 <script src="{{ url_for('static', filename='js/jquery.flot.pie.js')}}"></script>
 <script src="{{ url_for('static', filename='js/jquery.flot.tickrotor.js')}}"></script>
 <script src="{{ url_for('static', filename='js/jquery.flot.time.js')}}"></script>
+<script type="text/javascript">
+  $(document).ready(function() {
+    try {
+      history.replaceState(null, "", "{{url_for('problems.bthash_permalink')}}?{{ bt_hash_qs|safe }}")
+    } catch(err) {};
+  });
+</script>
 {% endblock js %}
 
 {% block body %}


### PR DESCRIPTION
This way people will use permalinks instead of urls with
ever-changing problem IDs when copy-pasting the url somewhere.
See https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history