### PR TITLE
docker: Introduce FAF docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM fedora:26
+MAINTAINER mmarusak@redhat.com
+
+ARG password
+
+RUN dnf -y update && \
+    dnf install -y dnf-plugins-core && \
+    dnf -y copr enable @abrt/faf-el7 && \
+    dnf -y install git \
+                   sudo \
+                   which \
+                   cronie \
+                   postgresql-server \
+                   postgresql \
+                   python-psycopg2 \
+                   pg-semver \
+                   faf-* && \
+    dnf clean all && \
+    echo faf:${password:-passwd} | chpasswd && \
+    echo 'faf ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    echo 'root ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy initialization script
+COPY docker/files/init_db /usr/bin
+
+# Create crontabs and configurate FAF
+ADD docker/files/crontab-faf /etc/faf/crontab-faf
+RUN crontab -u faf /etc/faf/crontab-faf && \
+    sed -i -e"s/CreateComponents\s*=\s*False/CreateComponents = True/i" /etc/faf/faf.conf && \
+    sed -i -e"s/type\s*=\s*simple/type = null/i" /etc/faf/plugins/web.conf
+
+VOLUME /var/lib/postgres
+VOLUME /var/spool/faf
+
+EXPOSE 80
+CMD ["sh", "-c", "crond && apachectl -D FOREGROUND"]

--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -1,0 +1,34 @@
+FROM abrt/faf-image
+MAINTAINER mmarusak@redhat.com
+
+# Copy sources to the docker image
+COPY . /faf
+
+# From not on work from faf directory
+WORKDIR '/faf'
+
+# Change owner of /faf, clean git and install dependences
+RUN chown -R faf:faf /faf && \
+    git clean -dfx && \
+    dnf -y --setopt=strict=0 install $(./autogen.sh sysdeps) rpm-build && \
+    dnf clean all
+
+# Build as non root
+USER faf
+
+ENV HOME /faf
+
+# Build faf
+RUN ./autogen.sh && \
+    ./configure && \
+    make rpm
+
+#And continue as root
+USER root
+
+# Update FAF
+RUN rpm -Uvh noarch/faf-* && \
+    sed -i -e"s/everyone_is_admin\s*=\s*false/everyone_is_admin = true/i" /etc/faf/plugins/web.conf
+
+#Switch workdir back to /
+WORKDIR '/'

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,20 @@
+build:
+	docker build -t faf-image -f Dockerfile ../
+
+build_local:
+	docker build -t faf-image-local -f Dockerfile_local ../
+
+run:
+	docker run --name faf -dit faf-image
+
+run_local:
+	docker run --name faf -dit faf-image-local
+
+init_db:
+	docker exec faf init_db
+
+sh:
+	docker exec -it faf bash
+
+del:
+	docker rm -f faf

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,59 @@
+# FAF in Docker container
+
+**Easiest way how to run FAF**
+---
+
+## How to deploy
+
+It is as simple as:
+
+`docker run --name faf -dit abrt/faf-image`
+
+However you also probably want to mount volumes to `/var/lib/postgres` and
+to `/var/spool/faf` not to lose database and FAF's data.
+
+`docker run --name faf -v /var/lib/faf-docker/faf:/var/spool/faf -v
+/var/lib/faf-docker/postgres:/var/lib/postgres/ -dit abrt/faf-image`
+
+If you run FAF for the first time, then there is no database. You have to
+initialize it.
+
+`docker exec faf init_db`
+
+Then FAF is ready for use.
+
+## What's next
+You can see incoming reports in webUI. It is accessible on `http://<container_IP>/faf`.
+
+Finding out container IP address:
+
+`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' faf`
+
+Also to send reports into your own FAF, you have to set up libreport on all
+machines, from with you wish to report into your own FAF. To do so, set up
+`URL = http://<container_IP>/faf` in `/etc/libreport/plugins/ureport.conf`.
+
+## Configuring FAF
+New containers come with fully working and configured FAF (on top of basic configuration
+Fedora releases are added, caching is disabled, and FAF accepts unknown components).
+
+To run any FAF action, please run them as faf user.
+
+`docker exec -u faf faf faf <action> <arguments>`
+
+## How to build the image
+`cd faf/docker`
+
+`make build` to build from copr
+
+`make build_local` to build from currently checked out github branch
+
+For easier using and debugging you can use also:
+
+`make run` to run copr version of FAF
+
+`make run_local` to run git version of FAF
+
+`make sh` to jump into bash in the container
+
+`make del` to remove faf container

--- a/docker/files/crontab-faf
+++ b/docker/files/crontab-faf
@@ -1,0 +1,17 @@
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * command to be executed
+
+*/5  *  *  *  * faf save-reports -v
+5    1  *  *  * faf find-crashfn -vp core ; faf find-crashfn -vp kerneloops
+5    3  *  *  * faf create-problems -vp core ; faf create-problems -vp kerneloops ; faf create-problems -vp python

--- a/docker/files/init_db
+++ b/docker/files/init_db
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+mkdir -p /var/lib/postgres/data
+chown postgres:postgres /var/lib/postgres/data
+
+mkdir -p /var/spool/faf/reports/incoming /var/spool/faf/reports/saved /var/spool/faf/reports/deferred /var/spool/faf/lob /var/spool/faf/attachments/incoming
+chown -R faf:faf /var/spool/faf/reports
+chown -R faf:faf /var/spool/faf/lob
+chown -R faf:faf /var/spool/faf/attachments
+
+sudo -u postgres /usr/bin/pg_ctl initdb -D /var/lib/postgres/data > /dev/null
+sudo -u postgres /usr/bin/pg_ctl start -D /var/lib/postgres/data -w > /dev/null
+
+sudo -u postgres psql -c "CREATE USER faf;"
+sudo -u postgres psql -c "CREATE DATABASE faf;"
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE faf TO faf;"
+sudo -u postgres psql -c "ALTER USER faf WITH superuser;"
+sudo -u faf psql -c "CREATE EXTENSION semver;"
+sudo -u faf faf-migrate-db --create-all
+sudo -u faf faf-migrate-db --stamp-only
+sudo -u faf faf init
+sudo -u faf faf pull-releases -o fedora


### PR DESCRIPTION
Obsoletes abrt/faf-docker repository.

Why have I created a new docker image?

Firstly, because I didn't know there is one.
Secondly, the image needed some rewriting and rethinking.

So why is it directly in FAF repo?
Because it is the correct place. We do not need another repository for
so little data. And also, nobody misses it ever again:)

How does it differ?
The biggest difference is that it builds FAF from currently checked out
git branch. It makes it perfect for development. It makes however, the image a
bit bigger (there are some build-requires).

Signed-off-by: Matej Marusak <mmarusak@redhat.com>