### PR TITLE
save-reports: saving unkonwn components configurable

### DIFF
--- a/config/plugins/save-reports.conf
+++ b/config/plugins/save-reports.conf
@@ -1,2 +1,9 @@
 [Processing]
 HashFrames = 16
+
+[save-reports]
+# Componets are packages you want to track in faf, by default faf will save just
+# known packages i.e. those already present in database.
+# Setting this to true turns on tracking of all of them, so creating new
+# database entries for unknown components (packages).
+save_unknown_components = false

--- a/src/pyfaf/actions/save_reports.py
+++ b/src/pyfaf/actions/save_reports.py
@@ -32,7 +32,7 @@ from pyfaf.queries import get_unknown_opsys
 from pyfaf.storage import UnknownOpSys
 from pyfaf.ureport import save, save_attachment, validate, validate_attachment
 from pyfaf.utils.parse import str2bool
-from pyfaf.config import paths
+from pyfaf.config import paths, config
 
 
 class SaveReports(Action):
@@ -40,13 +40,15 @@ class SaveReports(Action):
 
     def __init__(self):
         super(SaveReports, self).__init__()
+        save_unknown_components = str2bool(config.get(
+            "save-reports.save_unknown_components", "false"))
 
         basedir_keys = ["ureport.directory", "report.spooldirectory"]
         self.load_config_to_self("basedir", basedir_keys, "/var/spool/faf/")
 
         self.load_config_to_self("create_components",
                                  ["ureport.createcomponents"],
-                                 False, callback=str2bool)
+                                 save_unknown_components, callback=str2bool)
 
         # Instance of 'SaveReports' has no 'basedir' member
         # pylint: disable-msg=E1101


### PR DESCRIPTION
Allows user to configure if ureports of new, yet unknown components,
that means those not yet present in database, should be stored as well.
Default value is false, as it was the only behavior yet.