### PR TITLE
webfaf: Explain dumpdirs

### DIFF
--- a/src/webfaf/templates/dumpdirs/new.html
+++ b/src/webfaf/templates/dumpdirs/new.html
@@ -6,11 +6,51 @@
 {% block body %}
   <div class="row">
     <div class="col-md-12">
-      <p>Submit dump dir archive</p>
-      <form class="form" enctype="multipart/form-data" action="" method="POST">
-        {{ render_field(form.file) }}
-        <p><button type='submit' class='btn btn-primary'>Submit</button></p>
-      </form>
+      <h2 class="text-center">Submit dump dir archive</h2>
+      <p class="text-center">This page is used for submiting dump dirs that cannot be processed by ABRT's reporting tools (such as gnome-abrt).<br>
+      If you came here from gnome-abrt that means that reporting failed unexpectedly.<br>
+      If you belive it is a bug in ABRT component and want to help developers to resolve this problem consider doing two things:</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-4" style="float: none; margin-left: auto; margin-right: auto;">
+       <div class="panel-group" id="accordion-markup" align="center">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h4 class="panel-title">
+                <a data-toggle="collapse" data-parent="#accordion-markup" href="#collapseTwo" class="collapsed">
+                  Upload dumpdir
+                </a>
+              </h4>
+            </div>
+            <div id="collapseTwo" class="panel-collapse collapse in">
+              <div class="panel-body">
+                Please archive dump dir into 'tar.gz' file and upload into form belowe.<br>
+                You can easily jump into dump dir by pressing CTRL+O in gnome-abrt. Please select all files, right click and select compressing  as tar.gz. If you don't have this option please use 'tar -pczf' from commandline.<br>
+                The archive will be seen only by ABRT developers but please still mind your private data.
+              <form class="form" enctype="multipart/form-data" action="" method="POST">
+                {{ render_field(form.file) }}
+                <p><button type='submit' class='btn btn-primary'>Submit</button></p>
+              </form>
+              </div>
+            </div>
+          </div>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h4 class="panel-title">
+                <a data-toggle="collapse" data-parent="#accordion-markup" href="#collapseOne">
+                  Contact developers
+                </a>
+              </h4>
+            </div>
+            <div id="collapseOne" class="panel-collapse collapse">
+              <div class="panel-body">
+                IRC: #abrt on FreeNode<br>
+                Mailing_list: crash-catcher@lists.fedorahosted.org<br>
+              </div>
+            </div>
+          </div>
+        </div>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Users can get confused when gnome abrt sends them to this page.

This commit introduces some short explanation to help understand users
what has happened and how can they proceed.

![one1](https://cloud.githubusercontent.com/assets/12330670/25936080/53b9b778-3626-11e7-977e-8822f4452715.png)

![two2](https://cloud.githubusercontent.com/assets/12330670/25936082/5794cc48-3626-11e7-8d18-1759732a90ea.png)

Somewhat related to https://github.com/abrt/faf/issues/547

If somebody has better idea what to write there or how it should look like, let me know and I'll gladly change it:)

