### PR TITLE
py3 compatibility: Add `from functools import reduce`

### DIFF
--- a/src/pyfaf/utils/format.py
+++ b/src/pyfaf/utils/format.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+from functools import reduce
+
 __all__ = ["as_table"]
 
 


### PR DESCRIPTION
`reduce()` was removed from built-ins in Python 3 and has been placed
into `functools` module since Python 2.6 to allow writing code
more forward-compatible with Python 3.

Signed-off-by: Jan Beran <jberan@redhat.com>