### PR TITLE
WIP webfaf: Limit the number of exception mails

### DIFF
--- a/config/plugins/web.conf
+++ b/config/plugins/web.conf
@@ -44,3 +44,11 @@ type = simple
 # memcached_host = localhost
 # memcached_port = 11211
 # memcached_key_prefix = webfaf
+
+[throttle]
+# Number of mails that can be sent per the time frame
+# rate = 1
+# Time to wait before another mail can be sent
+# timeframe = 30
+# Start the throttling after this number of mails is sent
+# burst = 1

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -82,6 +82,7 @@ Requires: python-openid-teams
 Requires: python-jinja2 >= 2.7
 Requires: python-bunch
 Requires: python-dateutil
+Requires: python2-ratelimitingfilter
 
 %description webui
 A WebUI rewrite

--- a/src/webfaf/config.py
+++ b/src/webfaf/config.py
@@ -37,6 +37,9 @@ class Config(object):
     EVERYONE_IS_ADMIN = str2bool(config.get("hub.everyone_is_admin", "false"))
     FEDMENU_URL = config.get("hub.fedmenu_url", None)
     FEDMENU_DATA_URL = config.get("hub.fedmenu_data_url", None)
+    THROTTLING_RATE = config.get("throttle.rate", 1)
+    THROTTLING_TIMEFRAME = config.get("throttle.timeframe", 30)
+    THROTTLING_BURST = config.get("throttle.burst", 1)
 
 
 class ProductionConfig(Config):

--- a/src/webfaf/webfaf_main.py
+++ b/src/webfaf/webfaf_main.py
@@ -2,6 +2,8 @@ import os
 import logging
 from logging.handlers import SMTPHandler
 
+from ratelimitingfilter import RateLimitingFilter
+
 import flask
 import json
 import bunch
@@ -169,6 +171,11 @@ if not app.debug:
         'webfaf exception', credentials)
 
     mail_handler.setLevel(logging.ERROR)
+    rate_limiter = RateLimitingFilter(app.config['THROTTLING_RATE'],
+                                      app.config['THROTTLING_TIMEFRAME'],
+                                      app.config['THROTTLING_BURST'])
+
+    mail_handler.addFilter(rate_limiter)
     app.logger.addHandler(mail_handler)
 
 


### PR DESCRIPTION
Limits the rate at which the messages are passed to the SMTP handler.
It uses a token bucket based algorithm to filter the messages.

* Ex.1: rate=1 timeframe=30 burst=1
After a mail is sent there is a 30s period until another one can be sent.

* Ex.2: rate=1 timeframe=60 burst=5
Allows to send 5 mails in burst before the filtering kicks in. After that
the number of mails that can be sent starts recovering at the rate of 1 mail
per 60s.

There is also possibility to filter the mails based on the substring
in the exception message.

More info at https://github.com/wkeeling/ratelimitingfilter

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>