### PR TITLE
Add old package garbage collector

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -229,6 +229,13 @@ Requires: %{name} = %{faf_version}
 %description action-find-components
 A plugin for %{name} implementing find-components action
 
+%package action-assign-release-to-builds
+Summary: %{name}'s assign-release-to-builds plugin
+Requires: %{name} = %{faf_version}
+
+%description action-assign-release-to-builds
+A plugin for %{name} implementing assign-release-to-builds action
+
 %package action-find-crash-function
 Summary: %{name}'s find-crash-function plugin
 Requires: %{name} = %{faf_version}
@@ -830,6 +837,9 @@ fi
 
 %files action-find-report-solution
 %{python_sitelib}/pyfaf/actions/find_report_solution.py*
+
+%files action-assign-release-to-builds
+%{python_sitelib}/pyfaf/actions/assign_release_to_builds.py*
 
 %files action-repo
 %{python_sitelib}/pyfaf/actions/repoadd.py*

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -358,6 +358,13 @@ Requires: %{name}-fedmsg = %{faf_version}
 %description action-fedmsg-notify
 A plugin for %{name} implementing notification into Fedmsg
 
+%package action-cleanup-packages
+Summary: %{name}'s cleanup-packages plugin
+Requires: %{name} = %{faf_version}
+
+%description action-cleanup-packages
+A plugin for %{name} implementing cleanup of old packages.
+
 %package action-cleanup-task-results
 Summary: %{name}'s cleanup-task-results plugin
 Requires: %{name} = %{faf_version}
@@ -904,6 +911,9 @@ fi
 
 %files action-fedmsg-notify
 %{python_sitelib}/pyfaf/actions/fedmsg_notify.py*
+
+%files action-cleanup-packages
+%{python_sitelib}/pyfaf/actions/cleanup_packages.py*
 
 %files action-cleanup-task-results
 %{python_sitelib}/pyfaf/actions/cleanup_task_results.py*

--- a/src/pyfaf/actions/Makefile.am
+++ b/src/pyfaf/actions/Makefile.am
@@ -4,6 +4,7 @@ actions_PYTHON = \
     archadd.py \
     archive_reports.py \
     archlist.py \
+    assign_release_to_builds.py \
     attach_centos_bugs.py \
     bugtrackerlist.py \
     pull_abrt_bugs.py \

--- a/src/pyfaf/actions/Makefile.am
+++ b/src/pyfaf/actions/Makefile.am
@@ -11,6 +11,7 @@ actions_PYTHON = \
     pull_bug.py \
     update_bugs.py \
     c2p.py \
+    cleanup_packages.py \
     cleanup_task_results.py \
     componentadd.py \
     create_problems.py \

