### PR TITLE
tests: Add test for alembic migration tool

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -54,6 +54,7 @@ BuildRequires: packagedb-cli
 BuildRequires: pg-semver
 BuildRequires: postgresql
 BuildRequires: postgresql-server
+BuildRequires: python-alembic
 BuildRequires: python-setuptools
 BuildRequires: python-unittest2
 BuildRequires: python-bugzilla

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,7 @@ SUBDIRS = faftests sample_plugin_dir sample_reports sample_rpms webfaf \
 		  retrace_outputs bin
 
 TESTS = actions \
+	alembic \
 	bugzilla \
 	common \
 	create_problems \

--- a/tests/alembic
+++ b/tests/alembic
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+# -*- encoding: utf-8 -*-
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import logging
+
+import faftests
+
+import os
+import inspect
+import cStringIO
+from pyfaf.storage import migrations
+from alembic.config import Config
+from alembic import command
+
+
+class AlembicTestCase(faftests.DatabaseCase):
+
+    """
+    Test case for migrations by alembic
+    """
+
+    def setUp(self):
+        super(AlembicTestCase, self).setUp()
+        self.basic_fixtures()
+
+    def test_alembic_head(self):
+        heads_ = cStringIO.StringIO()
+        alembic_cfg = Config(stdout=heads_)
+        alembic_cfg.set_main_option("script_location",
+                                    os.path.dirname(inspect.getfile(migrations)))
+        command.heads(alembic_cfg)
+        heads = heads_.getvalue()
+        heads = heads[:-1]
+
+        self.assertNotIn('\n', heads)
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
Introduce test for testing if there is only one head for alembic tree.
Creating new revision automatically sets down version to the current head. But
if in the time of creating author does not have current head, or the head
changes in the time between creating revision and merging the code, it can
create new head, which is not intended.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>