### PR TITLE
py3 compatibility: classic division

### DIFF
--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import division
 from operator import itemgetter
 from collections import defaultdict
 import satyr
@@ -177,7 +178,7 @@ class CreateProblems(Action):
 
             if match > 0:
                 # Ratio of problems matched
-                match_metric = float(match)/len(db_reports)
+                match_metric = float(match)//len(db_reports)
                 self.log_debug("Found possible match #{0} ({1:.2f})"
                                .format(db_problem.id, match_metric))
                 matches.append((match_metric, db_reports, db_problem))

--- a/src/pyfaf/actions/mark_probably_fixed.py
+++ b/src/pyfaf/actions/mark_probably_fixed.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import division
 from datetime import datetime
 from pyfaf.actions import Action
 from pyfaf.common import FafError
@@ -289,7 +290,7 @@ class MarkProbablyFixed(Action):
             db.session.flush()
             if problems_in_release > 0:
                 self.log_info("{0}% of problems in this release probably fixed.".format(
-                    (probably_fixed_total * 100) / problems_in_release))
+                    (probably_fixed_total * 100) // problems_in_release))
             else:
                 self.log_info("No problems found in this release.")
 

--- a/src/pyfaf/actions/stats.py
+++ b/src/pyfaf/actions/stats.py
@@ -19,6 +19,7 @@
 
 from __future__ import unicode_literals
 
+from __future__ import division
 import datetime
 import collections
 
@@ -120,7 +121,7 @@ class Stats(Action):
         for num, (comp, count, reports) in enumerate(results):
             if reports:
                 out += ("{0}. {1} seen {2} times ({3:.0%} of all reports)\n"
-                        .format(num + 1, comp, count, count / float(total_num)))
+                        .format(num + 1, comp, count, count // float(total_num)))
 
                 for problem_url, bugs in reports:
                     if problem_url or bugs:
@@ -182,8 +183,8 @@ class Stats(Action):
                 yysum += y * y
 
             # y = bx + a
-            b = xysum - xsum * ysum / num_days
-            b /= xxsum - xsum ** 2 / num_days
+            b = xysum - xsum * ysum // num_days
+            b /= xxsum - xsum ** 2 // num_days
 
             a = ysum - b * xsum
             a /= num_days
@@ -239,13 +240,13 @@ class Stats(Action):
 
             minval = min(counts)
             maxval = max(counts)
-            scale = ((maxval - minval) << 8) / (len(self.graph_symbols) - 1)
+            scale = ((maxval - minval) << 8) // (len(self.graph_symbols) - 1)
             scale = max(scale, 1)
             graph = ""
 
             for day in prev_days(num_days):
                 graph += self.graph_symbols[((comp.history[day] - minval)
-                                             << 8) / scale]
+                                             << 8) // scale]
 
             out += row.format(component=comp.name,
                               jump=comp.jump,

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import division
 from datetime import timedelta
 import datetime
 import functools
@@ -742,7 +743,7 @@ def prioritize_longterm_problems(min_fa, problem_tuples):
         if problem.first_occurrence.day != 1:
             months -= 1
 
-        problem.rank = rank / float(months)
+        problem.rank = rank // float(months)
 
     return sorted(problem_tuples, key=lambda (problem, _, __): problem.rank,
                   reverse=True)

--- a/src/pyfaf/storage/fixtures/__init__.py
+++ b/src/pyfaf/storage/fixtures/__init__.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import division
 import sys
 import os
 import time
@@ -451,7 +452,7 @@ class Generator(object):
                     bytes_so_far += len(chunk)
                     f.write(chunk)
 
-                    percent = float(bytes_so_far) / total_size
+                    percent = float(bytes_so_far) // total_size
                     percent = round(percent*100, 2)
                     sys.stdout.write("Downloaded %d of %d bytes (%0.2f%%)\r" %
                                         (bytes_so_far, total_size, percent))

--- a/src/pyfaf/storage/fixtures/randutils.py
+++ b/src/pyfaf/storage/fixtures/randutils.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import division
 import os
 import random
 import hashlib
@@ -24,13 +25,13 @@ def pickhalf(objects):
     '''
     Randomly pick half of the objects
     '''
-    return random.sample(objects, len(objects)/2)
+    return random.sample(objects, len(objects)//2)
 
 def pickmost(objects):
     '''
     Randomly pick 9/10 of the objects
     '''
-    return random.sample(objects, len(objects)-len(objects)/10)
+    return random.sample(objects, len(objects)-len(objects)//10)
 
 def toss():
     '''

--- a/src/webfaf/filters.py
+++ b/src/webfaf/filters.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import calendar
 import datetime
 import time
@@ -56,7 +57,7 @@ def fancydate(value, base_date=None):
 
     if old_date.month == base_date.month and old_date.year == base_date.year:
         # computes a number of calendar weeks (not only 7 days)
-        offset = round((d.days - base_date.isoweekday()) / 7, 0) + 1
+        offset = round((d.days - base_date.isoweekday()) // 7, 0) + 1
         name = 'week'
     elif old_date.year == base_date.year:
         offset = base_date.month - old_date.month

--- a/src/webfaf/problems.py
+++ b/src/webfaf/problems.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import datetime
 from collections import defaultdict
 from operator import itemgetter
@@ -533,7 +534,7 @@ def item(problem_id):
     # are selected which is not a good representation.)
     k = min(len(bt_hashes), 10)
     a = 0
-    d = len(bt_hashes)/float(k)
+    d = len(bt_hashes)//float(k)
     bt_hashes_limited = []
     for i in range(k):
         bt_hashes_limited.append("bth=" + bt_hashes[int(a)][0])

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import datetime
 import logging
 import json
@@ -1014,8 +1015,8 @@ def attach():
 
 def get_avg_count(first, last, count):
     diff = last - first
-    r_d = diff.days / 30.4  # avg month size
+    r_d = diff.days // 30.4  # avg month size
     if r_d < 1:
         r_d = 1
 
-    return int(round(count / r_d))
+    return int(round(count // r_d))

--- a/src/webfaf/stats.py
+++ b/src/webfaf/stats.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import datetime
 
 from pyfaf import queries
@@ -85,14 +86,14 @@ def by_daterange(since, to):
         if not release_sum:
             continue
 
-        percentage = int(release_sum * 100.0 / total)
+        percentage = int(release_sum * 100.0 // total)
 
         comps = queries.get_report_count_by_component(
             db, release.opsys.name, release.version, history=history)
 
         comp_data = []
         for comp, count in date_filter(comps).all():
-            comp_percentage = int(count * 100.0 / release_sum)
+            comp_percentage = int(count * 100.0 // release_sum)
             comp_data.append((comp, count, comp_percentage))
 
         release_data.append({


### PR DESCRIPTION
The PR supports the same "classic" division in both Python 2 & 3 simultaneously according to [Porting Python 2 Code to Python 3](https://docs.python.org/3/howto/pyporting.html#division) documentation, using python-modernize tool.