--- a/src/pyfaf/actions/assign_release_to_builds.py
+++ b/src/pyfaf/actions/assign_release_to_builds.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2016  ABRT Team
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyfaf.actions import Action
+from pyfaf.storage.opsys import (Build, BuildOpSysReleaseArch, OpSys,
+                                 OpSysRelease, Arch)
+from pyfaf.opsys import systems
+from pyfaf.queries import get_opsys_by_name, get_osrelease, get_arch_by_name
+
+
+class AssignReleaseToBuilds(Action):
+    name = "assign-release-to-builds"
+
+    def __init__(self):
+        super(AssignReleaseToBuilds, self).__init__()
+
+    def run(self, cmdline, db):
+        # nobody will write the full name
+        if cmdline.OPSYS == "rhel":
+            cmdline.OPSYS = "Red Hat Enterprise Linux"
+
+        # check if operating system is known
+        if not get_opsys_by_name(db, cmdline.OPSYS):
+            self.log_error("Selected operating system '{0}' is not supported."
+                            .format(cmdline.OPSYS))
+            return 1
+        else:
+            self.log_info("Selected operating system: '{0}'"
+                    .format(cmdline.OPSYS))
+
+        # check if release is known
+        opsysrelease = get_osrelease(db, cmdline.OPSYS, cmdline.RELEASE)
+        if not opsysrelease:
+            self.log_error("Selected release '{0}' is not supported."
+                            .format(cmdline.RELEASE))
+            return 1
+        else:
+            self.log_info("Selected release: '{0}'".format(cmdline.RELEASE))
+
+        # check if architecture is known
+        arch = get_arch_by_name(db, cmdline.ARCH)
+        if not arch:
+            self.log_error("Selected architecture '{0}' is not supported."
+                            .format(cmdline.ARCH))
+            return 1
+        else:
+            self.log_info("Selected architecture: '{0}'".format(cmdline.ARCH))
+
+        # when release-builds argument specified
+        if cmdline.released_builds:
+            self.log_info("Assigning released builds for '{0} {1}'"
+                    .format(cmdline.OPSYS, cmdline.RELEASE))
+            opsys = self._edit_opsys(cmdline.OPSYS)
+            if not opsys in systems.keys():
+                self.log_error("There are no known released builds for '{0}'"
+                                    .format(cmdline.OPSYS))
+                return 1
+
+            for build in systems[opsys].get_released_builds(cmdline.RELEASE):
+                found_build = (db.session.query(Build)
+                         .filter(Build.base_package_name ==
+                                 build["name"])
+                         .filter(Build.version == build["version"])
+                         .filter(Build.release == build["release"])
+                         .filter(Build.epoch == build["epoch"])
+                         .first())
+
+                if found_build:
+                    self._add_into_build_opsysrelease_arch(db, found_build,
+                                                           opsysrelease, arch)
+
+        # when expression argument was passed
+        if cmdline.expression:
+            self.log_info("Selecting builds by expression: '{0}'"
+                    .format(cmdline.expression))
+            found_builds = (db.session.query(Build)
+                            .filter(Build.release.like("%{0}"
+                            .format(cmdline.expression)))
+                            .all())
+            for build in found_builds:
+                self._add_into_build_opsysrelease_arch(db, build,
+                                                       opsysrelease, arch)
+
+
+    def _edit_opsys(self, original_name):
+        """ Solve name problem
+
+        There is one complication with operating system names. In the database
+        names are in a full form, with capital latters e.g. Fedora, CentOS,
+        Red Hat Enterpise Linux. On the other hand, plugins are associated with
+        names in shorter form a without capitals e.g fedora, centos, rhel.
+        """
+        if original_name == "Red Hat Enterprise Linux":
+            return "rhel"
+        else:
+            return original_name.lower()
+
+
+    def _add_into_build_opsysrelease_arch(self, db, build, opsysrelease, arch):
+        build_opsysrelease_arch = (
+               db.session.query(BuildOpSysReleaseArch)
+               .join(Build)
+               .join(OpSysRelease)
+               .join(Arch)
+               .filter(Build.id == build.id)
+               .filter(OpSys.name == opsysrelease.opsys.name)
+               .filter(OpSysRelease.version == opsysrelease.version)
+               .filter(Arch.name == arch.name)
+               .first())
+
+        if not build_opsysrelease_arch:
+            self.log_info("Adding link between build {0}-{1} "
+                    "operating system '{2}', release '{3} and "
+                    "architecture {4}".format(build.base_package_name,
+                    build.version, opsysrelease.opsys.name,
+                    opsysrelease.version, arch.name))
+            bosra = BuildOpSysReleaseArch()
+            bosra.build = build
+            bosra.opsysrelease = opsysrelease
+            bosra.arch = arch
+
+            db.session.add(bosra)
+            db.session.flush()
+
+
+    def tweak_cmdline_parser(self, parser):
+        parser.add_argument("OPSYS", help="operating system to be assigned")
+        parser.add_argument("RELEASE", help="release to be assigned")
+        parser.add_argument("ARCH", help="architecture to be assigned")
+        parser.add_argument("--expression", dest='expression',
+                            help="sql 'like' statement will be used with given"
+                                 " expession")
+        parser.add_argument("--released-builds", action="store_true", 
+                            help = "released builds will be assigned")

