### PR TITLE
webfaf: Dumpdirs support for more filenames

### DIFF
--- a/src/webfaf/dumpdirs.py
+++ b/src/webfaf/dumpdirs.py
@@ -22,11 +22,12 @@ from forms import NewDumpDirForm
 def check_filename(fn):
     """
     Check if filename matches format used by libreport:
-        ccpp-2014-09-19-18:42:28-12810.tar.gz
+        ccpp-2014-09-19-18:42:28-12810.tar.gz or
+        Python3-2014-09-19-18:42:28-12810.tar.gz
     """
 
     return bool(
-        re.match("[a-z]+-\d{4}-\d{2}-\d{2}-\d{2}:\d{2}:\d{2}-\d+.tar.gz", fn))
+        re.match("[a-zA-Z]+\d?-\d{4}-\d{2}-\d{2}-\d{2}:\d{2}:\d{2}-\d+.tar.gz", fn))
 
 
 @dumpdirs.route("/")

--- a/tests/webfaf/dumpdirs
+++ b/tests/webfaf/dumpdirs
@@ -42,6 +42,10 @@ class DumpdirsTestCase(WebfafTestCase):
         r = self.post_dumpdir("ccpp-2014-09-19-18:42:29-12810.tar.gz")
         self.assertEqual(r.status_code, 201)
 
+        # Correct file name
+        r = self.post_dumpdir("Python3-2017-05-02-09:38:47-5285.tar.gz")
+        self.assertEqual(r.status_code, 201)
+
         # Too big dumpdir
         config["dumpdir.maxdumpdirsize"] = 1
         r = self.post_dumpdir("ccpp-2014-09-19-18:42:29-12811.tar.gz")


### PR DESCRIPTION
Submitting dumpdir archive expects the first part of filename (the type)
    to consist only from small letters.
However the type can be Python or Python3. These filenames were
rejected.

This commit fixes this. Now name can be Python3 (see the updated test).

Signed-off-by: Matej Marusak <mmarusak@redhat.com>