### PR TITLE
Attachments: One url can be attached to many reports

### DIFF
--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -31,7 +31,10 @@ url_prefix = "/celery_tasks"
 celery_tasks = Blueprint("celery_tasks", __name__)
 
 # Filter actions to exclude cmdline_only ones
-actions = {n: a for (n, a) in actions_all.items() if not a.cmdline_only}
+actions = dict()
+for(n, a) in actions_all.items():
+    if not a.cmdline_only:
+        actions[n] = a
 
 
 @celery_tasks.route("/")


### PR DESCRIPTION
One url can be attached to many reports, but every report must have unique url's
QA'S want save one url for more reports.

Here will be a redundancy, but i think its better then creating junction tables
and join more tables is more expensive on resources.

Signed-off-by: Patrik Helia <phelia@redhat.com>