--- a/src/pyfaf/actions/cleanup_packages.py
+++ b/src/pyfaf/actions/cleanup_packages.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2016  ABRT Team
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyfaf.actions import Action
+from sqlalchemy.orm import aliased
+from pyfaf.storage.opsys import (BuildOpSysReleaseArch, Build, OpSysRelease,
+                                Package, Build, PackageDependency, BuildArch,
+                                BuildComponent)
+from pyfaf.storage.report import ReportPackage
+from pyfaf.storage.problem import ProblemOpSysRelease
+from pyfaf.storage.llvm import LlvmBuild, LlvmBcFile, LlvmResultFile
+from pyfaf.queries import get_opsys_by_name, get_osrelease
+
+class CleanupPackages(Action):
+    name = "cleanup-packages"
+
+    def run(self, cmdline, db):
+        # nobody will write the full name
+        if cmdline.OPSYS == "rhel":
+            cmdline.OPSYS = "Red Hat Enterprise Linux"
+
+        # check if operating system is known
+        if not get_opsys_by_name(db, cmdline.OPSYS):
+            self.log_error("Selected operating system '{0}' is not supported."
+                            .format(cmdline.OPSYS))
+            return 1
+        else:
+            self.log_info("Selected operating system: '{0}'"
+                    .format(cmdline.OPSYS))
+
+        # check if release is known
+        opsysrelease = get_osrelease(db, cmdline.OPSYS, cmdline.RELEASE)
+        if not opsysrelease:
+            self.log_error("Selected release '{0}' is not supported."
+                            .format(cmdline.RELEASE))
+            return 1
+        else:
+            self.log_info("Selected release: '{0}'".format(cmdline.RELEASE))
+
+        # find all builds, that are assigned to this opsysrelease but none other
+        # architecture is missed out intentionally
+        bosra1 = aliased(BuildOpSysReleaseArch)
+        bosra2 = aliased(BuildOpSysReleaseArch)
+        all_builds = (db.session.query(bosra1)
+                 .filter(bosra1.opsysrelease_id == opsysrelease.id)
+                 .filter(~bosra1.build_id.in_(
+                        db.session.query(bosra2.build_id)
+                        .filter(bosra1.build_id == bosra2.build_id)
+                        .filter(bosra2.opsysrelease_id != opsysrelease.id)
+                        ))
+                 .all())
+
+        #delete all records, where the opsysrelease.id is present
+        query = (db.session.query(BuildOpSysReleaseArch)
+            .filter(BuildOpSysReleaseArch.opsysrelease_id == opsysrelease.id))
+
+        self.log_info("{0} links will be removed".format(query.count()))
+        if cmdline.dry_run:
+            self.log_info("Dry run active, removal will be skipped")
+        else:
+            query.delete()
+
+        #delete all builds and packages from them
+        for build in all_builds:
+            for pkg in (db.session.query(Package)
+                  .filter(Package.build_id == build.build_id)
+                  .all()):
+                self.delete_package(pkg, db, cmdline.dry_run)
+
+
+    def delete_package(self, pkg, db, dry_run):
+        #delete package from disk
+        if pkg.has_lob("package"):
+            self.log_info("Deleting lob for: {0}".format(pkg.nevr()))
+            if dry_run:
+                self.log_info("Dry run active, removal will be skipped")
+            else:
+                pkg.del_lob("package")
+
+
+    def tweak_cmdline_parser(self, parser):
+
+        parser.add_argument("OPSYS", help="operating system")
+        parser.add_argument("RELEASE", help="release")

