### PR TITLE
py3 compatibility: Replace StringIO and cStringIO modules with io module

### DIFF
--- a/src/pyfaf/utils/contextmanager.py
+++ b/src/pyfaf/utils/contextmanager.py
@@ -1,5 +1,12 @@
 import sys
-from StringIO import StringIO
+
+if sys.version_info.major == 2:
+#Python 2
+    from StringIO import StringIO
+else:
+#Python 3+
+    from io import StringIO
+
 from contextlib import contextmanager
 
 

--- a/src/webfaf/dumpdirs.py
+++ b/src/webfaf/dumpdirs.py
@@ -3,7 +3,14 @@ import re
 import tarfile
 import logging
 import datetime
-from cStringIO import StringIO
+import sys
+
+if sys.version_info.major == 2:
+#Python 2
+    from cStringIO import StringIO
+else:
+#Python 3
+    from io import StringIO
 
 from pyfaf.config import config, paths
 from flask import (Blueprint, render_template, request, abort, redirect,

--- a/tests/alembic
+++ b/tests/alembic
@@ -10,7 +10,15 @@ import faftests
 
 import os
 import inspect
-import cStringIO
+import sys
+
+if sys.version_info.major == 2:
+#Python 2
+    from cStringIO import StringIO as BytesIO
+else:
+#Python 3
+    from io import BytesIO
+
 from pyfaf.storage import migrations
 from alembic.config import Config
 from alembic import command
@@ -27,7 +35,7 @@ class AlembicTestCase(faftests.DatabaseCase):
         self.basic_fixtures()
 
     def test_alembic_head(self):
-        heads_ = cStringIO.StringIO()
+        heads_ = BytesIO()
         alembic_cfg = Config(stdout=heads_)
         alembic_cfg.set_main_option("script_location",
                                     os.path.dirname(inspect.getfile(migrations)))

--- a/tests/webfaf/dumpdirs
+++ b/tests/webfaf/dumpdirs
@@ -5,7 +5,15 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from StringIO import StringIO
+
+import sys
+if sys.version_info.major == 2:
+#Python 2
+    from StringIO import StringIO
+else:
+#Python 3
+    from io import StringIO
+
 from webfaftests import WebfafTestCase
 from pyfaf.config import paths, config
 

--- a/tests/webfaf/reports
+++ b/tests/webfaf/reports
@@ -6,7 +6,15 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from StringIO import StringIO
+
+import sys
+if sys.version_info.major == 2:
+#Python 2
+    from StringIO import StringIO
+else:
+#Python 3
+    from io import StringIO
+
 from webfaftests import WebfafTestCase
 
 from pyfaf.storage import InvalidUReport, Report, ReportHash, BzBug, ReportBz, Bugtracker, BzUser, BzBug


### PR DESCRIPTION
The `StringIO` and `cStringIO` modules are gone in Python 3.
Instead, import the `io` module and use `io.StringIO` or `io.BytesIO`
for text and data respectively.

Signed-off-by: Jan Beran <jberan@redhat.com>