### PR TITLE
py3 compatibility: Replacement of long type with int type

### DIFF
--- a/src/pyfaf/actions/stats.py
+++ b/src/pyfaf/actions/stats.py
@@ -168,7 +168,7 @@ class Stats(Action):
             if len(history) < 2:
                 continue
 
-            hist_dict = collections.defaultdict(long)
+            hist_dict = collections.defaultdict(int)
             for key, value in history:
                 hist_dict[key] = value
 


### PR DESCRIPTION
Python 2 had separate `int` and `long` types for non-floating-point numbers.
In Python 3, there is only `int` type, which mostly behaves like
the `long` type in Python 2. The replacement of `long` with `int` type
should not have any impact in Python 2 as the value is related to days here.

Signed-off-by: Jan Beran <jberan@redhat.com>