--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -352,7 +352,7 @@ class Fedora(System):
                                             inherit=False)
 
         return [{"name": b["name"],
-                 "epoch": b["epoch"],
+                 "epoch": b["epoch"] if b["epoch"] is not None else 0,
                  "version": b["version"],
                  "release": b["release"],
                  "nvr": b["nvr"],

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -22,6 +22,7 @@ import functools
 from pyfaf.storage import (Arch,
                            AssociatePeople,
                            Build,
+                           BuildOpSysReleaseArch,
                            Bugtracker,
                            BzAttachment,
                            BzBug,
@@ -109,7 +110,7 @@ __all__ = ["get_arch_by_name", "get_archs", "get_associate_by_name",
            "get_symbolsource", "get_taint_flag_by_ureport_name",
            "get_unknown_opsys", "get_unknown_package", "update_frame_ssource",
            "query_hot_problems", "query_longterm_problems",
-           "user_is_maintainer"]
+           "user_is_maintainer", "get_packages_by_osrelease"]
 
 
 def get_arch_by_name(db, arch_name):
@@ -504,6 +505,22 @@ def get_osrelease(db, name, version):
                       .filter(OpSys.name == name)
                       .filter(OpSysRelease.version == version)
                       .first())
+
+
+def get_packages_by_osrelease(db, name, version):
+    """
+    Return pyfaf.storage.Package objects assigned to specific osrelease
+    specified by name and version or None if not found.
+    """
+
+    return (db.session.query(Package)
+                      .join(Build)
+                      .join(BuildOpSysReleaseArch)
+                      .join(OpSysRelease)
+                      .join(OpSys)
+                      .filter(OpSys.name == name)
+                      .filter(OpSysRelease.version == version)
+                      .all())
 
 
 def get_package_by_file(db, filename):

--- a/src/pyfaf/storage/migrations/versions/133991a89da4_build_to_opsysrelease.py
+++ b/src/pyfaf/storage/migrations/versions/133991a89da4_build_to_opsysrelease.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2014  ABRT Team
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""assign build to operating system, release and architecture
+
+Revision ID: 133991a89da4
+Revises: 17d4911132f8
+Create Date: 2016-09-08 09:08:26.035450
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '133991a89da4'
+down_revision = '17d4911132f8'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('buildopsysreleasearch',
+    sa.Column('build_id', sa.Integer(), nullable=False),
+    sa.Column('opsysrelease_id', sa.Integer(), nullable=False),
+    sa.Column('arch_id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['build_id'], ['builds.id'], ),
+    sa.ForeignKeyConstraint(['opsysrelease_id'], ['opsysreleases.id'], ),
+    sa.ForeignKeyConstraint(['arch_id'], ['archs.id'], ),
+    sa.PrimaryKeyConstraint('build_id', 'opsysrelease_id', 'arch_id'),
+    )
+
+
+def downgrade():
+    op.drop_table('buildopsysreleasearch')

--- a/src/pyfaf/storage/migrations/versions/17d4911132f8_assigning_release_to_repo.py
+++ b/src/pyfaf/storage/migrations/versions/17d4911132f8_assigning_release_to_repo.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2014  ABRT Team
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""assigning release to repository
+
+Revision ID: 17d4911132f8
+Revises: 13557f1962e6
+Create Date: 2016-09-08 08:49:52.450697
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '17d4911132f8'
+down_revision = '13557f1962e6'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('opsysreleaserepo',
+    sa.Column('opsysrelease_id', sa.Integer(), nullable=False),
+    sa.Column('repo_id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['opsysrelease_id'], ['opsysreleases.id'], ),
+    sa.ForeignKeyConstraint(['repo_id'], ['repo.id'], ),
+    sa.PrimaryKeyConstraint('opsysrelease_id', 'repo_id'),
+    )
+
+
+def downgrade():
+    op.drop_table('opsysreleaserepo')

--- a/src/pyfaf/storage/migrations/versions/Makefile.am
+++ b/src/pyfaf/storage/migrations/versions/Makefile.am
@@ -1,4 +1,5 @@
 versions_PYTHON = \
+    17d4911132f8_assigning_release_to_repo.py \
     1b264b21ca91_add_semrel_to_build.py \
     1c7edfbf8941_drop_reportunknownpackage_running_fields.py \
     21345f007bdf_add_privileged_user_field.py \

--- a/src/pyfaf/storage/migrations/versions/Makefile.am
+++ b/src/pyfaf/storage/migrations/versions/Makefile.am
@@ -1,4 +1,5 @@
 versions_PYTHON = \
+    133991a89da4_build_to_opsysrelease.py \
     17d4911132f8_assigning_release_to_repo.py \
     1b264b21ca91_add_semrel_to_build.py \
     1c7edfbf8941_drop_reportunknownpackage_running_fields.py \

--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -64,6 +64,21 @@ class OpSys(GenericTable):
                       self.releases)
 
 
+class OpSysRelease(GenericTable):
+    __tablename__ = "opsysreleases"
+    __table_args__ = (UniqueConstraint('opsys_id', 'version'),)
+
+    id = Column(Integer, primary_key=True)
+    opsys_id = Column(Integer, ForeignKey("{0}.id".format(OpSys.__tablename__)), nullable=False, index=True)
+    version = Column(String(32), nullable=False)
+    releasedate = Column(DateTime, nullable=True)
+    status = Column(OpSysReleaseStatus, nullable=False)
+    opsys = relationship(OpSys, backref="releases")
+
+    def __str__(self):
+        return '{0} {1}'.format(self.opsys, self.version)
+
+
 class Repo(GenericTable):
     __tablename__ = "repo"
 
@@ -74,6 +89,7 @@ class Repo(GenericTable):
     nice_name = Column(String(256), nullable=True)
     nogpgcheck = Column(Boolean, nullable=False)
     opsys_list = relationship(OpSys, secondary="opsysrepo")
+    opsysrelease_list = relationship(OpSysRelease, secondary="opsysreleaserepo")
     arch_list = relationship(Arch, secondary="archrepo")
 
     def __str__(self):
@@ -94,19 +110,11 @@ class ArchRepo(GenericTable):
     repo_id = Column(Integer, ForeignKey("{0}.id".format(Repo.__tablename__)), primary_key=True)
 
 
-class OpSysRelease(GenericTable):
-    __tablename__ = "opsysreleases"
-    __table_args__ = (UniqueConstraint('opsys_id', 'version'),)
+class OpSysReleaseRepo(GenericTable):
+    __tablename__ = "opsysreleaserepo"
 
-    id = Column(Integer, primary_key=True)
-    opsys_id = Column(Integer, ForeignKey("{0}.id".format(OpSys.__tablename__)), nullable=False, index=True)
-    version = Column(String(32), nullable=False)
-    releasedate = Column(DateTime, nullable=True)
-    status = Column(OpSysReleaseStatus, nullable=False)
-    opsys = relationship(OpSys, backref="releases")
-
-    def __str__(self):
-        return '{0} {1}'.format(self.opsys, self.version)
+    opsysrelease_id = Column(Integer, ForeignKey("{0}.id".format(OpSysRelease.__tablename__)), primary_key=True)
+    repo_id = Column(Integer, ForeignKey("{0}.id".format(Repo.__tablename__)), primary_key=True)
 
 
 class OpSysComponent(GenericTable):

--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -183,6 +183,18 @@ class Build(GenericTable):
         return "{0}-{1}:{2}-{3}".format(self.base_package_name, self.epoch, self.version, self.release)
 
 
+class BuildOpSysReleaseArch(GenericTable):
+    __tablename__ = "buildopsysreleasearch"
+
+    build_id = Column(Integer, ForeignKey("{0}.id".format(Build.__tablename__)), primary_key=True)
+    opsysrelease_id = Column(Integer, ForeignKey("{0}.id".format(OpSysRelease.__tablename__)), primary_key=True)
+    arch_id = Column(Integer, ForeignKey("{0}.id".format(Arch.__tablename__)), primary_key=True)
+
+    build = relationship(Build)
+    opsysrelease = relationship(OpSysRelease)
+    arch = relationship(Arch)
+
+
 class BuildArch(GenericTable):
     __tablename__ = "buildarchs"
     __lobs__ = {"build.log": 1 << 26, "state.log": 1 << 16, "root.log": 1 << 26}

--- a/tests/actions
+++ b/tests/actions
@@ -16,11 +16,13 @@ import os
 import faftests
 
 from pyfaf.utils.proc import popen
+from pyfaf.config import config
 from pyfaf.opsys import systems
 from pyfaf.storage.opsys import (Arch,
                                  OpSysReleaseRepo,
                                  BuildOpSysReleaseArch,
                                  Build,
+                                 Package,
                                  )
 from pyfaf.solutionfinders import find_solution
 
@@ -197,6 +199,34 @@ class ActionsTestCase(faftests.DatabaseCase):
         ]), 0)
         bosra = self.db.session.query(BuildOpSysReleaseArch).count()
         self.assertEqual(bosra, init_bosra + 2)
