### PR TITLE
bugzilla: don't use tokenfile

### DIFF
--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -86,7 +86,8 @@ class Bugzilla(BugTracker):
         self.log_debug("Opening bugzilla connection for '{0}'"
                        .format(self.name))
 
-        self.bz = bugzilla.Bugzilla(url=str(self.api_url), cookiefile=None)
+        self.bz = bugzilla.Bugzilla(url=str(self.api_url), cookiefile=None,
+                                    tokenfile=None)
 
         if self.user and self.password:
             self.log_debug("Logging into bugzilla '{0}' as '{1}'"


### PR DESCRIPTION
Our service is crashing with the following exception:

```
DEBUG:urllib3.connectionpool:"POST /xmlrpc.cgi HTTP/1.1" 200 None
Traceback (most recent call last):
  File "/usr/bin/faf-save-reports", line 92, in <module>
    bugzilla.login()
  File "/usr/lib/python2.6/site-packages/pyfaf/bugzilla.py", line 61, in login
    self.bz.login(user, password)
  File "/usr/lib/python2.6/site-packages/bugzilla/base.py", line 639, in login
    ret = self._login(self.user, self.password)
  File "/usr/lib/python2.6/site-packages/bugzilla/base.py", line 607, in _login
    return self._proxy.User.login({'login': user, 'password': password})
  File "/usr/lib64/python2.6/xmlrpclib.py", line 1199, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python2.6/site-packages/bugzilla/base.py", line 169, in _ServerProxy__request
    self.token.value = ret.get('token')
  File "/usr/lib/python2.6/site-packages/bugzilla/base.py", line 138, in value
    with open(self.tokenfilename, 'w') as tokenfile:
IOError: [Errno 13] Permission denied: '/etc/faf/.bugzillatoken'
```

I am not sure how to test this pull request automatically. Any ideas?