### PR TITLE
Support mirrors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,7 @@ AC_CONFIG_FILES([
     tests/webfaf/webfaftests/Makefile
     tests/retrace_outputs/Makefile
     tests/bin/Makefile
+    tests/sample_repo/Makefile
 ])
 
 AC_OUTPUT

--- a/src/pyfaf/actions/repoadd.py
+++ b/src/pyfaf/actions/repoadd.py
@@ -18,7 +18,7 @@
 
 import pyfaf.repos
 from pyfaf.actions import Action
-from pyfaf.storage.opsys import Repo
+from pyfaf.storage.opsys import Repo, Url
 
 
 class RepoAdd(Action):
@@ -44,7 +44,11 @@ class RepoAdd(Action):
         new = Repo()
         new.name = cmdline.NAME
         new.type = cmdline.TYPE
-        new.url = cmdline.URL
+        for url in cmdline.URL:
+            new_url = Url()
+            new_url.url = url
+            new.url_list.append(new_url)
+
         if cmdline.nice_name:
             new.nice_name = cmdline.nice_name
 
@@ -57,7 +61,8 @@ class RepoAdd(Action):
         parser.add_argument("NAME", help="name of this repository")
         parser.add_argument("TYPE", choices=self.repo_types,
                             help="type of the repository")
-        parser.add_argument("URL", help="repository/buildsystem API URL")
+        parser.add_argument("URL", nargs="*",
+                            help="repository/buildsystem API URL")
         parser.add_argument("--nice-name", help="human readable name")
         parser.add_argument("--nogpgcheck", action="store_true",
                             help="disable gpg check for this repository")

--- a/src/pyfaf/actions/repoassign.py
+++ b/src/pyfaf/actions/repoassign.py
@@ -80,12 +80,12 @@ class RepoAssign(Action):
                 arch_list.append(arch)
 
         # test if url type correspond with type of repo
-        if '$' in repo.url and opsysrelease_list:
+        if any('$' in url.url for url in repo.url_list) and opsysrelease_list:
             self.log_error("Assigning operating system with release to "
                         "parametrized repo. Assign only operating system.")
             return 1
 
-        if '$' not in repo.url and opsys_list:
+        if any('$' not in url.url for url in repo.url_list) and opsys_list:
             self.log_error("Assigning operating system without release to "
                         "non - parametrized repo. Assign operating system"
                         " with release.")

--- a/src/pyfaf/actions/repodel.py
+++ b/src/pyfaf/actions/repodel.py
@@ -36,6 +36,9 @@ class RepoDel(Action):
                            .format(cmdline.NAME))
             return 1
 
+        for url in repo.url_list:
+            db.session.delete(url)
+
         self.log_info("Removing repository '{0}'".format(cmdline.NAME))
 
         db.session.delete(repo)

--- a/src/pyfaf/actions/repoimport.py
+++ b/src/pyfaf/actions/repoimport.py
@@ -21,7 +21,7 @@ import ConfigParser
 
 import pyfaf.repos
 from pyfaf.actions import Action
-from pyfaf.storage.opsys import Repo
+from pyfaf.storage.opsys import Repo, Url
 
 
 class RepoImport(Action):
@@ -58,7 +58,9 @@ class RepoImport(Action):
                                " option 'baseurl'".format(section))
                 return None
 
-            new.url = parser.get(section, "baseurl")
+            new_url = Url()
+            new_url.url = parser.get(section, "baseurl")
+            new.url_list = [new_url]
 
             if parser.has_option(section, "gpgcheck"):
                 new.nogpgcheck = parser.getint(section, "gpgcheck") == 0
@@ -99,8 +101,8 @@ class RepoImport(Action):
                                .format(repo.name))
                 return 1
 
-            self.log_info("Adding repository '{0}' ({1})"
-                          .format(repo.name, repo.url))
+            self.log_info("Adding repository '{0}' {1}"
+                          .format(repo.name, [url.url for url in repo.url_list]))
 
             db.session.add(repo)
 

--- a/src/pyfaf/actions/repoinfo.py
+++ b/src/pyfaf/actions/repoinfo.py
@@ -41,7 +41,8 @@ class RepoInfo(Action):
             print("Nice name: {0}".format(repo.nice_name))
 
         print("Type: {0}".format(repo.type))
-        print("URL: {0}".format(repo.url))
+        for url in repo.url_list:
+            print("URL: {0}".format(url.url))
         print("GPG check enabled: {0}".format(not repo.nogpgcheck))
 
         if cmdline.assigned:

--- a/src/pyfaf/actions/repolist.py
+++ b/src/pyfaf/actions/repolist.py
@@ -32,8 +32,10 @@ class RepoList(Action):
             data = []
             header = ["Name", "Type", "URL", "Nice name"]
             for repo in db.session.query(Repo):
-                data.append((repo.name, repo.type, repo.url,
+                data.append((repo.name, repo.type, repo.url_list[0].url,
                              repo.nice_name or ""))
+                for url in repo.url_list[1:]:
+                    data.append(("", "", url.url, ""))
 
             print(as_table(header, data, margin=2))
         else:

--- a/src/pyfaf/storage/migrations/versions/1c4d6317721a_support_mirrors.py
+++ b/src/pyfaf/storage/migrations/versions/1c4d6317721a_support_mirrors.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2016  ABRT Team
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Support mirror urls in repositories
+
+Revision ID: 1c4d6317721a
+Revises: 183a15e52a4f
+Create Date: 2016-11-22 10:41:15.866893
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1c4d6317721a'
+down_revision = '183a15e52a4f'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('urls',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('url', sa.String(length=256), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+    op.create_table('urlrepo',
+        sa.Column('url_id', sa.Integer(), nullable=False),
+        sa.Column('repo_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['url_id'], ['urls.id'], ),
+        sa.ForeignKeyConstraint(['repo_id'], ['repo.id'], ),
+        sa.PrimaryKeyConstraint('url_id', 'repo_id'),
+    )
+
+    url_id = 1
+    for repo in op.get_bind().execute("select * from repo").fetchall():
+        op.execute("insert into urls (url) values('{0}')".format(repo.url))
+        op.execute("insert into urlrepo values({0}, {1})".format(url_id, repo.id))
+        url_id += 1
+    op.drop_column('repo', 'url')
+
+
+def downgrade():
+    op.add_column('repo', sa.Column('url', sa.String(length=256))) 
+
+    for repo in op.get_bind().execute("select * from repo").fetchall():
+        urls = op.get_bind().execute("select * from urlrepo r, urls u where r.repo_id = {0} and\
+                r.url_id = u.id".format(repo.id)).fetchall()
+        if not urls:
+            print "Repository {0} does not have any url assigned.".format(repo.name)
+            continue
+        op.execute("update repo set url = '{0}' where id = {1}".format(urls[0].url, repo.id))
+        for url in urls[1:]:
+            print "Skipping url {0} for repository {1}".format(url.url, repo.name)
+
+    op.drop_table('urlrepo')
+    op.drop_table('urls')

--- a/src/pyfaf/storage/migrations/versions/Makefile.am
+++ b/src/pyfaf/storage/migrations/versions/Makefile.am
@@ -1,4 +1,5 @@
 versions_PYTHON = \
+    1c4d6317721a_support_mirrors.py \
     133991a89da4_build_to_opsysrelease.py \
     17d4911132f8_assigning_release_to_repo.py \
     183a15e52a4f_report_history_unique.py \

--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -64,6 +64,13 @@ class OpSys(GenericTable):
                       self.releases)
 
 
+class Url(GenericTable):
+    __tablename__ = "urls"
+
+    id = Column(Integer, primary_key=True)
+    url = Column(String(256), nullable=False)
+
+
 class OpSysRelease(GenericTable):
     __tablename__ = "opsysreleases"
     __table_args__ = (UniqueConstraint('opsys_id', 'version'),)
@@ -85,12 +92,12 @@ class Repo(GenericTable):
     id = Column(Integer, primary_key=True)
     name = Column(String(256))
     type = Column(Enum("yum", "koji", "rpmmetadata", name="repo_type"), nullable=False)
-    url = Column(String(256))
     nice_name = Column(String(256), nullable=True)
     nogpgcheck = Column(Boolean, nullable=False)
     opsys_list = relationship(OpSys, secondary="opsysrepo")
     opsysrelease_list = relationship(OpSysRelease, secondary="opsysreleaserepo")
     arch_list = relationship(Arch, secondary="archrepo")
+    url_list = relationship(Url, secondary="urlrepo")
 
     def __str__(self):
         return self.name
@@ -107,6 +114,12 @@ class ArchRepo(GenericTable):
     __tablename__ = "archrepo"
 
     arch_id = Column(Integer, ForeignKey("{0}.id".format(Arch.__tablename__)), primary_key=True)
+    repo_id = Column(Integer, ForeignKey("{0}.id".format(Repo.__tablename__)), primary_key=True)
+
+class UrlRepo(GenericTable):
+    __tablename__ = "urlrepo"
+
+    url_id = Column(Integer, ForeignKey("{0}.id".format(Url.__tablename__)), primary_key=True)
     repo_id = Column(Integer, ForeignKey("{0}.id".format(Repo.__tablename__)), primary_key=True)
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS = faftests sample_plugin_dir sample_reports sample_rpms webfaf \
-		  retrace_outputs bin
+		  retrace_outputs bin sample_repo
 
 TESTS = actions \
 	alembic \

--- a/tests/actions
+++ b/tests/actions
@@ -80,6 +80,120 @@ class ActionsTestCase(faftests.DatabaseCase):
         archs = self.db.session.query(Arch).all()
         self.assertEqual(len(archs), len(init_archs) + 1)
 
+    def test_repoadd(self):
+        self.assertEqual(self.call_action_ordered_args("repoadd", [
+            "sample_repo", # NAME
+            "yum", # TYPE
+            "file:///sample_rpms", # URL
+        ]), 0)
+
+        self.assertEqual(self.call_action_ordered_args("repoadd", [
+            "sample_repo", # NAME
+            "yum", # TYPE
+            "file:///sample_rpms", # URL
+        ]), 1)
+
+        self.assertEqual(self.call_action_ordered_args("repoadd", [
+            "another_repo", # NAME
+            "yum", # TYPE
+            "file:///sample_rpms", # URL1
+            "file:///sample_rpms1", # URL2
+            "file:///sample_rpms2", # URL3
+        ]), 0)
+
+    def test_repoinfo(self):
+        self.test_repoadd()
+
+        self.assertEqual(self.call_action_ordered_args("repoinfo", [
+            "sample_repo"]), 0)
+
+        self.assertIn("file:///sample_rpms", self.action_stdout)
+
+        self.assertEqual(self.call_action_ordered_args("repoinfo", [
+            "another_repo"]), 0)
+
+        self.assertIn("file:///sample_rpms", self.action_stdout)
+        self.assertIn("file:///sample_rpms1", self.action_stdout)
+        self.assertIn("file:///sample_rpms2", self.action_stdout)
+
+        self.assertEqual(self.call_action_ordered_args("repoinfo", [
+            "sample_repo_unknown"]), 1)
+
+    def test_repolist(self):
+        self.test_repoadd()
+
+        self.assertEqual(self.call_action_ordered_args("repolist", [
+            ]), 0)
+
+        self.assertIn("another_repo", self.action_stdout)
+        self.assertIn("sample_repo", self.action_stdout)
+
+        self.assertEqual(self.call_action_ordered_args("repolist", [
+            "--detailed"]), 0)
+
+        self.assertIn("another_repo", self.action_stdout)
+        self.assertIn("sample_repo", self.action_stdout)
+        self.assertIn("file:///sample_rpms", self.action_stdout)
+        self.assertIn("file:///sample_rpms1", self.action_stdout)
+        self.assertIn("file:///sample_rpms2", self.action_stdout)
+
+    def test_repomod(self):
+        self.test_repoadd()
+
+        self.assertEqual(self.call_action_ordered_args("repomod", [
+            "sample_repo", "--add-url=file:///some/new/url"]), 0)
+
+        self.assertEqual(self.call_action_ordered_args("repoinfo", [
+            "sample_repo"]), 0)
+
+        self.assertIn("file:///sample_rpms", self.action_stdout)
+        self.assertIn("file:///some/new/url", self.action_stdout)
+
+        self.assertEqual(self.call_action_ordered_args("repomod", [
+            "sample_repo", "--remove-url=file:///sample_rpms"]), 0)
+
+        self.assertEqual(self.call_action_ordered_args("repoinfo", [
+            "sample_repo"]), 0)
+
+        self.assertNotIn("file:///sample_rpms", self.action_stdout)
+        self.assertIn("file:///some/new/url", self.action_stdout)
+
+    def test_repodel(self):
+        self.test_repoadd()
+
+        self.assertEqual(self.call_action_ordered_args("repodel", [
+            "sample_repo"]), 0)
+
+        self.assertEqual(self.call_action_ordered_args("repolist", [
+            "--detailed"]), 0)
+
+        self.assertIn("another_repo", self.action_stdout)
+        self.assertNotIn("sample_repo", self.action_stdout)
+        self.assertIn("file:///sample_rpms", self.action_stdout)
+        self.assertIn("file:///sample_rpms1", self.action_stdout)
+        self.assertIn("file:///sample_rpms2", self.action_stdout)
+
+        self.assertEqual(self.call_action_ordered_args("repodel", [
+            "another_repo"]), 0)
+
+        self.assertEqual(self.call_action_ordered_args("repolist", [
+            "--detailed"]), 0)
+
+        self.assertNotIn("another_repo", self.action_stdout)
+        self.assertNotIn("sample_repo", self.action_stdout)
+
+    def test_repoimport(self):
+        self.assertEqual(self.call_action_ordered_args("repoimport", [
+            "yum", "sample_repo/dummy_repo.repo"]), 0)
+
+        self.assertEqual(self.call_action_ordered_args("repolist", [
+            "--detailed"]), 0)
+
+        self.assertIn("repo1", self.action_stdout)
+        self.assertIn("repo2", self.action_stdout)
+        self.assertIn("file:///some/where", self.action_stdout)
+        self.assertIn("file:///some/other/place", self.action_stdout)
+
     def test_repoassign_opsysrelease(self):
         # add repo
         self.assertEqual(self.call_action_ordered_args("repoadd", [
@@ -104,6 +218,12 @@ class ActionsTestCase(faftests.DatabaseCase):
 
         opsysreleaserepo = self.db.session.query(OpSysReleaseRepo).count()
         self.assertEqual(opsysreleaserepo, init_opsysreleaserepo + 1)
+
+        self.assertEqual(self.call_action_ordered_args("repoassign", [
+            "sample_repo", # NAME
+            "Fedora", # OPSYS
+            "x86_64",# ARCH
+        ]), 1)
 
     def test_reposync(self):
         self.rpm = glob.glob("sample_rpms/sample*.rpm")[0]
@@ -135,6 +255,7 @@ class ActionsTestCase(faftests.DatabaseCase):
         ])
 
         init_bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        init_packages = self.db.session.query(Package).count()
         self.assertEqual(self.call_action("reposync", {
             "NAME": "sample_repo",
             "no-download-rpm": ""
@@ -142,7 +263,64 @@ class ActionsTestCase(faftests.DatabaseCase):
 
         bosra = self.db.session.query(BuildOpSysReleaseArch).count()
         self.assertEqual(bosra, init_bosra + 1)
+        packages = self.db.session.query(Package).count()
+        self.assertEqual(init_packages + 1 , packages)
 
+        shutil.rmtree(self.tmpdir)
+
+        self.call_action_ordered_args("repoadd", [
+            "fail_repo", # NAME
+            "yum", # TYPE
+            "file:///non/existing", # URL
+        ])
+
+        self.call_action_ordered_args("repoassign", [
+            "fail_repo", # NAME
+            "Fedora 24", # OPSYS
+            "x86_64",# ARCH
+        ])
+
+        self.assertEqual(self.call_action("reposync", {
+            "NAME": "fail_repo",
+        }), 1)
+
+        self.assertEqual(packages, self.db.session.query(Package).count())
+
+    def test_reposync_mirror(self):
+        self.rpm = glob.glob("sample_rpms/sample*.rpm")[0]
+
+        self.tmpdir = tempfile.mkdtemp()
+        shutil.copyfile(self.rpm,
+                        os.path.join(self.tmpdir, os.path.basename(self.rpm)))
+
+        proc = popen("createrepo", self.tmpdir)
+        self.assertIn("Workers Finished", proc.stdout)
+
+        self.call_action_ordered_args("repoadd", [
+            "one_correct_repo", # NAME
+            "yum", # TYPE
+            "file:///non/existing", # URL
+            "file://{0}".format(self.tmpdir), # URL
+        ])
+
+        self.call_action("releaseadd", {
+            "opsys": "fedora",
+            "opsys-release": "24",
+            "status": "ACTIVE",
+        })
+
+        self.call_action_ordered_args("repoassign", [
+            "one_correct_repo", # NAME
+            "Fedora 24", # OPSYS
+            "x86_64",# ARCH
+        ])
+
+        packages = self.db.session.query(Package).count()
+        self.assertEqual(self.call_action("reposync", {
+            "NAME": "one_correct_repo",
+        }), 0)
+
+        self.assertEqual(packages + 1, self.db.session.query(Package).count())
         shutil.rmtree(self.tmpdir)
 
     def test_assign_release_to_builds(self):

--- a/tests/sample_repo/Makefile.am
+++ b/tests/sample_repo/Makefile.am
@@ -1,0 +1,2 @@
+EXTRA_DIST = dummy_repo.repo
+

--- a/tests/sample_repo/dummy_repo.repo
+++ b/tests/sample_repo/dummy_repo.repo
@@ -1,0 +1,9 @@
+[repo1]
+name=Repo1
+baseurl=file:///some/where
+gpgcheck=0
+
+[repo2]
+name=Repo2
+baseurl=file:///some/other/place
+gpgcheck=0


### PR DESCRIPTION
This pull-request enables repositories to have more than one url, so in case that
one url is not available in time of reposyncing, another can be used.
