### PR TITLE
ureport: Always check for validity of ureport

### DIFF
--- a/src/pyfaf/solutionfinders/__init__.py
+++ b/src/pyfaf/solutionfinders/__init__.py
@@ -20,7 +20,7 @@ import os
 import cgi
 from pyfaf.common import FafError, Plugin, import_dir, load_plugins
 from pyfaf.storage import Report, getDatabase
-from pyfaf.ureport import ureport2
+from pyfaf.ureport import ureport2, validate
 from pyfaf.problemtypes import problemtypes
 from pyfaf.queries import get_report
 
@@ -74,6 +74,7 @@ class SolutionFinder(Plugin):
 
     def _get_db_report(self, db, ureport):
         ureport = ureport2(ureport)
+        validate(ureport)
 
         problemplugin = problemtypes[ureport["problem"]["type"]]
         report_hash = problemplugin.hash_ureport(ureport["problem"])

--- a/src/pyfaf/solutionfinders/prefilter_solution_finder.py
+++ b/src/pyfaf/solutionfinders/prefilter_solution_finder.py
@@ -25,6 +25,7 @@ from pyfaf.queries import (get_sf_prefilter_btpaths, get_sf_prefilter_pkgnames,
                            get_opsys_by_name)
 from pyfaf.solutionfinders import Solution
 from pyfaf.ureport_compat import ureport1to2
+from pyfaf.ureport import validate
 
 
 class PrefilterSolutionFinder(SolutionFinder):
@@ -95,6 +96,7 @@ class PrefilterSolutionFinder(SolutionFinder):
 
         if "ureport_version" in ureport and ureport["ureport_version"] == 1:
             ureport = ureport1to2(ureport)
+            validate(ureport)
 
         db_opsys = None
         if osr is not None:

--- a/src/pyfaf/solutionfinders/probable_fix_solution_finder.py
+++ b/src/pyfaf/solutionfinders/probable_fix_solution_finder.py
@@ -17,7 +17,7 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 from pyfaf.solutionfinders import SolutionFinder, Solution
-from pyfaf.ureport import ureport2
+from pyfaf.ureport import ureport2, validate
 from pyfaf.utils.parse import cmp_evr
 
 
@@ -49,6 +49,7 @@ class ProbableFixSolutionFinder(SolutionFinder):
 
     def find_solution_ureport(self, db, ureport, osr=None):
         ureport = ureport2(ureport)
+        validate(ureport)
         db_report = self._get_db_report(db, ureport)
         if db_report is None:
             return None

--- a/src/pyfaf/ureport.py
+++ b/src/pyfaf/ureport.py
@@ -563,6 +563,7 @@ def valid_known_type(known_type):
 
 def is_known(ureport, db, return_report=False, opsysrelease_id=None):
     ureport = ureport2(ureport)
+    validate(ureport)
 
     problemplugin = problemtypes[ureport["problem"]["type"]]
     report_hash = problemplugin.hash_ureport(ureport["problem"])

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -876,6 +876,7 @@ def new():
 
                 try:
                     report2 = ureport2(report)
+                    ureport.validate(report2)
                 except FafError:
                     report2 = None
 


### PR DESCRIPTION
1) Because it is better to know, if the ureport is valid
2) It has side effects (edits the ureport)

Closes #501

Signed-off-by: Matej Marusak <mmarusak@redhat.com>