### PR TITLE
Configurable finding known ureport and buzilla bug's

### DIFF
--- a/config/faf.conf.in
+++ b/config/faf.conf.in
@@ -30,3 +30,17 @@ CreateComponents = False
 # allowed values: fedora-bugzilla rhel-bugzilla centos-mantisb comment email url
 # or * to allow all attachments
 AcceptAttachments = fedora-bugzilla rhel-bugzilla centos-mantisbt
+
+# Determines which strategy will be used for searching known or uknown ureport's
+# and bugzilla bug's, if known is empty, then is used BUG_OS_MINOR_VERSION
+#
+# BUG_OS_MAJOR_VERSION - The report has attached a bug with equivalent OS Major
+# version name
+# BUG_OS_MINOR_VERSION - The report has attached a bug with equivalent OS Major
+# version and OS Minor version name
+# EQUAL_UREPORT_EXISTS - Report OS Major version match AND uReport OS Minor
+# version match AND uReport OS Architecture match AND Packages match name
+#
+# allowed values for the Known option
+# BUG_OS_MAJOR_VERSION BUG_OS_MINOR_VERSION EQUAL_UREPORT_EXISTS
+Known = 

--- a/src/pyfaf/actions/addcompathashes.py
+++ b/src/pyfaf/actions/addcompathashes.py
@@ -24,7 +24,7 @@ import datetime
 from pyfaf.actions import Action
 from pyfaf.common import FafError
 from pyfaf.problemtypes import problemtypes
-from pyfaf.queries import get_reports_by_type, get_report_by_hash
+from pyfaf.queries import get_reports_by_type, get_report
 from pyfaf.storage import ReportHash
 
 
@@ -130,7 +130,7 @@ class AddCompatHashes(Action):
                                                       hashbase=[component],
                                                       offset=include_offset)
                         self.log_debug("    {0}".format(bthash))
-                        db_dup = get_report_by_hash(db, bthash)
+                        db_dup = get_report(db, bthash)
                         if db_dup is None:
                             self.log_info("    Adding hash '{0}'"
                                           .format(bthash))

--- a/src/pyfaf/actions/attach_centos_bugs.py
+++ b/src/pyfaf/actions/attach_centos_bugs.py
@@ -19,7 +19,7 @@
 from pyfaf.actions import Action
 from pyfaf.bugtrackers import bugtrackers
 from pyfaf.queries import (get_mantis_bug,
-                           get_report_by_hash,
+                           get_report,
                            get_reportmantis,
                            get_osrelease,
                            get_bugtracker_by_name)
@@ -44,7 +44,7 @@ class AttachCentosBugs(Action):
             if bug_dict and bug_dict.get("url", False):
                 url = bug_dict["url"]
                 report_hash = url.split("/")[-1]
-                db_report = get_report_by_hash(db, report_hash)
+                db_report = get_report(db, report_hash)
                 if db_report is None:
                     self.log_info("Report with hash {0} not found."
                                   .format(report_hash))

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -70,6 +70,7 @@ from pyfaf.storage import (Arch,
                            SymbolSource,
                            UnknownOpSys)
 
+from pyfaf.opsys import systems
 from sqlalchemy import func, desc
 
 __all__ = ["get_arch_by_name", "get_archs", "get_associate_by_name",
@@ -96,7 +97,7 @@ __all__ = ["get_arch_by_name", "get_archs", "get_associate_by_name",
            "get_package_by_name_build_arch", "get_package_by_nevra",
            "get_problems", "get_problem_component", "get_empty_problems",
            "get_problem_opsysrelease", "get_build_by_nevr",
-           "get_release_ids", "get_releases", "get_report_by_hash",
+           "get_release_ids", "get_releases", "get_report",
            "get_report_count_by_component", "get_report_release_desktop",
            "get_report_stats_by_component", "get_report_by_id",
            "get_reportarch", "get_reportexe", "get_reportosrelease",
@@ -238,7 +239,7 @@ def get_debug_files(db, db_package):
                       .filter(PackageDependency.package == db_package)
                       .filter(PackageDependency.type == "PROVIDES")
                       .filter((PackageDependency.name.like("/%%.ko.debug") |
-                              (PackageDependency.name.like("/%%/vmlinux"))))
+                               (PackageDependency.name.like("/%%/vmlinux"))))
                       .all())
 
     return [dep.name for dep in deps]
@@ -703,7 +704,8 @@ def prioritize_longterm_problems(min_fa, problem_tuples):
         months = (min_fa.month - problem.first_occurrence.month) + 1
         if min_fa.year != problem.first_occurrence.year:
             months = (min_fa.month
-                      + (12 * (min_fa.year - problem.first_occurrence.year - 1))
+                      +
+                      (12 * (min_fa.year - problem.first_occurrence.year - 1))
                       + (13 - problem.first_occurrence.month))
 
         if problem.first_occurrence.day != 1:
