### PR TITLE
pyfaf: load Report bug backrefs based of bugtracker plugins

### DIFF
--- a/src/pyfaf/bugtrackers/__init__.py
+++ b/src/pyfaf/bugtrackers/__init__.py
@@ -35,6 +35,9 @@ class BugTracker(Plugin):
     A common superclass for bug tracker plugins.
     """
 
+    # backref name for accessing bugs associated with a Report
+    report_backref_name = None
+
     @classmethod
     def install(cls, db, logger=None):
         if logger is None:
@@ -124,5 +127,11 @@ class BugTracker(Plugin):
         raise NotImplementedError("clone_bug is not implemented for {0}"
                                   .format(self.__class__.__name__))
 
+
 import_dir(__name__, os.path.dirname(__file__))
 load_plugins(BugTracker, bugtrackers)
+
+report_backref_names = set()
+for bt in bugtrackers.values():
+    if bt.report_backref_name is not None:
+        report_backref_names.add(bt.report_backref_name)

--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -51,6 +51,8 @@ class Bugzilla(BugTracker):
 
     name = "abstract_bugzilla"
 
+    report_backref_name = "bz_bugs"
+
     def __init__(self):
         """
         Load required configuration based on instance name.

--- a/src/pyfaf/bugtrackers/mantisbt.py
+++ b/src/pyfaf/bugtrackers/mantisbt.py
@@ -57,6 +57,8 @@ class Mantis(BugTracker):
 
     name = "abstract_mantisbt"
 
+    report_backref_name = "mantis_bugs"
+
     def __init__(self):
         """
         Load required configuration based on instance name.

--- a/src/pyfaf/storage/report.py
+++ b/src/pyfaf/storage/report.py
@@ -64,13 +64,13 @@ class Report(GenericTable):
 
     @property
     def bugs(self):
+        # must be imported here to avoid dependency circle
+        from pyfaf.bugtrackers import report_backref_names
         my_bugs = []
 
-        for bug in self.bz_bugs:
-            my_bugs.append(bug.bzbug)
-
-        for bug in self.mantis_bugs:
-            my_bugs.append(bug.mantisbug)
+        for br in report_backref_names:
+            for reportbug in getattr(self, br):
+                my_bugs.append(reportbug.bug)
 
         return my_bugs
 
@@ -485,6 +485,10 @@ class ReportBz(GenericTable):
     report = relationship(Report, backref="bz_bugs")
     bzbug = relationship(BzBug)
 
+    @property
+    def bug(self):
+        return self.bzbug
+
 
 class ReportMantis(GenericTable):
     __tablename__ = "reportmantis"
@@ -493,6 +497,10 @@ class ReportMantis(GenericTable):
     mantisbug_id = Column(Integer, ForeignKey("{0}.id".format(MantisBug.__tablename__)), primary_key=True)
     report = relationship(Report, backref="mantis_bugs")
     mantisbug = relationship(MantisBug)
+
+    @property
+    def bug(self):
+        return self.mantisbug
 
 
 class ReportRaw(GenericTable):


### PR DESCRIPTION
Bugtracker plugins are no longer hardcoded and show automatically
in report.item and problem.item and list.