### PR TITLE
webfaf: Show month and day when weekly resolution

### DIFF
--- a/src/webfaf/static/js/report_graph.js
+++ b/src/webfaf/static/js/report_graph.js
@@ -32,6 +32,7 @@ function plotReportGraph(data, tick_unit) {
             max: x_max + x_margin*2,
             ticks: my_ticks,
             mode: "time",
+            timeformat: "%b %d",
         };
     } else if (tick_unit == 'day') {
         x_axis_options = {


### PR DESCRIPTION
On summary page, when displaying by week, only year was displayed.
After this patch, instead the year, a month name and day is displayed.

Fixes #550

Before:
https://pageshot.net/Wo2Y8UzwucKyXR9K/localhost
After:
https://pageshot.net/9uYsVEAsKEIeYUeS/localhost