@@ -802,16 +804,43 @@ def get_report_by_id(db, report_id):
                       .first())
 
 
-def get_report_by_hash(db, report_hash):
-    """
-    Return pyfaf.storage.Report object from pyfaf.storage.ReportHash
-    or None if not found.
-    """
+def get_report(db, report_hash, os_name=None, os_version=None, os_arch=None):
+    '''
+    Return pyfaf.storage.Report object or None if not found
+    This method takes optionally parameters for searching
+    Reports by os parameters
+    '''
 
-    return (db.session.query(Report)
-                      .join(ReportHash)
-                      .filter(ReportHash.hash == report_hash)
-                      .first())
+    result = None
+
+    db_query = (db.session.query(Report)
+                .join(ReportHash)
+                .filter(ReportHash.hash == report_hash))
+
+    if os_name:
+        osplugin = systems[os_name]
+
+        db_query = (db_query
+                    .join(ReportOpSysRelease)
+                    .join(OpSys, ReportOpSysRelease.opsysrelease_id == OpSys.id)
+                    .filter(OpSys.name == osplugin.nice_name)
+                    .filter(ReportOpSysRelease.report_id == Report.id))
+
+    if os_version:
+        if not os_name:
+            db_query = (db_query.join(ReportOpSysRelease))
+                        
+        db_query = (db_query
+                    .join(OpSysRelease, ReportOpSysRelease.opsysrelease_id == OpSysRelease.id)
+                    .filter(OpSysRelease.version == os_version))
+
+    if os_arch:
+        db_query = (db_query
+                    .join(ReportArch)
+                    .join(Arch, ReportArch.arch_id == Arch.id)
+                    .filter(Arch.name == os_arch))
+
+    return db_query.first()
 
 
 def get_report_count_by_component(db, opsys_name=None, opsys_version=None,
@@ -969,11 +998,27 @@ def get_reportbz(db, report_id, opsysrelease_id=None):
     Return pyfaf.storage.ReportBz objects of given `report_id`.
     Optionally filter by `opsysrelease_id` of the BzBug.
     """
+
     query = (db.session.query(ReportBz)
                        .filter(ReportBz.report_id == report_id))
     if opsysrelease_id:
         query = (query.join(BzBug)
                       .filter(BzBug.opsysrelease_id == opsysrelease_id))
+
+    return query
+
+
+def get_reportbz_by_major_version(db, report_id, major_version):
+    """
+    Return pyfaf.storage.ReportBz objects of given `report_id`.
+    Optionally filter by `opsysrelease_id` of the BzBug.
+    """
+
+    query = (db.session.query(ReportBz)
+             .join(BzBug)
+             .join(OpSysRelease)
+             .filter(ReportBz.report_id == report_id)
+             .filter(OpSysRelease.version.like(str(major_version) + ".%")))
 
     return query
 
@@ -1000,6 +1045,7 @@ def get_repos_for_opsys(db, opsys_id):
                       .join(OpSysRepo)
                       .filter(OpSysRepo.opsys_id == opsys_id)
                       .all())
+
 
 def get_src_package_by_build(db, db_build):
     """
@@ -1055,6 +1101,7 @@ def get_supported_components(db):
                       .join(OpSysRelease)
                       .filter(OpSysRelease.status != 'EOL')
                       .all())
