### PR TITLE
Development/debugging tools

### DIFF
--- a/config/faf-devel.conf
+++ b/config/faf-devel.conf
@@ -1,0 +1,18 @@
+# Faf development configuration file
+[Main]
+PluginsDir = plugins/
+TemplatesDir = templates/
+AutoEnablePlugins = True
+
+[Storage]
+ConnectString = postgresql:///faf
+LobDir = ~/.local/var/spool/faf/lob
+
+[uReport]
+# The directory that holds 'reports' and 'attachments' subdirectories
+Directory = ~/.local/var/spool/faf
+CreateComponents = False
+# attachments accepted by this server
+# allowed values: fedora-bugzilla rhel-bugzilla centos-mantisb comment email url
+# or * to allow all attachments
+AcceptAttachments = fedora-bugzilla rhel-bugzilla centos-mantisbt

--- a/src/pyfaf/config.py
+++ b/src/pyfaf/config.py
@@ -74,13 +74,20 @@ def load_config():
             logging.error("Config file specified by {0} environment variable"
                           " ({1}) not found or unreadable".format(
                           CONFIG_FILE_ENV_VAR, fpath))
+    elif not os.access(main_config_files[0], os.R_OK):
+        logging.error("Main config file {0} not found or unreadable, "
+                      "using default development config file.".format(
+                          main_config_files[0]))
+        main_config_files = [os.path.dirname(os.path.dirname(os.path.abspath(
+            os.path.dirname(__file__)))) + "/config/faf-devel.conf"]
 
     cfg = load_config_files(main_config_files)
 
     plugin_config_files = []
     for section in CONFIG_CHILD_SECTIONS:
         if section in cfg:
-            plugins_dir = os.path.join(MAIN_CONFIG_DIR, cfg[section])
+            plugins_dir = os.path.join(MAIN_CONFIG_DIR,
+                                       os.path.expanduser(cfg[section]))
             plugin_config_files = get_config_files(plugins_dir)
 
     # append main_config_files to the end so that plugins can't override it

--- a/src/webfaf/manage.py
+++ b/src/webfaf/manage.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python2
+
+import os
+import sys
+
+from flask_script import Manager, Shell
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+
+from webfaf_main import app, db
+from webfaf_main import import_blueprint_plugins
+
+
+import_blueprint_plugins(app)
+manager = Manager(app)
+
+
+def make_shell_context():
+    return dict(app=app, db=db)
+
+manager.add_command('shell', Shell(make_context=make_shell_context))
+
+if __name__ == '__main__':
+    manager.run()

--- a/src/webfaf/requirements.txt
+++ b/src/webfaf/requirements.txt
@@ -1,0 +1,27 @@
+# To make this project work inside virtualenv, it has to be created
+# using --system-site-packages option and following RPMs must be installed
+# on the system:
+# python2-rpm yum python2-psycopg2 gcc redhat-rpm-config python2-devel openssl-devel
+
+bunch==1.0.1
+Flask==0.11.1
+Flask_rstpages==0.3
+Flask_Script==2.0.5
+Flask_SQLAlchemy==2.1
+Flask-OpenID==1.2.5
+python_openid_teams==1.1
+SQLAlchemy==1.0.15
+Werkzeug==0.11.10
+WTForms==2.0
+python_dateutil==2.6.0
+fedmsg==0.18.2
+setuptools==20.3.1
+packagedb_cli==2.14.1
+requests==2.10.0
+ipython==5.2.2
+alembic==0.8.10
+celery==4.0.2
+pycurl==7.43.0
+satyr==0.2.1
+suds_jurko==0.6
+psycopg2==2.6.2


### PR DESCRIPTION
In this PR:
   - simple manage.py script providing local development server and shell features, more commands 
     for testing, db management etc. can be added later

    - requirements.txt file specifying set of dependencies, unfortunately some requirements
      aren't available on PyPI. A few RPMs must be installed on the system and visible inside
      virtualenv created for FAF.

It is possible to run development server and shell directly from sources thanks to this tools.
To make it completely independent of installed instance of FAF it is necessary to create config file
similar to [this example](https://paste.fedoraproject.org/557383/) in the local directory and set
FAF_CONFIG_FILE environment variable to point to this config file.