### PR TITLE
py3 compatibility: Replacement of `unicode` type with `six.text_type`

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -28,6 +28,16 @@ Requires: python-psycopg2 >= 2.5
 Requires: python-sqlalchemy >= 0.8
 Requires: rpm-python
 
+# six library to cover Python 3 compatibility
+%if 0%{?fedora}
+Requires:      python2-six
+BuildRequires: python2-six
+%else
+# rhel7
+Requires:      python-six
+BuildRequires: python-six
+%endif
+
 BuildRequires: autoconf
 BuildRequires: intltool
 BuildRequires: libtool

--- a/src/pyfaf/storage/__init__.py
+++ b/src/pyfaf/storage/__init__.py
@@ -26,6 +26,7 @@ from pyfaf.config import config
 # also required for EL6
 import __main__
 import pkg_resources
+import six
 __main__.__requires__ = __requires__ = []
 __requires__.append("SQLAlchemy >= 0.8.2")
 pkg_resources.require(__requires__)
@@ -144,7 +145,7 @@ class GenericTableBase(object):
             mode += "b"
 
         with open(lobpath, mode) as lob:
-            if type(data) in [str, unicode]:
+            if isinstance(data, six.string_types):
                 self._save_lob_string(lob, data, maxlen, truncate)
             elif hasattr(data, "read"):
                 if not truncate:

--- a/src/webfaf/forms.py
+++ b/src/webfaf/forms.py
@@ -24,6 +24,7 @@ from pyfaf.storage.opsys import AssociatePeople, Arch
 from pyfaf.problemtypes import problemtypes
 from pyfaf.bugtrackers import bugtrackers
 from pyfaf.queries import get_associate_by_name
+import six
 
 
 class DaterangeField(TextField):
@@ -318,7 +319,7 @@ class NewDumpDirForm(Form):
 class BugIdField(TextField):
     def _value(self):
         if self.data:
-            return unicode(self.data)
+            return six.text_type(self.data)
         else:
             return u''
 

--- a/src/webfaf/stats.py
+++ b/src/webfaf/stats.py
@@ -7,6 +7,7 @@ from flask import (Blueprint, render_template, abort, redirect,
                    url_for, jsonify)
 
 from webfaf_main import db
+import six
 
 stats = Blueprint("stats", __name__)
 
@@ -50,10 +51,10 @@ def by_daterange(since, to):
     '''
 
     try:
-        if isinstance(since, str) or isinstance(since, unicode):
+        if isinstance(since, six.string_types):
             since = datetime.datetime.strptime(since, "%Y-%m-%d").date()
 
-        if isinstance(to, str) or isinstance(to, unicode):
+        if isinstance(to, six.string_types):
             to = datetime.datetime.strptime(to, "%Y-%m-%d").date()
     except:
         return abort(400)


### PR DESCRIPTION
The `unicode` type is `unicode` in Python 2 and `str` on Python 3.
The replacement of `unicode` type with `six.text_type` ensures
the compatibility between Python 2 and Python 3.

Signed-off-by: Jan Beran <jberan@redhat.com>