### PR TITLE
py3 compatibility: classic division - corrected

### DIFF
--- a/src/pyfaf/actions/mark_probably_fixed.py
+++ b/src/pyfaf/actions/mark_probably_fixed.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import division
 from datetime import datetime
 from pyfaf.actions import Action
 from pyfaf.common import FafError
@@ -289,7 +290,7 @@ class MarkProbablyFixed(Action):
             db.session.flush()
             if problems_in_release > 0:
                 self.log_info("{0}% of problems in this release probably fixed.".format(
-                    (probably_fixed_total * 100) / problems_in_release))
+                    (probably_fixed_total * 100) // problems_in_release))
             else:
                 self.log_info("No problems found in this release.")
 

--- a/src/pyfaf/actions/stats.py
+++ b/src/pyfaf/actions/stats.py
@@ -19,6 +19,7 @@
 
 from __future__ import unicode_literals
 
+from __future__ import division
 import datetime
 import collections
 
@@ -182,11 +183,11 @@ class Stats(Action):
                 yysum += y * y
 
             # y = bx + a
-            b = xysum - xsum * ysum / num_days
-            b /= xxsum - xsum ** 2 / num_days
+            b = xysum - xsum * ysum // num_days
+            b //= xxsum - xsum ** 2 // num_days
 
             a = ysum - b * xsum
-            a /= num_days
+            a //= num_days
 
             first_day = hist_dict[prev_days(num_days)[0]]
             last_day = hist_dict[prev_days(num_days)[-1]]
@@ -239,13 +240,13 @@ class Stats(Action):
 
             minval = min(counts)
             maxval = max(counts)
-            scale = ((maxval - minval) << 8) / (len(self.graph_symbols) - 1)
+            scale = ((maxval - minval) << 8) // (len(self.graph_symbols) - 1)
             scale = max(scale, 1)
             graph = ""
 
             for day in prev_days(num_days):
                 graph += self.graph_symbols[((comp.history[day] - minval)
-                                             << 8) / scale]
+                                             << 8) // scale]
 
             out += row.format(component=comp.name,
                               jump=comp.jump,

--- a/src/pyfaf/storage/fixtures/randutils.py
+++ b/src/pyfaf/storage/fixtures/randutils.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import division
 import os
 import random
 import hashlib
@@ -24,13 +25,13 @@ def pickhalf(objects):
     '''
     Randomly pick half of the objects
     '''
-    return random.sample(objects, len(objects)/2)
+    return random.sample(objects, len(objects)//2)
 
 def pickmost(objects):
     '''
     Randomly pick 9/10 of the objects
     '''
-    return random.sample(objects, len(objects)-len(objects)/10)
+    return random.sample(objects, len(objects)-len(objects)//10)
 
 def toss():
     '''

--- a/src/webfaf/filters.py
+++ b/src/webfaf/filters.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import calendar
 import datetime
 import time
@@ -56,7 +57,7 @@ def fancydate(value, base_date=None):
 
     if old_date.month == base_date.month and old_date.year == base_date.year:
         # computes a number of calendar weeks (not only 7 days)
-        offset = round((d.days - base_date.isoweekday()) / 7, 0) + 1
+        offset = ((d.days - base_date.isoweekday()) // 7) + 1
         name = 'week'
     elif old_date.year == base_date.year:
         offset = base_date.month - old_date.month


### PR DESCRIPTION
Support of the same "classic" division in both Python 2 & 3 simultaneously.
It is related to such a division when both operators are ```int```.

Signed-off-by: Jan Beran <jberan@redhat.com>