### PR TITLE
webfaf: remove redefinitions of built-in list function

### DIFF
--- a/src/pyfaf/actions/stats.py
+++ b/src/pyfaf/actions/stats.py
@@ -298,7 +298,7 @@ class Stats(Action):
             out += "\n"
             if webfaf_installed():
                 out += "URL: "
-                out += reverse("problems.list")
+                out += reverse("problems.dashboard")
                 out += "\n\n"
 
         lt = query_longterm_problems(db, release_ids, history=self.history_type)

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import (Blueprint, request, abort, Response, render_template, flash,
+from flask import (Blueprint, request, abort, render_template, flash,
                    redirect, url_for)
 from pyfaf.storage import (PeriodicTask, TaskResult, OpSysRelease, Repo)
 from webfaf_main import db
@@ -13,12 +13,10 @@ from pyfaf.bugtrackers import bugtrackers
 from pyfaf.solutionfinders import solution_finders
 
 from wtforms import (Form,
-                     IntegerField,
                      validators,
                      SelectMultipleField,
                      TextField,
                      SelectField,
-                     FileField,
                      BooleanField,
                      TextAreaField,
                      ValidationError)

--- a/src/webfaf/blueprints/symbol_transfer.py
+++ b/src/webfaf/blueprints/symbol_transfer.py
@@ -12,7 +12,6 @@ from pyfaf.storage import (OpSysComponent,
                            ReportHash,
                            SymbolSource)
 from pyfaf.config import config
-from pyfaf.queries import get_report
 from webfaf_main import db
 
 

--- a/src/webfaf/dumpdirs.py
+++ b/src/webfaf/dumpdirs.py
@@ -31,7 +31,7 @@ def check_filename(fn):
 
 @dumpdirs.route("/")
 @admin_required
-def list():
+def dashboard():
     dirs = ((datetime.datetime.fromtimestamp(os.path.getctime(full_path)),
              dir_entry,
              os.path.getsize(full_path))
@@ -231,4 +231,4 @@ def delete(dirname):
             logger.exception(e)
             return Response("Can't delete dump directory", status=500)
 
-    return redirect(url_for("dumpdirs.list"))
+    return redirect(url_for("dumpdirs.dashboard"))

--- a/src/webfaf/forms.py
+++ b/src/webfaf/forms.py
@@ -9,7 +9,6 @@ from flask import g
 from sqlalchemy import asc, distinct
 
 from wtforms import (Form,
-                     IntegerField,
                      validators,
                      SelectMultipleField,
                      TextField,

--- a/src/webfaf/problems.py
+++ b/src/webfaf/problems.py
@@ -408,7 +408,7 @@ def problems_list_table_rows_cache(filter_form, pagination):
 
 
 @problems.route("/")
-def list():
+def dashboard():
     pagination = Pagination(request)
 
     filter_form = ProblemFilterForm(request.args)

--- a/src/webfaf/problems.py
+++ b/src/webfaf/problems.py
@@ -41,7 +41,7 @@ from sqlalchemy import desc, func, and_, or_
 
 problems = Blueprint("problems", __name__)
 
-from webfaf_main import db, flask_cache, app
+from webfaf_main import db, flask_cache
 from forms import ProblemFilterForm, BacktraceDiffForm, component_names_to_ids
 from utils import Pagination, request_wants_json, metric, is_problem_maintainer
 

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -41,7 +41,6 @@ from pyfaf.storage import (AssociatePeople,
                            )
 from pyfaf.queries import (get_report,
                            get_unknown_opsys,
-                           user_is_maintainer,
                            get_bz_bug,
                            get_external_faf_instances,
                            get_report_opsysrelease
@@ -59,19 +58,16 @@ from flask import (Blueprint, render_template, request, abort, redirect,
                    url_for, flash, jsonify, g)
 from sqlalchemy import literal, desc, or_
 from utils import (Pagination,
-                   cache,
                    diff as seq_diff,
                    InvalidUsage,
-                   login_required,
                    metric,
-                   metric_tuple,
                    request_wants_json,
                    is_component_maintainer)
 
 
 reports = Blueprint("reports", __name__)
 
-from webfaf_main import db, flask_cache, app
+from webfaf_main import db, flask_cache
 from forms import (ReportFilterForm, NewReportForm, NewAttachmentForm,
                    component_names_to_ids, AssociateBzForm)
 

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -226,7 +226,7 @@ def reports_list_table_rows_cache(filter_form, pagination):
 
 
 @reports.route("/")
-def list():
+def dashboard():
     pagination = Pagination(request)
 
     filter_form = ReportFilterForm(request.args)

--- a/src/webfaf/stats.py
+++ b/src/webfaf/stats.py
@@ -1,6 +1,5 @@
 import datetime
 
-import pyfaf
 from pyfaf import queries
 from utils import cache, request_wants_json
 

--- a/src/webfaf/templates/base.html
+++ b/src/webfaf/templates/base.html
@@ -41,8 +41,8 @@
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-primary">
               <li {% if request.url_rule and request.url_rule.endpoint.startswith('summary.') %}class="active" {% endif %}><a href="{{ url_for('summary.index') }}">Summary</a></li>
-              <li {% if request.url_rule and request.url_rule.endpoint.startswith('problems.') %}class="active" {% endif %}><a id="href_problems" href="{{ url_for('problems.list') }}">Problems</a></li>
-              <li {% if request.url_rule and request.url_rule.endpoint.startswith('reports.') %}class="active" {% endif %}><a href="{{ url_for('reports.list') }}">Reports</a></li>
+              <li {% if request.url_rule and request.url_rule.endpoint.startswith('problems.') %}class="active" {% endif %}><a id="href_problems" href="{{ url_for('problems.dashboard') }}">Problems</a></li>
+              <li {% if request.url_rule and request.url_rule.endpoint.startswith('reports.') %}class="active" {% endif %}><a href="{{ url_for('reports.dashboard') }}">Reports</a></li>
               <li class="dropdown" {% if request.url_rul and request.url_rule.endpoint.startswith('stats.') %}class="active" {% endif %} >
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Statistics <span class="caret"></span></a>
                 <ul class="dropdown-menu" role="menu">
@@ -57,7 +57,7 @@
                   <li {% if request.url_rule and request.url_rule.endpoint.startswith(menu_item['route']) %}class="active" {% endif %}><a href="{{ url_for(menu_item['route']) }}">{{menu_item["title"]}}</a></li>
                 {% endfor %}
               {% if g.user.admin %}
-                <li {% if request.url_rule and request.url_rule.endpoint.startswith('dumpdirs.') %}class="active" {% endif %}><a href="{{ url_for('dumpdirs.list') }}"><i class="fa fa-gear"></i> Dumpdirs</a></li>
+                <li {% if request.url_rule and request.url_rule.endpoint.startswith('dumpdirs.') %}class="active" {% endif %}><a href="{{ url_for('dumpdirs.dashboard') }}"><i class="fa fa-gear"></i> Dumpdirs</a></li>
                 {% for menu_item in current_menu["admin"] %}
                   <li {% if request.url_rule and request.url_rule.endpoint.startswith(menu_item['route']) %}class="active" {% endif %}><a href="{{ url_for(menu_item['route']) }}"><i class="fa fa-gear"></i> {{menu_item["title"]}}</a></li>
                 {% endfor %}


### PR DESCRIPTION
Modules reports, problems and dumpdirs contain functions called `list()`. I don't consider redefinition of Python's built-in functions to be a good practice. This can cause an errors that are really hard to debug. I suggest to rename these functions. In my opinion the name "dashboard" reflects the data content of documents on routes /problems and /reports.