+
 
 def get_symbol_by_name_path(db, name, path):
     """
@@ -1224,9 +1271,9 @@ def get_crashed_unknown_package_nevr_for_report(db, report_id):
                              ReportUnknownPackage.epoch,
                              ReportUnknownPackage.version,
                              ReportUnknownPackage.release)
-                      .filter(ReportUnknownPackage.report_id == report_id)
-                      .filter(ReportUnknownPackage.type == "CRASHED")
-                      .all())
+            .filter(ReportUnknownPackage.report_id == report_id)
+            .filter(ReportUnknownPackage.type == "CRASHED")
+            .all())
 
 
 def get_problem_opsysrelease(db, problem_id, opsysrelease_id):

--- a/src/pyfaf/solutionfinders/__init__.py
+++ b/src/pyfaf/solutionfinders/__init__.py
@@ -22,7 +22,7 @@ from pyfaf.common import FafError, Plugin, import_dir, load_plugins
 from pyfaf.storage import Report, getDatabase
 from pyfaf.ureport import ureport2
 from pyfaf.problemtypes import problemtypes
-from pyfaf.queries import get_report_by_hash
+from pyfaf.queries import get_report
 
 solution_finders = {}
 
@@ -69,7 +69,7 @@ class SolutionFinder(Plugin):
         problemplugin = problemtypes[ureport["problem"]["type"]]
         report_hash = problemplugin.hash_ureport(ureport["problem"])
 
-        report = get_report_by_hash(db, report_hash)
+        report = get_report(db, report_hash)
         if report is None:
             return None
         return report

--- a/src/pyfaf/ureport.py
+++ b/src/pyfaf/ureport.py
@@ -30,6 +30,7 @@ from pyfaf.opsys import systems
 from pyfaf.problemtypes import problemtypes
 from pyfaf.queries import (get_arch_by_name,
                            get_bz_bug,
+                           get_reportbz_by_major_version,
                            get_component_by_name,
                            get_contact_email,
                            get_history_day,
@@ -37,7 +38,7 @@ from pyfaf.queries import (get_arch_by_name,
                            get_history_week,
                            get_osrelease,
                            get_mantis_bug,
-                           get_report_by_hash,
+                           get_report,
                            get_report_contact_email,
                            get_reportarch,
                            get_reportreason,
@@ -194,7 +195,7 @@ def save_ureport2(db, ureport, create_component=False, timestamp=None, count=1):
                        .format(osplugin.nice_name, ureport["os"]["version"]))
 
     report_hash = problemplugin.hash_ureport(ureport["problem"])
-    db_report = get_report_by_hash(db, report_hash)
+    db_report = get_report(db, report_hash)
     if db_report is None:
         component_name = problemplugin.get_component_name(ureport["problem"])
         db_component = get_component_by_name(db, component_name,
@@ -382,7 +383,7 @@ def save_attachment(db, attachment):
         raise FafError("Attachment type '{}' not allowed on this server"
                        .format(atype))
 
-    report = get_report_by_hash(db, attachment["bthash"])
+    report = get_report(db, attachment["bthash"])
     if not report:
         raise FafError("Report for given bthash not found")
 
@@ -521,7 +522,7 @@ def save_attachment(db, attachment):
         db_url.report = report
         db_url.url = url
         db_url.saved = datetime.datetime.utcnow()
-        
+
         try:
             db.session.flush()
         except IntegrityError:
@@ -531,19 +532,79 @@ def save_attachment(db, attachment):
         log.warning("Unknown attachment type")
 
 
+def valid_known_type(known_type):
+    """
+    Check if all "known" values from configuration file are correct
+    allowed_known_type is list with allowed values
+    """
+    allowed_known_type = ['EQUAL_UREPORT_EXISTS', 'BUG_OS_MINOR_VERSION',
+                          'BUG_OS_MAJOR_VERSION']
+
+    for ktype in known_type:
+        if ktype not in allowed_known_type and ktype.strip() != "":
+            log.error("Known type '{0}' is not supported by FAF Server"
+                      .format(ktype))
+            return False
+
+    return True
+
+
 def is_known(ureport, db, return_report=False, opsysrelease_id=None):
     ureport = ureport2(ureport)
 
     problemplugin = problemtypes[ureport["problem"]["type"]]
     report_hash = problemplugin.hash_ureport(ureport["problem"])
 
-    report = get_report_by_hash(db, report_hash)
+    known_type = []
+
+    # Split allowed types from config
+    if 'ureport.known' in config and config['ureport.known'].strip() != "":
+        known_type = config['ureport.known'].strip().split(" ")
+
+    if len(known_type) > 0 and not valid_known_type(known_type):
+        return None
+
+    report_os = {'name':None,
+                 'version':None,
+                 'architecture':None}
+
+    if 'EQUAL_UREPORT_EXISTS' in known_type:
+        report_os = ureport["os"]
+
+    reports = db.session.query(Report).all()
+
+    report = get_report(db, report_hash, os_name=report_os['name'], os_version=report_os['version'], os_arch=report_os['architecture'])
 
     if report is None:
         return None
-    if get_reportbz(db, report.id, opsysrelease_id).first() is not None:
+
+    found = False
+
+    if 'EQUAL_UREPORT_EXISTS' in known_type:
+
+        found = True
+
+    elif ('BUG_OS_MINOR_VERSION' in known_type and
+        get_reportbz(db, report.id, opsysrelease_id).first() is not None):
+
+        found = True
+
+    elif ('BUG_OS_MAJOR_VERSION' in known_type and
+          get_reportbz_by_major_version(db, report.id,
+                                        major_version=ureport["os"]["version"]
+                                        .split(".")[0])
+          .first() is not None):
+
+        found = True
+
+    elif (not known_type and
+          get_reportbz(db, report.id, opsysrelease_id).first() is not None):
+
+        found = True
+
+    if found:
         if return_report:
             return report
         return True
-
-    return None
+    else:
+        return None

--- a/src/webfaf/blueprints/symbol_transfer.py
+++ b/src/webfaf/blueprints/symbol_transfer.py
@@ -12,7 +12,7 @@ from pyfaf.storage import (OpSysComponent,
                            ReportHash,
                            SymbolSource)
 from pyfaf.config import config
-from pyfaf.queries import get_report_by_hash
+from pyfaf.queries import get_report
 from webfaf_main import db
 
 

--- a/src/webfaf/problems.py
+++ b/src/webfaf/problems.py
@@ -29,7 +29,7 @@ from pyfaf.storage import (Arch,
                            ReportUnknownPackage,
                            Symbol,
                            SymbolSource)
-from pyfaf.queries import (get_history_target, get_report_by_hash,
+from pyfaf.queries import (get_history_target, get_report,
                            get_external_faf_instances)
 
 from flask import (Blueprint, render_template, request,
@@ -556,7 +556,7 @@ def item(problem_id):
 def bthash_forward(bthash=None):
     # single hash
     if bthash is not None:
-        db_report = get_report_by_hash(db, bthash)
+        db_report = get_report(db, bthash)
         if db_report is None:
             raise abort(404)
 

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -31,7 +31,7 @@ from pyfaf.storage import (Build,
                            ReportBacktrace,
                            UnknownOpSys,
                            )
-from pyfaf.queries import (get_report_by_hash,
+from pyfaf.queries import (get_report,
                            get_unknown_opsys,
                            user_is_maintainer,
                            get_bz_bug,
@@ -513,7 +513,7 @@ def diff():
 
 @reports.route("/bthash/<bthash>/")
 def bthash_forward(bthash):
-    db_report = get_report_by_hash(db, bthash)
+    db_report = get_report(db, bthash)
     if db_report is None:
         return render_template("reports/waitforit.html"), 404
 

--- a/tests/faftests/__init__.py
+++ b/tests/faftests/__init__.py
@@ -165,8 +165,23 @@ class DatabaseCase(TestCase):
             self.db.session.add(arch)
             setattr(self, "arch_{0}".format(arch_name), arch)
 
+        rhel_sys = OpSys(name="Red Hat Enterprise Linux")
+        self.db.session.add(rhel_sys)
+
+        self.opsys_rhel = rhel_sys
+
+        releases = []
+        versions = ["6.7","6.8","7.1","7.2","7.3","7.7"]
+        for ver in versions:
+            rel = OpSysRelease(opsys=rhel_sys, version=ver, status="ACTIVE")
+
+            releases.append(rel)
+            self.db.session.add(rel)
+            setattr(self, "release_{0}".format(ver), rel)
+
         sys = OpSys(name="Fedora")
         self.db.session.add(sys)
+
         self.opsys_fedora = sys
 
         releases = []
@@ -181,6 +196,10 @@ class DatabaseCase(TestCase):
 
             comp = OpSysComponent(opsys=sys, name=cname)
             self.db.session.add(comp)
+
+            comp = OpSysComponent(opsys=rhel_sys, name=cname)
+            self.db.session.add(comp)
+
             setattr(self, "comp_{0}".format(cname), comp)
 
             for rel in releases:

--- a/tests/faftests/test_config.conf
+++ b/tests/faftests/test_config.conf
@@ -5,6 +5,9 @@ LobDir = /tmp/faf_test_data/lob
 [Ureport]
 Directory = /tmp/faf_test_data/reports/
 AcceptAttachments = *
+# allowed values for known
+# BUG_OS_MAJOR_VERSION BUG_OS_MINOR_VERSION EQUAL_UREPORT_EXISTS
+Known = 
 
 [Hub]
 debug = True

--- a/tests/sample_reports/Makefile.am
+++ b/tests/sample_reports/Makefile.am
@@ -4,4 +4,6 @@ EXTRA_DIST = bugzilla_attachment comment_attachment contact_email_attachment \
              ureport_core ureport_core1 ureport_core_invalid \
              ureport_java ureport_kerneloops ureport_kerneloops2 \
              ureport_python ureport_ruby \
-             ureport_systemd2 ureport_systemd77 ureport_kerneloops_nouveau
+             ureport_systemd2 ureport_systemd77 ureport_kerneloops_nouveau \
+             ureport_duplicate ureport_duplicate2 ureport_duplicate3 \
+             ureport_duplicate4

--- a/tests/sample_reports/ureport_duplicate
+++ b/tests/sample_reports/ureport_duplicate
@@ -1,0 +1,85 @@
+{
+  "ureport_version": 2,
+
+  "reason": "ImportError in /usr/bin/faf:55",
+
+  "os": {
+    "name": "rhel",
+    "version": "6.7",
+    "architecture": "x86_64"
+  },
+
+  "problem": {
+    "type": "python",
+
+    "component": "faf",
+
+    "exception_name": "ImportError",
+
+    "user": {
+      "local": true,
+      "root": false
+    },
+
+    "stacktrace": [
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py",
+        "file_line": 312,
+        "line_contents": "psycopg = __import__('psycopg2')",
+        "function_name": "dbapi"
+      },
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/strategies.py",
+        "file_line": 64,
+        "line_contents": "dbapi = dialect_cls.dbapi(**dbapi_args)",
+        "function_name": "create"
+      },
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/__init__.py",
+        "file_line": 338,
+        "line_contents": "return strategy.create(*args, **kwargs)",
+        "function_name": "create_engine"
+      },
+      {
+        "file_name": "/usr/lib/python2.7/site-packages/pyfaf/storage/__init__.py",
+        "file_line": 213,
+        "line_contents": "self._db = create_engine(config['storage.connectstring'])",
+        "function_name": "__init__"
+      },
+      {
+        "file_name": "/usr/lib/python2.7/site-packages/pyfaf/storage/__init__.py",
+        "file_line": 199,
+        "line_contents": "db = Database(debug=debug, dry=dry)",
+        "function_name": "getDatabase"
+      },
+      {
+        "file_name": "/usr/bin/faf",
+        "file_line": 29,
+        "line_contents": "db = getDatabase(debug=cmdline.sql_verbose, dry=cmdline.dry_run)",
+        "function_name": "main"
+      },
+      {
+        "file_name": "/usr/bin/faf",
+        "file_line": 55,
+        "special_function": "module",
+        "line_contents": "main()"
+      }
+    ]
+  },
+
+  "packages": [
+    {
+      "name": "faf",
+      "epoch": 0,
+      "version": "0.9",
+      "architecture": "noarch",
+      "package_role": "affected",
+      "release": "1.fc18"
+    }
+  ],
+
+  "reporter": {
+    "version": "0.3",
+    "name": "satyr"
+  }
+}

--- a/tests/sample_reports/ureport_duplicate2
+++ b/tests/sample_reports/ureport_duplicate2
@@ -1,0 +1,85 @@
+{
+  "ureport_version": 2,
+
+  "reason": "ImportError in /usr/bin/faf:55",
+
+  "os": {
+    "name": "rhel",
+    "version": "6.8",
+    "architecture": "x86_64"
+  },
+
+  "problem": {
+    "type": "python",
+
+    "component": "faf",
+
+    "exception_name": "ImportError",
+
+    "user": {
+      "local": true,
+      "root": false
+    },
+
+    "stacktrace": [
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py",
+        "file_line": 312,
+        "line_contents": "psycopg = __import__('psycopg2')",
+        "function_name": "dbapi"
+      },
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/strategies.py",
+        "file_line": 64,
+        "line_contents": "dbapi = dialect_cls.dbapi(**dbapi_args)",
+        "function_name": "create"
+      },
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/__init__.py",
+        "file_line": 338,
+        "line_contents": "return strategy.create(*args, **kwargs)",
+        "function_name": "create_engine"
+      },
+      {
+        "file_name": "/usr/lib/python2.7/site-packages/pyfaf/storage/__init__.py",
+        "file_line": 213,
+        "line_contents": "self._db = create_engine(config['storage.connectstring'])",
+        "function_name": "__init__"
+      },
+      {
+        "file_name": "/usr/lib/python2.7/site-packages/pyfaf/storage/__init__.py",
+        "file_line": 199,
+        "line_contents": "db = Database(debug=debug, dry=dry)",
+        "function_name": "getDatabase"
+      },
+      {
+        "file_name": "/usr/bin/faf",
+        "file_line": 29,
+        "line_contents": "db = getDatabase(debug=cmdline.sql_verbose, dry=cmdline.dry_run)",
+        "function_name": "main"
+      },
+      {
+        "file_name": "/usr/bin/faf",
+        "file_line": 55,
+        "special_function": "module",
+        "line_contents": "main()"
+      }
+    ]
+  },
+
+  "packages": [
+    {
+      "name": "faf",
+      "epoch": 0,
+      "version": "0.9",
+      "architecture": "noarch",
+      "package_role": "affected",
+      "release": "1.fc18"
+    }
+  ],
+
+  "reporter": {
+    "version": "0.3",
+    "name": "satyr"
+  }
+}

--- a/tests/sample_reports/ureport_duplicate3
+++ b/tests/sample_reports/ureport_duplicate3
@@ -1,0 +1,85 @@
+{
+  "ureport_version": 2,
+
+  "reason": "ImportError in /usr/bin/faf:55",
+
+  "os": {
+    "name": "rhel",
+    "version": "7.2",
+    "architecture": "x86_64"
+  },
+
+  "problem": {
+    "type": "python",
+
+    "component": "faf",
+
+    "exception_name": "ImportError",
+
+    "user": {
+      "local": true,
+      "root": false
+    },
+
+    "stacktrace": [
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py",
+        "file_line": 312,
+        "line_contents": "psycopg = __import__('psycopg2')",
+        "function_name": "dbapi"
+      },
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/strategies.py",
+        "file_line": 64,
+        "line_contents": "dbapi = dialect_cls.dbapi(**dbapi_args)",
+        "function_name": "create"
+      },
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/__init__.py",
+        "file_line": 338,
+        "line_contents": "return strategy.create(*args, **kwargs)",
+        "function_name": "create_engine"
+      },
+      {
+        "file_name": "/usr/lib/python2.7/site-packages/pyfaf/storage/__init__.py",
+        "file_line": 213,
+        "line_contents": "self._db = create_engine(config['storage.connectstring'])",
+        "function_name": "__init__"
+      },
+      {
+        "file_name": "/usr/lib/python2.7/site-packages/pyfaf/storage/__init__.py",
+        "file_line": 199,
+        "line_contents": "db = Database(debug=debug, dry=dry)",
+        "function_name": "getDatabase"
+      },
+      {
+        "file_name": "/usr/bin/faf",
+        "file_line": 29,
+        "line_contents": "db = getDatabase(debug=cmdline.sql_verbose, dry=cmdline.dry_run)",
+        "function_name": "main"
+      },
+      {
+        "file_name": "/usr/bin/faf",
+        "file_line": 55,
+        "special_function": "module",
+        "line_contents": "main()"
+      }
+    ]
+  },
+
+  "packages": [
+    {
+      "name": "faf",
+      "epoch": 0,
+      "version": "0.9",
+      "architecture": "noarch",
+      "package_role": "affected",
+      "release": "1.fc18"
+    }
+  ],
+
+  "reporter": {
+    "version": "0.3",
+    "name": "satyr"
+  }
+}

--- a/tests/sample_reports/ureport_duplicate4
+++ b/tests/sample_reports/ureport_duplicate4
@@ -1,0 +1,85 @@
+{
+  "ureport_version": 2,
+
+  "reason": "ImportError in /usr/bin/faf:55",
+
+  "os": {
+    "name": "rhel",
+    "version": "7.7",
+    "architecture": "x86_64"
+  },
+
+  "problem": {
+    "type": "python",
+
+    "component": "faf",
+
+    "exception_name": "ImportError",
+
+    "user": {
+      "local": true,
+      "root": false
+    },
+
+    "stacktrace": [
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py",
+        "file_line": 312,
+        "line_contents": "psycopg = __import__('psycopg2')",
+        "function_name": "dbapi"
+      },
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/strategies.py",
+        "file_line": 64,
+        "line_contents": "dbapi = dialect_cls.dbapi(**dbapi_args)",
+        "function_name": "create"
+      },
+      {
+        "file_name": "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/__init__.py",
+        "file_line": 338,
+        "line_contents": "return strategy.create(*args, **kwargs)",
+        "function_name": "create_engine"
+      },
+      {
+        "file_name": "/usr/lib/python2.7/site-packages/pyfaf/storage/__init__.py",
+        "file_line": 213,
+        "line_contents": "self._db = create_engine(config['storage.connectstring'])",
+        "function_name": "__init__"
+      },
+      {
+        "file_name": "/usr/lib/python2.7/site-packages/pyfaf/storage/__init__.py",
+        "file_line": 199,
+        "line_contents": "db = Database(debug=debug, dry=dry)",
+        "function_name": "getDatabase"
+      },
+      {
+        "file_name": "/usr/bin/faf",
+        "file_line": 29,
+        "line_contents": "db = getDatabase(debug=cmdline.sql_verbose, dry=cmdline.dry_run)",
+        "function_name": "main"
+      },
+      {
+        "file_name": "/usr/bin/faf",
+        "file_line": 55,
+        "special_function": "module",
+        "line_contents": "main()"
+      }
+    ]
+  },
+
+  "packages": [
+    {
+      "name": "faf",
+      "epoch": 0,
+      "version": "0.9",
+      "architecture": "noarch",
+      "package_role": "affected",
+      "release": "1.fc18"
+    }
+  ],
+
+  "reporter": {
+    "version": "0.3",
+    "name": "satyr"
+  }
+}

--- a/tests/webfaf/reports
+++ b/tests/webfaf/reports
@@ -8,8 +8,10 @@ except ImportError:
     import unittest
 from StringIO import StringIO
 from webfaftests import WebfafTestCase
-from pyfaf.storage import InvalidUReport
 
+from pyfaf.storage import InvalidUReport, Report, ReportHash, BzBug, ReportBz, Bugtracker, BzUser, BzBug
+from pyfaf import config, ureport
+from pyfaf.queries import *
 
 class ReportTestCase(WebfafTestCase):
     """
