### PR TITLE
retracing: execute eu-addr2line with hex address

### DIFF
--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -589,7 +589,7 @@ class CoredumpProblem(ProblemType):
                 try:
                     debug_path = os.path.join(task.debuginfo.unpacked_path,
                                               "usr", "lib", "debug")
-                    results = addr2line(binary, address, debug_path)
+                    results = addr2line(binary, hex(int(address)), debug_path)
                     results.reverse()
                 except Exception as ex:
                     self.log_debug("addr2line failed: {0}".format(str(ex)))

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -639,7 +639,7 @@ class KerneloopsProblem(ProblemType):
                 try:
                     abspath = os.path.join(task.debuginfo.unpacked_path,
                                            debug_path[1:])
-                    results = addr2line(abspath, address, debug_dir)
+                    results = addr2line(abspath, hex(int(address)), debug_dir)
                     results.reverse()
                 except FafError as ex:
                     self.log_debug("addr2line failed: {0}".format(str(ex)))


### PR DESCRIPTION
The tool requires hexadecimal address. The address must be converted to
int first to avoid the "L" suffix as the type of address is long. int
and long are unified for a quite long while so it safe to cast long to
int.

Signed-off-by: Jakub Filak <jfilak@redhat.com>