### PR TITLE
ureport: stop wasting memory by loading all ureports

### DIFF
--- a/src/pyfaf/ureport.py
+++ b/src/pyfaf/ureport.py
@@ -574,8 +574,6 @@ def is_known(ureport, db, return_report=False, opsysrelease_id=None):
     if 'EQUAL_UREPORT_EXISTS' in known_type:
         report_os = ureport["os"]
 
-    reports = db.session.query(Report).all()
-
     report = get_report(db, report_hash, os_name=report_os['name'], os_version=report_os['version'], os_arch=report_os['architecture'])
 
     if report is None:


### PR DESCRIPTION
The removed command is clearly a bug. There is no need to load all
micro-reports and the variable is never used.

Signed-off-by: Jakub Filak <jfilak@redhat.com>