### PR TITLE
py3 compatibility: file

### DIFF
--- a/src/webfaf/dumpdirs.py
+++ b/src/webfaf/dumpdirs.py
@@ -69,7 +69,7 @@ def item(dirname):
         if not os.path.isfile(archive_path):
             abort(404)
 
-        archive = file(archive_path)
+        archive = open(archive_path)
         archive_size = os.path.getsize(archive_path)
 
         return Response(archive, content_type="application/octet-stream",


### PR DESCRIPTION
When opening a file, it is preferable to use `open()`
instead of invoking the `file` constructor directly.
`file()` has been removed in Python 3.

Signed-off-by: Jan Beran <jberan@redhat.com>