### PR TITLE
retrace: fix tests failing on RHEL6

### DIFF
--- a/tests/bin/eu-addr2line
+++ b/tests/bin/eu-addr2line
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 if [ -n "$EU_ADDR2LINE_SAMPLE_DIR" ]; then
     FILE="${EU_ADDR2LINE_SAMPLE_DIR%/}/"


### PR DESCRIPTION
RHEL-6 was not subject of the /usr move.

Signed-off-by: Jakub Filak <jfilak@redhat.com>