### PR TITLE
pyfaf: Add action for deleting all unassigned builds

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -381,6 +381,13 @@ Requires: %{name} = %{faf_version}
 %description action-cleanup-task-results
 A plugin for %{name} implementing cleanup of old task results.
 
+%package action-cleanup-unassigned
+Summary: %{name}'s cleanup-unassigned plugin
+Requires: %{name} = %{faf_version}
+
+%description action-cleanup-unassigned
+A plugin for %{name} implementing cleanup of unassigned packages
+
 %package bugtracker-bugzilla
 Summary: %{name}'s bugzilla support
 Requires: %{name} = %{faf_version}
@@ -927,6 +934,9 @@ fi
 
 %files action-cleanup-task-results
 %{python_sitelib}/pyfaf/actions/cleanup_task_results.py*
+
+%files action-cleanup-unassigned
+%{python_sitelib}/pyfaf/actions/cleanup_unassigned.py*
 
 %files bugtracker-bugzilla
 %{python_sitelib}/pyfaf/bugtrackers/bugzilla.py*

--- a/src/pyfaf/actions/Makefile.am
+++ b/src/pyfaf/actions/Makefile.am
@@ -13,6 +13,7 @@ actions_PYTHON = \
     c2p.py \
     cleanup_packages.py \
     cleanup_task_results.py \
+    cleanup_unassigned.py \
     componentadd.py \
     create_problems.py \
     delete_invalid_ureports.py \

--- a/src/pyfaf/actions/cleanup_unassigned.py
+++ b/src/pyfaf/actions/cleanup_unassigned.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2016  ABRT Team
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyfaf.actions import Action
+from pyfaf.storage.opsys import (BuildOpSysReleaseArch, Build, Package,
+                                 PackageDependency, BuildArch, BuildComponent)
+from pyfaf.storage.report import ReportPackage
+from pyfaf.storage.problem import ProblemOpSysRelease
+from pyfaf.storage.llvm import LlvmBuild, LlvmBcFile, LlvmResultFile
+
+class CleanupUnassigned(Action):
+    name = "cleanup-unassigned"
+
+    def run(self, cmdline, db):
+        # find all build, that are not assigned to any opsysrelease
+        all_opsysrelases = db.session.query(BuildOpSysReleaseArch.build_id).distinct()
+        all_builds = (db.session.query(Build)
+                      .filter(~Build.id.in_(all_opsysrelases))
+                      .yield_per(1000))
+
+        count = 0;
+        #delete all builds and packages from them
+        for build in all_builds:
+            count += 1;
+            q = db.session.query(Package).filter(Package.build_id == build.id)
+            for pkg in q.all():
+                self.log_info("Processing package {0}".format(pkg.nevr()))
+                self.delete_package(pkg, db, cmdline.force)
+                if cmdline.force:
+                    db.session.query(PackageDependency).filter(PackageDependency.package_id == pkg.id).delete()
+                    db.session.query(ReportPackage).filter(ReportPackage.installed_package_id == pkg.id).delete()
+            if cmdline.force:
+                q.delete()
+                db.session.query(BuildArch).filter(build.id == BuildArch.build_id).delete()
+                db.session.query(BuildComponent).filter(build.id == BuildComponent.build_id).delete()
+                db.session.query(ProblemOpSysRelease).filter(build.id == ProblemOpSysRelease.probable_fix_build_id).delete()
+                q_llvm = db.session.query(LlvmBuild.build_id == build.id)
+                for llvm in q_llvm.all():
+                    db.session.query(LlvmBcFile).filter(LlvmBcFile.llvmbuild_id == llvm.id).delete()
+                    db.session.query(LlvmResultFile).filter(LlvmResultFile.llvmbuild_id == llvm.id).delete()
+                db.session.query(Build).filter(Build.id == build.id).delete()
+            if (count > 1000):
+                db.session.flush()
+                count = 0
+
+    def delete_package(self, pkg, db, force):
+        #delete package from disk
+        if pkg.has_lob("package"):
+            self.log_info("Deleting lob for: {0}".format(pkg.nevr()))
+            if not force:
+                self.log_info("Use --force to delete. Skipping removal")
+            else:
+                pkg.del_lob("package")
+
+
+    def tweak_cmdline_parser(self, parser):
+        parser.add_argument("-f", "--force", action="store_true",
+                            help="delete all unassigned packages."
+                                 " Without -f acts like --dry-run.")

--- a/tests/actions
+++ b/tests/actions
@@ -379,6 +379,56 @@ class ActionsTestCase(faftests.DatabaseCase):
         bosra = self.db.session.query(BuildOpSysReleaseArch).count()
         self.assertEqual(bosra, init_bosra + 2)
 
+    def test_clenup_unassigned(self):
+        self.test_assign_release_to_builds()
+
+        # add package and lob that will not be deleted
+        pkg_stay = Package()
+        pkg_stay.build = self.db.session.query(Build).first()
+        pkg_stay.arch = self.db.session.query(Arch).first()
+        pkg_stay.name = "pkg-test-stay"
+        self.db.session.add(pkg_stay)
+        self.db.session.flush()
+
+        config["storage.lobdir"] = tempfile.mkdtemp(prefix="faf")
+
+        sample_rpm = glob.glob("sample_rpms/sample*.rpm")[0]
+        with open(sample_rpm) as sample:
+            pkg_stay.save_lob("package", sample, truncate=True)
+        self.assertTrue(pkg_stay.has_lob("package"))
+
+        # add build and package and lob that will be deleted
+        build = Build()
+        build.base_package_name = "build_unassigned"
+        build.epoch = 0
+        build.version = "1.2.3"
+        build.release = "20.fc23"
+        self.db.session.add(build)
+
+        pkg_del = Package()
+        pkg_del.build = build
+        pkg_del.arch = self.db.session.query(Arch).first()
+        pkg_del.name = "pkg-test-del"
+        self.db.session.add(pkg_del)
+
+        self.db.session.flush()
+
+        sample_rpm = glob.glob("sample_rpms/sample*.rpm")[0]
+        with open(sample_rpm) as sample:
+            pkg_del.save_lob("package", sample, truncate=True)
+        self.assertTrue(pkg_del.has_lob("package"))
+
+        init_bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        self.assertEqual(self.call_action_ordered_args("cleanup-unassigned",[
+            "--force"
+        ]), 0)
+
+        bosra = self.db.session.query(BuildOpSysReleaseArch).count()
+        self.assertEqual(bosra, init_bosra)
+
+        self.assertFalse(pkg_del.has_lob("package"))
+        self.assertTrue(pkg_stay.has_lob("package"))
+
     def test_cleanup_packages(self):
         self.test_assign_release_to_builds()
 


### PR DESCRIPTION
In commit 8b9bcac was introduced assigning releases to build. Also in
a6b9ba4 was introduced cleaning of builds (packages) for specific
assigned release. However, unassigned builds cannot be removed.

This commit introduces action for cleaning such builds (packages). Since
I understand this is rather a dangerous action, I made it run by default
as dry run and only by using `--force` packages can be removed.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>