### PR TITLE
Remove debug print when creating new bug for a report

### DIFF
--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -466,7 +466,6 @@ def associate_bug(report_id):
                                   version=osr.version)
                 else:
                     params.update(product=osr.opsys.name, version=osr.version)
-                print(params)
                 new_bug_urls.append(
                     ("{0} {1} in {2}".format(osr.opsys.name, osr.version,
                                              bugtracker),


### PR DESCRIPTION
It spams error logs.