### PR TITLE
Syntax error in celery task action filter

### DIFF
--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -31,7 +31,10 @@ url_prefix = "/celery_tasks"
 celery_tasks = Blueprint("celery_tasks", __name__)
 
 # Filter actions to exclude cmdline_only ones
-actions = {n: a for (n, a) in actions_all.items() if not a.cmdline_only}
+actions = dict()
+for n, a in actions_all.items():
+    if not a.cmdline_only:
+        actions[n] = a
 
 
 @celery_tasks.route("/")


### PR DESCRIPTION
In Python 2.6 was syntax error.

Signed-off-by: Patrik Helia <phelia@redhat.com>