### PR TITLE
webfaf: Always show executable on report page

### DIFF
--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -34,6 +34,7 @@ from pyfaf.storage import (AssociatePeople,
                            ReportHistoryMonthly,
                            ReportUnknownPackage,
                            ReportBacktrace,
+                           ReportExecutable,
                            UnknownOpSys,
                            ProblemOpSysRelease,
                            Problem,
@@ -377,6 +378,10 @@ def item(report_id, want_object=False):
 
     report, component = result
 
+    executable = (db.session.query(ReportExecutable.path)
+                  .filter(ReportExecutable.report_id == report_id)
+                  .scalar())
+
     solutions = None
 
     if report.max_certainty is not None:
@@ -557,6 +562,7 @@ def item(report_id, want_object=False):
                       .first())
 
     forward = dict(report=report,
+                   executable=executable,
                    probably_fixed=probably_fixed,
                    component=component,
                    releases=metric(releases),

--- a/src/webfaf/templates/reports/item.html
+++ b/src/webfaf/templates/reports/item.html
@@ -62,6 +62,10 @@
               <span class="label label-warning">Tainted</span>
             {% endif %}
           </dd>
+            <dt>Executable</dt>
+            <dd>
+              {{ executable }}
+            </dd>
           {% if report.error_name %}
             <dt>Error name</dt>
             <dd>


### PR DESCRIPTION
If stack trace does not include main, it is hard to guess what
executable actually crashed. After this commit, executable is always
displayed.

Fixes #524

Signed-off-by: Matej Marusak <mmarusak@redhat.com>