### PR TITLE
py3 compatibility: Removal of tuple parameter unpacking

### DIFF
--- a/src/pyfaf/actions/mark_probably_fixed.py
+++ b/src/pyfaf/actions/mark_probably_fixed.py
@@ -99,7 +99,7 @@ class MarkProbablyFixed(Action):
                 for db_release in db_opsys.releases:
                     result.add((osplugin, db_release))
 
-        return sorted(result, key=lambda (p, r): (r.opsys.name, r.version))
+        return sorted(result, key=lambda p_r: (p_r[1].opsys.name, p_r[1].version))
 
     def _save_probable_fix(self, db, problem, db_release, probable_fix,
                            probably_fixed_since=None):

--- a/src/pyfaf/actions/pull_components.py
+++ b/src/pyfaf/actions/pull_components.py
@@ -91,7 +91,7 @@ class PullComponents(Action):
                 for db_release in db_opsys.releases:
                     result.add((osplugin, db_release))
 
-        return sorted(result, key=lambda (p, r): (r.opsys.name, r.version))
+        return sorted(result, key=lambda p_r: (p_r[1].opsys.name, p_r[1].version))
 
     def run(self, cmdline, db):
         try:

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -744,7 +744,10 @@ def prioritize_longterm_problems(min_fa, problem_tuples):
 
         problem.rank = rank / float(months)
 
-    return sorted(problem_tuples, key=lambda (problem, _, __): problem.rank,
+# Original Python 2 code:
+#   return sorted(problem_tuples, key=lambda (problem, _, __): problem.rank,
+#                 reverse=True)
+    return sorted(problem_tuples, key=lambda problem_____: problem_____[0].rank,
                   reverse=True)
 
 

--- a/src/pyfaf/utils/format.py
+++ b/src/pyfaf/utils/format.py
@@ -31,7 +31,7 @@ def as_table(headers, data, margin=1, separator=' '):
 
     widths = reduce(
         lambda x, y: map(
-            lambda (a, b): max(a, b), zip(x, y)
+            lambda a_b: max(a_b[0], a_b[1]), zip(x, y)
         ),
         map(lambda x: map(len, x), data) + [map(len, headers)],
         map(lambda _: 0, headers))


### PR DESCRIPTION
Replacement of `lambda (a, b): function(a, b)`
with `lambda a_b: function(a_b[0], a_b[1])` according to PEP 3113.

Signed-off-by: Jan Beran <jberan@redhat.com>