### PR TITLE
Action delete invalid ureports

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -375,6 +375,13 @@ Requires: %{name} = %{faf_version}
 %description action-cleanup-packages
 A plugin for %{name} implementing cleanup of old packages.
 
+%package action-delete-invalid-ureports
+Summary: %{name}'s delete-invalid-ureports plugin
+Requires: %{name} = %{faf_version}
+
+%description action-delete-invalid-ureports
+A plugin for %{name} implementing delete of old invalid ureports.
+
 %package action-cleanup-task-results
 Summary: %{name}'s cleanup-task-results plugin
 Requires: %{name} = %{faf_version}
@@ -924,6 +931,9 @@ fi
 
 %files action-cleanup-packages
 %{python_sitelib}/pyfaf/actions/cleanup_packages.py*
+
+%files action-delete-invalid-ureports
+%{python_sitelib}/pyfaf/actions/delete_invalid_ureports.py*
 
 %files action-cleanup-task-results
 %{python_sitelib}/pyfaf/actions/cleanup_task_results.py*

--- a/src/pyfaf/actions/Makefile.am
+++ b/src/pyfaf/actions/Makefile.am
@@ -15,6 +15,7 @@ actions_PYTHON = \
     cleanup_task_results.py \
     componentadd.py \
     create_problems.py \
+    delete_invalid_ureports.py \
     extfafadd.py \
     extfafclonebz.py \
     extfafdelete.py \

--- a/src/pyfaf/actions/delete_invalid_ureports.py
+++ b/src/pyfaf/actions/delete_invalid_ureports.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2017  ABRT Team
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyfaf.actions import Action
+from pyfaf.storage.debug import InvalidUReport
+
+import datetime
+
+class DeleteInvalidUReports(Action):
+    name = "delete-invalid-ureports"
+
+    def run(self, cmdline, db):
+        if cmdline.age:
+            age = int(cmdline.age)
+            if age < 0:
+                self.log_error("Negative age given: {0}, exiting".format(age))
+                return 1
+
+            current_time = datetime.datetime.utcnow()
+            given_days_ago = current_time - datetime.timedelta(days=age)
+
+            query = (db.session.query(InvalidUReport)
+                    .filter(InvalidUReport.date < given_days_ago))
+        else:
+            self.log_info("No age given, selecting all invalid ureports")
+            query = db.session.query(InvalidUReport)
+
+        self.log_info("{0} invalid ureports will be removed"
+                        .format(query.count()))
+
+        if cmdline.dry_run:
+            self.log_info("Dry run active, removal will be skipped")
+        else:
+            # delete ureport from disk
+            for inv_ureport in query.all():
+                if inv_ureport.has_lob("ureport"):
+                    inv_ureport.del_lob("ureport")
+            # delete ureports from database
+            query.delete()
+
+    def tweak_cmdline_parser(self, parser):
+        parser.add_argument("--age", default=None,
+                            help="delete older than AGE days")
+

--- a/tests/actions
+++ b/tests/actions
@@ -24,6 +24,7 @@ from pyfaf.storage.opsys import (Arch,
                                  Build,
                                  Package,
                                  )
+from pyfaf.storage.debug import InvalidUReport
 from pyfaf.solutionfinders import find_solution
 
 
@@ -405,6 +406,53 @@ class ActionsTestCase(faftests.DatabaseCase):
         self.assertEqual(bosra, init_bosra - 2)
 
         self.assertFalse(pkg.has_lob("package"))
+
+    def test_delete_invalid_ureports(self):
+        # try to delete from empty table
+        self.assertEqual(self.call_action("delete-invalid-ureports", {
+            "age": "6",
+        }), 0)
+
+        # add invalid ureport and lob
+        inv_ureport = InvalidUReport()
+        inv_ureport.errormsg = "fedora"
+        # 3 days old
+        current_time = datetime.utcnow()
+        inv_ureport.date = current_time - timedelta(days=3)
+        self.db.session.add(inv_ureport)
+        self.db.session.flush()
+
+        config["storage.lobdir"] = "/tmp/faf_test_data/lob"
+        sample_ureport = "sample_reports/ureport_core_invalid"
+        with open(sample_ureport) as sample:
+            inv_ureport.save_lob("ureport", sample, truncate=True)
+        self.assertTrue(inv_ureport.has_lob("ureport"))
+
+        # try to remove older than we have in the table, nothing should happen
+        tbl_size_before = self.db.session.query(InvalidUReport).count()
+        self.assertEqual(self.call_action("delete-invalid-ureports", {
+            "age": "4",
+        }), 0)
+
+        tbl_size_after = self.db.session.query(InvalidUReport).count()
+        self.assertEqual(tbl_size_after, tbl_size_before)
+        self.assertTrue(inv_ureport.has_lob("ureport"))
+
+        # remove correctly, at the time of call, our table entry is
+        # slightly older than 3 days
+        tbl_size_before = self.db.session.query(InvalidUReport).count()
+        self.assertEqual(self.call_action("delete-invalid-ureports", {
+            "age": "3",
+        }), 0)
+
+        tbl_size_after = self.db.session.query(InvalidUReport).count()
+        self.assertEqual(tbl_size_after, tbl_size_before - 1)
+        self.assertFalse(inv_ureport.has_lob("ureport"))
+
+        # negative age argument, should fail
+        self.assertEqual(self.call_action("delete-invalid-ureports", {
+            "age": "-4",
+        }), 1)
 
     def test_releasemod(self):
         self.assertEqual(self.call_action("releasemod"), 1)


### PR DESCRIPTION
Action for deleting old invalid ureports. Takes one optional argument --age, when given deletes older invalid ureports than age. Without argument, deletes all invalid ureports.