### PR TITLE
Attachments: One url can be attached to many reports

### DIFF
--- a/src/pyfaf/ureport.py
+++ b/src/pyfaf/ureport.py
@@ -510,8 +510,11 @@ def save_attachment(db, attachment):
     elif atype == "url":
         url = attachment["data"]
 
+        # 0ne URL can be attached to many Reports, but every reports must
+        # have unique url's
         db_url = (db.session.query(ReportURL)
                   .filter(ReportURL.url == url)
+                  .filter(ReportURL.report_id == report.id)
                   .first())
 
         if db_url:


### PR DESCRIPTION
Currently, a single URL can be added to the database only once - in other words, it is not possible to attache a single URL to more micro reports. I was not able to find a justification for it.

We have found a use case where we need to attach a single URL to more micro reports (test case URL). So this commit removes the constraints of uniqueness of URL column which is enforced in the application logic.

The constraint is enforced by looking up for the url in the reporturls. The commit adds a new filter condition which will ensure that a single URL can be attached to more micro reports but just only once to a particular one.

Signed-off-by: Patrik Helia <phelia@redhat.com>