### PR TITLE
docker: fix issue with autogen and rpmspec

### DIFF
--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -10,7 +10,8 @@ WORKDIR '/faf'
 # Change owner of /faf, clean git and install dependences
 RUN chown -R faf:faf /faf && \
     git clean -dfx && \
-    dnf -y --setopt=strict=0 install $(./autogen.sh sysdeps) rpm-build && \
+    dnf -y install rpm-build && \
+    eval dnf -y --setopt=strict=0 install $(./autogen.sh sysdeps) && \
     dnf clean all
 
 # Build as non root


### PR DESCRIPTION
Since f248784f5ebaf3a6e39eb3d5ca1d749f0b8ef556 rpmspec is needed to get list of dependencies with "autogen.sh sysdeps".

eval helps with evaluation of "package >= 0.00" strings.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>