### PR TITLE
queries: fix wrong join

### DIFF
--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -518,7 +518,7 @@ def get_packages_by_osrelease(db, name, version, arch):
                       .join(BuildOpSysReleaseArch)
                       .join(OpSysRelease)
                       .join(OpSys)
-                      .join(Arch)
+                      .join(Arch, Arch.id == BuildOpSysReleaseArch.arch_id)
                       .filter(OpSys.name == name)
                       .filter(OpSysRelease.version == version)
                       .filter(Arch.name == arch)


### PR DESCRIPTION
The problem is that Arch is in Build as well as in BuildOpSysReleaseArch.
Join therefore could not be created and ProgrammingError was returned.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>