### PR TITLE
java: drop all requirements on frame name

### DIFF
--- a/src/pyfaf/problemtypes/java.py
+++ b/src/pyfaf/problemtypes/java.py
@@ -57,8 +57,7 @@ class JavaProblem(ProblemType):
         "threads":        ListChecker(DictChecker({
             "name":           StringChecker(),
             "frames":         ListChecker(DictChecker({
-                "name":           StringChecker(pattern=r"^[a-zA-Z0-9\._]+$",
-                                                maxlen=column_len(Symbol,
+                "name":           StringChecker(maxlen=column_len(Symbol,
                                                                   "name")),
                 "is_native":      Checker(bool),
                 "is_exception":   Checker(bool),


### PR DESCRIPTION
For the same reason we do not check format of C++ function names, it is
too complex.

Signed-off-by: Jakub Filak <jfilak@redhat.com>