### PR TITLE
storage: Remove unused imports

### DIFF
--- a/src/pyfaf/storage/mantisbt.py
+++ b/src/pyfaf/storage/mantisbt.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from . import Boolean
 from . import Column
 from . import DateTime
 from . import Enum

--- a/src/pyfaf/storage/migrations/versions/168c63b81f85_report_history_default_value.py
+++ b/src/pyfaf/storage/migrations/versions/168c63b81f85_report_history_default_value.py
@@ -30,7 +30,6 @@ revision = '168c63b81f85'
 down_revision = '1c4d6317721a'
 
 from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/src/pyfaf/storage/migrations/versions/23bab42e7be7_initial_migration.py
+++ b/src/pyfaf/storage/migrations/versions/23bab42e7be7_initial_migration.py
@@ -29,9 +29,6 @@ Create Date: 2014-07-31 10:20:27.506558
 revision = '23bab42e7be7'
 down_revision = None
 
-from alembic import op
-import sqlalchemy as sa
-
 
 def upgrade():
     pass

--- a/src/pyfaf/storage/migrations/versions/2dfd5aef57ca_add_eol_bz_resolution.py
+++ b/src/pyfaf/storage/migrations/versions/2dfd5aef57ca_add_eol_bz_resolution.py
@@ -30,7 +30,6 @@ revision = '2dfd5aef57ca'
 down_revision = '58f44afc3a3a'
 
 from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/src/pyfaf/storage/migrations/versions/2e5f6d8b68f5_add_contact_email_tables.py
+++ b/src/pyfaf/storage/migrations/versions/2e5f6d8b68f5_add_contact_email_tables.py
@@ -31,7 +31,6 @@ down_revision = '272e6a3deea4'
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 
 def upgrade():

--- a/src/pyfaf/storage/migrations/versions/43bd2d59838e_add_mantisbt.py
+++ b/src/pyfaf/storage/migrations/versions/43bd2d59838e_add_mantisbt.py
@@ -31,7 +31,6 @@ down_revision = '2dfd5aef57ca'
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 
 def upgrade():

--- a/src/pyfaf/storage/migrations/versions/47cf82727ed1_acl_permissions.py
+++ b/src/pyfaf/storage/migrations/versions/47cf82727ed1_acl_permissions.py
@@ -32,7 +32,6 @@ down_revision = "2e5f6d8b68f5"
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
-from pyfaf.storage import OpSysReleaseComponentAssociate
 
 
 def upgrade():

--- a/src/pyfaf/storage/migrations/versions/5695a1c595c3_reportreleasedesktops.py
+++ b/src/pyfaf/storage/migrations/versions/5695a1c595c3_reportreleasedesktops.py
@@ -31,7 +31,6 @@ down_revision = '23bab42e7be7'
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 
 def upgrade():

--- a/src/pyfaf/storage/migrations/versions/82081a3c76b_rename_kb_to_sf_prefilter.py
+++ b/src/pyfaf/storage/migrations/versions/82081a3c76b_rename_kb_to_sf_prefilter.py
@@ -30,7 +30,6 @@ revision = '82081a3c76b'
 down_revision = '31d0249e8d4c'
 
 from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/src/pyfaf/storage/migrations/versions/cef2fcd69ef_celery_tasks.py
+++ b/src/pyfaf/storage/migrations/versions/cef2fcd69ef_celery_tasks.py
@@ -31,7 +31,6 @@ down_revision = '48550f308625'
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 
 def upgrade():


### PR DESCRIPTION
One unused import after some changes was making tests to fail.

Looked into other files and removed all unused imports in storage
(mainly migrations)

Signed-off-by: Matej Marusak <mmarusak@redhat.com>