### PR TITLE
py3 compatibility: Set literals

### DIFF
--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -347,7 +347,7 @@ class CreateProblems(Action):
 
             # Unique threads form their own unique problems
             for thread in unique_func_threads:
-                problems.append(set([report_map[thread]]))
+                problems.append({report_map[thread]})
 
         self.log_info("Creating problems from clusters")
         if speedup:


### PR DESCRIPTION
The new literal syntax for sets is available and preferred in Python 3.
It has been backported to Python 2.7.

Signed-off-by: Jan Beran <jberan@redhat.com>