@@ -29,17 +31,58 @@ class ReportTestCase(WebfafTestCase):
 
         return r
 
+    def create_bugzilla_bug(self):
+        #get last report id
+
+        bztracker = Bugtracker()
+        bztracker.name = "rhel-bugzilla"
+
+        bzuser = BzUser()
+        bzuser.email = "test@redhat.com"
+        bzuser.name = "test@redhat.com"
+        bzuser.real_name = "Test User"
+        bzuser.can_login = "t"
+
+        bzbug = BzBug()
+        bzbug.opsysrelease_id = 1
+        bzbug.summary = "summary"
+        bzbug.status = "NEW"
+        bzbug.creation_time = "2016-02-12 11:44:10"
+        bzbug.last_change_time = "2016-02-12 11:44:10"
+        bzbug.tracker_id = 1
+        bzbug.component_id = 1
+        bzbug.whiteboard = 1
+        bzbug.creator_id = 1
+
+        self.db.session.add(bztracker)
+        self.db.session.add(bzuser)
+        self.db.session.add(bzbug)
+        self.db.session.flush()
+
+        reports = self.db.session.query(Report).all()
+        for rep in reports:
+            reportbz = ReportBz()
+            reportbz.report_id = str(rep.id)
+            reportbz.bzbug_id = 1
+
+            self.db.session.add(reportbz)
+            self.db.session.flush()
+
     def post_report(self, contents):
         return self.post_file("/reports/new/", contents)
 
     def post_attachment(self, contents):
         return self.post_file("/reports/attach/", contents)
 
