### PR TITLE
Fix creating link between build and architecture

### DIFF
--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -111,7 +111,14 @@ class RepoSync(Action):
                     build.epoch = pkg["epoch"]
 
                     db.session.add(build)
+                    db.session.flush()
 
+                build_arch = (db.session.query(BuildArch)
+                         .filter(BuildArch.build_id == build.id)
+                         .filter(BuildArch.arch_id == arch.id)
+                         .first())
+
+                if not build_arch:
                     build_arch = BuildArch()
                     build_arch.build = build
                     build_arch.arch = arch


### PR DESCRIPTION
The implementation did not consider that there could be two packages, that
differ only in architecture. This is usual for libraries.
For example:
    $ls /valid/repo | grep libselinux
    >libselinux-2.5-9.fc24.i686.rpm
    >libselinux-2.5-9.fc24.x86_64.rpm

Both packages come from the same build. When the first one is processed, new
build (if not in database yet) is added into database and is linked with
architecture from package. When the second package is processed, build already
exists and therefore no link is added.

This commit fixes this behaviour by always checking, whether the specific link
exists or not.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>