+
+    def test_cleanup_packages(self):
+        self.test_assign_release_to_builds()
+
+        # add package and lob
+        pkg = Package()
+        pkg.build = self.db.session.query(Build).first()
+        pkg.arch = self.db.session.query(Arch).first()
+        pkg.name = "pkg-test"
+        self.db.session.add(pkg)
+        self.db.session.flush()
+
+        config["storage.lobdir"] = "/tmp/faf_test_data/lob"
+        sample_rpm = glob.glob("sample_rpms/sample*.rpm")[0]
+        with open(sample_rpm) as sample:
+            pkg.save_lob("package", sample, truncate=True)
+        self.assertTrue(pkg.has_lob("package"))
+
+        init_bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        self.assertEqual(self.call_action_ordered_args("cleanup-packages",[
+            "Fedora", # OPSYS
+            "24", # RELEASE
+        ]), 0)
+
+        bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        self.assertEqual(bosra, init_bosra - 2)
+
+        self.assertFalse(pkg.has_lob("package"))
 
     def test_releasemod(self):
         self.assertEqual(self.call_action("releasemod"), 1)

--- a/tests/actions
+++ b/tests/actions
@@ -7,10 +7,17 @@ except ImportError:
 import logging
 import json
 
+import glob
+import tempfile
+import shutil
+import os
+
 import faftests
 
