### PR TITLE
Fix url to FAF report in FedMsg notification

### DIFF
--- a/config/plugins/web.conf
+++ b/config/plugins/web.conf
@@ -2,6 +2,7 @@
 debug = false
 proxy_setup = false
 secret_key = @SECRET_KEY@
+require_https = true
 url = https://example.org/faf/
 # server name is the bare URL without protocols and trailing slash
 server_name = example.org/faf

--- a/src/pyfaf/utils/web.py
+++ b/src/pyfaf/utils/web.py
@@ -39,6 +39,19 @@ def server_name():
         return None
 
 
+def require_https():
+    """
+    Return if web server requires https (default true)
+    """
+
+    if webfaf_installed():
+        from pyfaf.utils.parse import str2bool
+        return str2bool(config.get("hub.require_https", "true"))
+    else:
+        logging.warn("Unable to get require https option, webfaf not available")
+        return True
+
+
 def reverse(view, **kwargs):
     """
     Return full URL to pointing to `view`
@@ -49,6 +62,7 @@ def reverse(view, **kwargs):
         from flask import url_for
         from webfaf.webfaf_main import app
         app.config["SERVER_NAME"] = server_name()
+        app.config['PREFERRED_URL_SCHEME'] = 'https' if require_https() else 'http'
         with app.app_context():
             kwargs["_external"] = True
             return url_for(view, **kwargs)


### PR DESCRIPTION
URLs attached into FedMsg notifications were always prefixed
by 'http://' even the server runs over https.
The URL prefix is now controlled by a new option 'require_https' which
was added into 'web.conf'. If the option is 'true' URLs are prefixed
by 'https://'.

Fixes #564

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>