### PR TITLE
reposync: Do not exit when cannot process one repo

### DIFF
--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -51,14 +51,14 @@ class RepoSync(Action):
 
                 if not repo.arch_list:
                     self.log_error("Parametrized repository is not assigned"
-                                   " with an architecture")
-                    return 1
+                                   " with an architecture, skipping")
+                    continue
                 try:
                     repo_instances += list(self._get_parametrized_variants(repo))
                 except:
-                    self.log_error("No valid mirror for repository {0}"
+                    self.log_error("No valid mirror for repository '{0}', skipping"
                                                     .format(repo.name))
-                    return 1
+                    continue
 
 
             elif repo.opsysrelease_list:
@@ -67,20 +67,20 @@ class RepoSync(Action):
 
                 if not repo.arch_list:
                     self.log_error("OpSysRelease repository is not assigned"
-                                   " with an architecture")
-                    return 1
+                                   " with an architecture, skipping")
+                    continue
                 try:
                     repo_instances += list(self._get_opsysrelease_variants(repo))
                 except:
-                    self.log_error("No valid mirror for repository {0}"
+                    self.log_error("No valid mirror for repository '{0}', skipping"
                                                     .format(repo.name))
-                    return 1
+                    continue
 
             else:
                 if any('$' in url.url for url in repo.url_list):
                     self.log_error("No operating system assigned to"
-                            "parametrized repo '{0}".format(repo.name))
-                    return 1
+                            "parametrized repo '{0}', skipping".format(repo.name))
+                    continue
                 for arch in repo.arch_list:
                     try:
                         repo_instance = {
@@ -91,9 +91,9 @@ class RepoSync(Action):
                                 'arch' : arch.name}
                         repo_instances.append(repo_instance)
                     except:
-                        self.log_error("No valid mirror for repository {0}"
+                        self.log_error("No valid mirror for repository '{0}', skipping"
                                                         .format(repo.name))
-                        return 1
+                        continue
 
         cmdline.name_prefix = cmdline.name_prefix.lower()
         architectures = dict((x.name, x) for x in get_archs(db))

--- a/tests/actions
+++ b/tests/actions
@@ -283,7 +283,7 @@ class ActionsTestCase(faftests.DatabaseCase):
 
         self.assertEqual(self.call_action("reposync", {
             "NAME": "fail_repo",
-        }), 1)
+        }), 0)
 
         self.assertEqual(packages, self.db.session.query(Package).count())
 


### PR DESCRIPTION
Reposync firstly checks all repositories, and only if all repositories
are ready and correct downloading starts. That means that if only one
incorrect repository is present, no repository is reposynced, even
though there are correct and available ones.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>