+from pyfaf.utils.proc import popen
 from pyfaf.storage.opsys import (Arch,
                                  OpSysReleaseRepo,
+                                 BuildOpSysReleaseArch,
                                  )
 from pyfaf.solutionfinders import find_solution
 
@@ -92,6 +99,46 @@ class ActionsTestCase(faftests.DatabaseCase):
 
         opsysreleaserepo = self.db.session.query(OpSysReleaseRepo).count()
         self.assertEqual(opsysreleaserepo, init_opsysreleaserepo + 1)
+
+    def test_reposync(self):
+        self.rpm = glob.glob("sample_rpms/sample*.rpm")[0]
+
+        self.tmpdir = tempfile.mkdtemp()
+        shutil.copyfile(self.rpm,
+                        os.path.join(self.tmpdir, os.path.basename(self.rpm)))
+
+        proc = popen("createrepo", self.tmpdir)
+        self.assertIn("Workers Finished", proc.stdout)
+
+        self.call_action_ordered_args("repoadd", [
+            "sample_repo", # NAME
+            "yum", # TYPE
+            "file://{0}".format(self.tmpdir), # URL
+        ])
+
+        # add release
+        self.call_action("releaseadd", {
+            "opsys": "fedora",
+            "opsys-release": "24",
+            "status": "ACTIVE",
+        })
+
+        self.call_action_ordered_args("repoassign", [
+            "sample_repo", # NAME
+            "Fedora 24", # OPSYS
+            "x86_64",# ARCH
+        ])
+
+        init_bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        self.assertEqual(self.call_action("reposync", {
+            "NAME": "sample_repo",
+            "no-download-rpm": ""
+        }), 0)
+
+        bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        self.assertEqual(bosra, init_bosra + 1)
+
+        shutil.rmtree(self.tmpdir)
 
     def test_releasemod(self):
         self.assertEqual(self.call_action("releasemod"), 1)

--- a/tests/actions
+++ b/tests/actions
@@ -6,6 +6,7 @@ except ImportError:
     import unittest
 import logging
 import json
+from datetime import datetime, timedelta
 
 import glob
 import tempfile
@@ -15,9 +16,11 @@ import os
 import faftests
 
 from pyfaf.utils.proc import popen
+from pyfaf.opsys import systems
 from pyfaf.storage.opsys import (Arch,
                                  OpSysReleaseRepo,
                                  BuildOpSysReleaseArch,
+                                 Build,
                                  )
 from pyfaf.solutionfinders import find_solution
 
