### PR TITLE
pyfaf: Fix revision tree

### DIFF
--- a/src/pyfaf/storage/migrations/versions/183a15e52a4f_report_history_unique.py
+++ b/src/pyfaf/storage/migrations/versions/183a15e52a4f_report_history_unique.py
@@ -20,14 +20,14 @@
 """Unique column added into report history
 
 Revision ID: 183a15e52a4f
-Revises: 13557f1962e6
+Revises: 133991a89da4
 Create Date: 2016-09-26 14:35:00.567052
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '183a15e52a4f'
-down_revision = '17d4911132f8'
+down_revision = '133991a89da4'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
In the commit e88e67d a new migration script was added but its downversion did
not point to the current head. That meant that there were two heads.

Before this commit:
    $alembic heads
        >133991a89da4 (head)
        >183a15e52a4f (head)
After this commit:
    $alembic heads
        >183a15e52a4f (head)

Signed-off-by: Matej Marusak <mmarusak@redhat.com>