+    def clear_reports(self):
+        self.db.session.query(Report).delete()
+        self.db.session.commit()
+        self.db.session.flush()
+
     def test_new_report_ureport1(self):
         """
         Test saving of ureport version 1
         """
-
         path = os.path.join(self.reports_path, 'ureport1')
         with open(path) as file:
             r = self.post_report(file.read())
@@ -87,7 +130,7 @@ class ReportTestCase(WebfafTestCase):
             r = self.post_report(file.read())
 
         js = json.loads(r.data)
-        print(js)
+
         self.assertEqual(js["result"], True)
         self.assertEqual(js["bthash"],
                          "2dd542ba1f1e074216196b6c0bd548609bf38ebc")
@@ -126,6 +169,185 @@ class ReportTestCase(WebfafTestCase):
 
         r = self.post_attachment("invalid")
         self.assertEqual(json.loads(r.data)["error"], u"Invalid JSON file")
+
+    def test_report_duplicates(self):
+        """
+        Test reporẗ́s duplicates
+        CONSTATNT WICH IS TESTED: EQUAL_UREPORT_EXISTS
+        """
+        self.clear_reports()
+        config.config['ureport.known'] = "EQUAL_UREPORT_EXISTS"
+
+        source = [{ 'file_name': 'ureport_duplicate', 'result': False },
+                  { 'file_name': 'ureport_duplicate', 'result': True },
+                  { 'file_name': 'ureport_duplicate2', 'result': False }]
+
+        for item in source:
+            path = os.path.join(self.reports_path, item['file_name'])
+
+            with open(path) as file:
+                data = self.post_report(file.read())
+
+            self.assertEqual(self.call_action("save-reports"), 0)
+
+            self.db.session.commit()
+            self.db.session.flush()
+
+            data_js = json.loads(data.data)
+
+            if item['result'] is True:
+                self.assertTrue(data_js['result'])
+            else:
+                self.assertFalse(data_js['result'])
+
+    def test_report_duplicate_os_minor(self):
+        """
+        Test reporẗ́s duplicates
+        CONSTATNT WICH IS TESTED: BUG_OS_MINOR_VERSION
+        """
+        self.clear_reports()
+        config.config['ureport.known'] = "BUG_OS_MINOR_VERSION"
+
+        source = [{ 'file_name': 'ureport_duplicate', 'result': False },
+                  { 'file_name': 'ureport_duplicate', 'result': True },
+                  { 'file_name': 'ureport_duplicate2', 'result': False },
+                  { 'file_name': 'ureport_duplicate3', 'result': False },
+                  { 'file_name': 'ureport_duplicate4', 'result': False }]
+
+        i = 0
+        for item in source:
+            path = os.path.join(self.reports_path, item['file_name'])
+
+            with open(path) as file:
+                data = self.post_report(file.read())
+
+            self.assertEqual(self.call_action("save-reports"), 0)
+
+            self.db.session.commit()
+            self.db.session.flush()
+
+            if i == 0:
+                self.create_bugzilla_bug()
+                self.db.session.commit()
+                self.db.session.flush()
+
+            data_js = json.loads(data.data)
+
+            if item['result'] is True:
+                self.assertTrue(data_js['result'])
+            else:
+                self.assertFalse(data_js['result'])
+
+            i += 1
+
+    def test_report_duplicate_os_major(self):
+        """
+        Test reporẗ́s duplicates
+        CONSTATNT WICH IS TESTED: BUG_OS_MAJOR_VERSION
+        """
+        self.clear_reports()
+        config.config['ureport.known'] = "BUG_OS_MAJOR_VERSION"
+
+        source = [{ 'file_name': 'ureport_duplicate', 'result': False },
+                  { 'file_name': 'ureport_duplicate', 'result': True },
+                  { 'file_name': 'ureport_duplicate2', 'result': True },
+                  { 'file_name': 'ureport_duplicate3', 'result': False },
+                  { 'file_name': 'ureport_duplicate4', 'result': False }]
+
+        i = 0
+        for item in source:
+            path = os.path.join(self.reports_path, item['file_name'])
+
+            with open(path) as file:
+                data = self.post_report(file.read())
+
+            self.assertEqual(self.call_action("save-reports"), 0)
+
+            self.db.session.commit()
+            self.db.session.flush()
+
+            if i == 0:
+                self.create_bugzilla_bug()
+                self.db.session.commit()
+                self.db.session.flush()
+
+            data_js = json.loads(data.data)
+
+            if item['result'] is True:
+                self.assertTrue(data_js['result'])
+            else:
+                self.assertFalse(data_js['result'])
+
+            i += 1
+
+    def test_get_report(self):
+        self.clear_reports()
+
+        path = os.path.join(self.reports_path, 'ureport_duplicate')
+        with open(path) as file:
+            first = self.post_report(file.read())
+
+        self.assertEqual(self.call_action("save-reports"), 0)
+        self.db.session.commit()
+        self.db.session.flush()
+
+        first_js  = json.loads(first.data)
+
+        report  = get_report(self.db, first_js['bthash'])
+
+        report1 = get_report(self.db, first_js['bthash'], os_name='rhel',
+                              os_version='6.7', os_arch='x86_64')
+
+        report2 = get_report(self.db, first_js['bthash'], os_name='rhel',
+                              os_version='7.1', os_arch='x86_64')
+
+        report3 = get_report(self.db, first_js['bthash'], os_name='rhel',
+                              os_version='6.7', os_arch='noarch')
+
+        report4 = get_report(self.db, first_js['bthash'], os_name='rhel',
+                              os_version='6.8', os_arch='x86_64')
+
+        report5 = get_report(self.db, first_js['bthash'], os_name='rhel')
+
+        report6 = get_report(self.db, first_js['bthash'], os_version='6.7')
+
+        report7 = get_report(self.db, first_js['bthash'], os_arch='x86_64')
+
+        report8 = get_report(self.db, first_js['bthash'], os_name='rhel',
+                              os_arch='x86_64')
+
+        report9 = get_report(self.db, first_js['bthash'], os_version='6.7',
+                              os_arch='x86_64')
+
+        self.assertIsNotNone(report)
+        self.assertIsNotNone(report1)
+        self.assertIsNone(report2)
+        self.assertIsNone(report3)
+        self.assertIsNone(report4)
+        self.assertIsNotNone(report5)
+        self.assertIsNotNone(report6)
+        self.assertIsNotNone(report7)
+        self.assertIsNotNone(report8)
+        self.assertIsNotNone(report9)
+
+    def test_known_type(self):
+        result = ureport.valid_known_type("EQUAL_UREPORT_EXISTS".split(" "))
+        result1 = ureport.valid_known_type("BUG_OS_MINOR_VERSION".split(" "))
+        result2 = ureport.valid_known_type("BUG_OS_MAJOR_VERSION".split(" "))
+        result3 = ureport.valid_known_type("EQUAL_UREPORT_EXISTS "
+                                           "BUG_OS_MINOR_VERSION".split(" "))
+        result4 = ureport.valid_known_type("  ".strip().split(" "))
+        result5 = ureport.valid_known_type("BUGS_OS_MAJOR_VERSION".split(" "))
+        result6 = ureport.valid_known_type( "EQUAL_UREPORT_EXISTS   "
+                                            "BUG_OS_MINOR_VERSION".split(" "))
+
+        self.assertTrue(result)
+        self.assertTrue(result1)
+        self.assertTrue(result2)
+        self.assertTrue(result3)
+        self.assertTrue(result4)
+        self.assertFalse(result5)
+        self.assertTrue(result6)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
https://github.com/abrt/faf/issues/489

Add known option to faf's configure file, renamed and rework method 'get_report_by_hash'
to 'get_report' which can finding known reports by OS attributes like OS Major version,
OS Minor version, OS architecture, next added method is 'get_reportbz_by_major_version'
which is searching bugzilla report's by OS Major version.

I added tests for all possible cases.

Signed-off-by: Patrik Helia <phelia@redhat.com>