@@ -140,6 +143,61 @@ class ActionsTestCase(faftests.DatabaseCase):
 
         shutil.rmtree(self.tmpdir)
 
+    def test_assign_release_to_builds(self):
+        # add repo
+        self.assertEqual(self.call_action_ordered_args("repoadd", [
+            "sample_repo", # NAME
+            "yum", # TYPE
+            "file:///sample_rpms", # URL
+        ]), 0)
+
+        # add release
+        self.assertEqual(self.call_action("releaseadd", {
+            "opsys": "fedora",
+            "opsys-release": "24",
+            "status": "ACTIVE",
+        }), 0)
+
+        # add two builds
+        build = Build()
+        build.base_package_name = "build"
+        build.epoch = 0
+        build.version = "1.2.3"
+        build.release = "20.fc24"
+        self.db.session.add(build)
+
+        build = Build()
+        build.base_package_name = "build1"
+        build.epoch = 0
+        build.version = "1.2.3"
+        build.release = "20.fc23"
+        self.db.session.add(build)
+
+        self.db.session.flush()
+
+        systems['fedora'].get_released_builds = get_released_builds_mock
+
+        init_bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        self.assertEqual(self.call_action_ordered_args(
+            "assign-release-to-builds",[
+            "Fedora", # OPSYS
+            "24", # RELEASE
+            "x86_64", # ARCH
+            "--expression=fc24", # variant
+        ]), 0)
+        bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        self.assertEqual(bosra, init_bosra + 1)
+
+        self.assertEqual(self.call_action_ordered_args(
+            "assign-release-to-builds",[
+            "Fedora", # OPSYS
+            "24", # RELEASE
+            "x86_64", # ARCH
+            "--released-builds", # variant
+        ]), 0)
+        bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        self.assertEqual(bosra, init_bosra + 2)
+
     def test_releasemod(self):
         self.assertEqual(self.call_action("releasemod"), 1)
         self.assertEqual(self.call_action("releasemod", {
@@ -242,6 +300,15 @@ class ActionsTestCase(faftests.DatabaseCase):
         solution = find_solution(sample_reports['ureport_java'])
         self.assertIsNone(solution)
 
+def get_released_builds_mock(release):
+    return [
+        {"name": "build1",
+         "epoch": "0",
+         "version": "1.2.3",
+         "release": "20.fc23",
+         "nvr": "build1-1.2.3-20.fc23",
+         "completion_time": datetime.now()-timedelta(days=2)
+         }]
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)

--- a/tests/actions
+++ b/tests/actions
@@ -9,7 +9,9 @@ import json
 
 import faftests
 
-from pyfaf.storage.opsys import Arch
+from pyfaf.storage.opsys import (Arch,
+                                 OpSysReleaseRepo,
+                                 )
 from pyfaf.solutionfinders import find_solution
 
 
@@ -65,6 +67,31 @@ class ActionsTestCase(faftests.DatabaseCase):
         }), 1)
         archs = self.db.session.query(Arch).all()
         self.assertEqual(len(archs), len(init_archs) + 1)
+
+    def test_repoassign_opsysrelease(self):
+        # add repo
+        self.assertEqual(self.call_action_ordered_args("repoadd", [
+            "sample_repo", # NAME
+            "yum", # TYPE
+            "file:///sample_rpms", # URL
+        ]), 0)
+
+        # add release
+        self.assertEqual(self.call_action("releaseadd", {
+            "opsys": "fedora",
+            "opsys-release": "24",
+            "status": "ACTIVE",
+        }), 0)
+
+        init_opsysreleaserepo = self.db.session.query(OpSysReleaseRepo).count()
+        self.assertEqual(self.call_action_ordered_args("repoassign", [
+            "sample_repo", # NAME
+            "Fedora 24", # OPSYS
+            "x86_64",# ARCH
+        ]), 0)
+
+        opsysreleaserepo = self.db.session.query(OpSysReleaseRepo).count()
+        self.assertEqual(opsysreleaserepo, init_opsysreleaserepo + 1)
 
     def test_releasemod(self):
         self.assertEqual(self.call_action("releasemod"), 1)

