### PR TITLE
pylint: allow 120 chars on line

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -143,7 +143,7 @@ notes=FIXME,XXX,TODO
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=80
+max-line-length=120
 
 # Maximum number of lines in a module
 max-module-lines=1000


### PR DESCRIPTION
80 is soo oldies. most terms nowdays are capable to show 120 chars.