### PR TITLE
py3 compatibility: Replacement of type()== with isinstance()

### DIFF
--- a/src/pyfaf/storage/fixtures/__init__.py
+++ b/src/pyfaf/storage/fixtures/__init__.py
@@ -364,7 +364,7 @@ class Generator(object):
                             [('bzbug', random.choice(bugs))]))
 
                     for table, cols in stat_map:
-                        fn = lambda x: type(x) == table
+                        fn = lambda x: isinstance(x, table)
                         for report_stat in filter(fn, current):
                             matching = True
                             for name, value in cols:

--- a/src/pyfaf/utils/decorators.py
+++ b/src/pyfaf/utils/decorators.py
@@ -57,7 +57,7 @@ def retry(tries, delay=3, backoff=2, verbose=False):
                         msg = traceback.format_exception(exc_type, exc_value,
                                                          exc_traceback)
 
-                        if type(msg) == list:
+                        if isinstance(msg, list):
                             msg = ''.join(msg)
 
                         print(msg)


### PR DESCRIPTION
`isinstance` built-in function is preferred to compare types.

Signed-off-by: Jan Beran <jberan@redhat.com>