--- a/tests/faftests/__init__.py
+++ b/tests/faftests/__init__.py
@@ -271,6 +271,38 @@ class DatabaseCase(TestCase):
 
         return ret
 
+    def call_action_ordered_args(self, action_name, args_list=None):
+        """
+        Run `action_name` action using `args_list`
+        as arguments.
+
+        Returns exit code of the action
+
+        Captures stdout and stderr during action execution
+        and stores both as `self.action_stdout` and `self.action_stderr`.
+        This is different from call_action by that, that arguments are in the
+            same order passed to the actual method
+        """
+
+        p = CmdlineParser(toplevel=True)
+        action_args = [action_name] + args_list
+
+        ns = p.parse_args(args=action_args)
+
+        with captured_output() as (cap_stdout, cap_stderr):
+            ret = ns.func(ns, self.db)
+
+        self.action_stdout = cap_stdout.getvalue()
+        self.action_stderr = cap_stderr.getvalue()
+
+        if ret is None:
+            ret = 0
+
+        if not isinstance(ret, int):
+            ret = 1
+
+        return ret
+
     def compare_symbols(self, expected):
         """
         Compare symbols present in database with `expected` list.


### PR DESCRIPTION
We need to be able get all package of a single release to perform efficient garbage collection of packages/builds of EOL releases. Now it is not possible to get all builds that belong to a specific operating system release because there is no relationship between operating system releases and builds. To make this possible we must introduce a new link table that will connect Builds, OpSysRelease and Arch. Having this link table would also solve another problem and that is need to be able to create a yum repository from all builds of a single release of operating system in order to be able to install a minimal set of packages to prepare a chroot environment for backtrace generation. 

The table will be populated in the “reposync” action. The action iterates over all packages in a repository denoted by URL and creates new builds. At this time we must create the connection between the new build and operating system release.

There are currently two types of repositories:
Repos assigned to a specific operating system (so called parametrized repositories)
Pure repo without relations

We need to introduce a third type of repository - repository assigned to operating system releases - which will be similar to the parametrized repositories but its URL will not include any parameters ($..).

Assigning operating system release to a third type of repository could be done by modifying  existing “repoassign” action. This module is now responsible for assigning operating systems to a repositories of the first type. Each assigned operating system is saved into OpSysRepo. To be able to save also releases, we need to introduce another table - OpSysReleaseRepo. Then “repoassign” action would have to decide, which table it will fill. 
This can be done by simple parser, that will try to read release from passed arguments. If the parser succeeds, a new item will be saved into  OpSysReleaseRepo rather than into OpSysRepo.
Example:
Resolves as 1st type: `faf repoassign repo_name Fedora x86_64 i686`
Resolves as 3rd type: `faf repoassign repo_name “Fedora 24” x86_64 i868’
(Note: since there is infinite amount of ways, in which opsys with release can be written, it would be sensible to make it strict - operating system is separated by one space from release. Also the operating system should start with capital letter.)

Currently “reposync” before adding any packages or builds goes through all existing repositories and checks theirs types. This check is done by testing if dollar sign is present in a url link. If is, the repository is considered the first type, otherwise the second. After adding the third type, this check would not be correct, since it would not be able to distinguish between second and the third type. Therefore a new condition is needed. It should be possible to check, which table from OpSysReleaseRepo or OpSysRepo is available. This way it could be possible to tell apart 1st, 2nd and 3rd version. (First version has OpSysRepo second has none and third has OpSysReleaseRepo)

In this stage “reposync” action would be able to read from repository operating system and release, if they are present. (Note: First type also has release in this stage. Dollars are replaced by active releases). And therefore when a new build is being added, we can assign it a operating system and release. Since one build can be for more than one operating system or release and even architectures a link table must be introduced. This table will connect Builds, OpSysRelease and Arch and therefore a suitable name would be BuildOpSysReleaseArch.

It is worth mentioning, that now it is necessary, that to each repository at least one architecture is assigned, since from now on architectures are read only from repositories and not from packages, as it was until now.

Finally a efficient garbage collector could be added.