### PR TITLE
fix migration - ignore_private_bz

### DIFF
--- a/src/pyfaf/storage/migrations/versions/acd3d9bf85d1_ignore_private_bz.py
+++ b/src/pyfaf/storage/migrations/versions/acd3d9bf85d1_ignore_private_bz.py
@@ -34,8 +34,7 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.add_column('bzbugs', sa.Column('private', sa.Boolean(), nullable=False))
-    op.execute('UPDATE bzbugs SET "private" = False WHERE "private" IS NULL')
+    op.add_column('bzbugs', sa.Column('private', sa.Boolean(), nullable=False, server_default='f'))
 
 
 def downgrade():


### PR DESCRIPTION
you cannot add column with nullable=False without default. DB will error that the column contains nullable values