### PR TITLE
py3 compatibility: Replacement of xrange with six.moves.range

### DIFF
--- a/src/pyfaf/actions/retrace.py
+++ b/src/pyfaf/actions/retrace.py
@@ -28,6 +28,7 @@ from pyfaf.retrace import (IncompleteTask,
                            RetraceTask,
                            RetraceWorker,
                            ssource2funcname)
+from six.moves import range
 
 class Retrace(Action):
     name = "retrace"
@@ -126,7 +127,7 @@ class Retrace(Action):
             total = len(tasks)
 
             workers = [RetraceWorker(i, inqueue, outqueue)
-                       for i in xrange(cmdline.workers)]
+                       for i in range(cmdline.workers)]
 
             for worker in workers:
                 self.log_debug("Spawning {0}".format(worker.name))

--- a/src/pyfaf/actions/retrace_remote.py
+++ b/src/pyfaf/actions/retrace_remote.py
@@ -24,6 +24,7 @@ from pyfaf.common import FafError
 from pyfaf.problemtypes import problemtypes
 from pyfaf.storage import Symbol
 from pyfaf.queries import get_symbol_by_name_path
+from six.moves import range
 
 
 class RetraceRemote(Action):
@@ -91,7 +92,7 @@ class RetraceRemote(Action):
                             continue
 
                         new_db_symbols = {}
-                        for j in xrange(len(res_data)):
+                        for j in range(len(res_data)):
                             data = res_data[j]
                             if data.get("error", False):
                                 self.log_info(data["error"])

--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -4,6 +4,7 @@ from pyfaf.common import FafError, log
 from pyfaf.queries import get_debug_files
 from pyfaf.rpm import unpack_rpm_to_tmp
 from pyfaf.utils.proc import safe_popen
+from six.moves import range
 
 # Instance of 'RootLogger' has no 'getChildLogger' member
 # Invalid name "log" for type constant
@@ -172,7 +173,7 @@ def addr2line(binary_path, address, debuginfo_dir):
     # eu-addr2line often finds the symbol if we decrement the address by one.
     # we try several addresses that maps to no file or to the same source file
     # and source line as the original address.
-    for addr_enh in xrange(0, 15):
+    for addr_enh in range(0, 15):
         if addr_enh > address:
             break
 

--- a/src/pyfaf/storage/__init__.py
+++ b/src/pyfaf/storage/__init__.py
@@ -27,6 +27,7 @@ from pyfaf.config import config
 import __main__
 import pkg_resources
 import six
+from six.moves import range
 __main__.__requires__ = __requires__ = []
 __requires__.append("SQLAlchemy >= 0.8.2")
 pkg_resources.require(__requires__)
@@ -66,7 +67,7 @@ class GenericTableBase(object):
         pkstr = self.pkstr()
         pkstr_long = pkstr
         while len(pkstr_long) < 5:
-            pkstr_long = "{0}{1}".format("".join(["0" for i in xrange(5 - len(pkstr_long))]), pkstr_long)
+            pkstr_long = "{0}{1}".format("".join(["0" for i in range(5 - len(pkstr_long))]), pkstr_long)
 
         lobdir = os.path.join(config["storage.lobdir"], classname, name,
                               pkstr_long[0:2], pkstr_long[2:4])

--- a/src/webfaf/utils.py
+++ b/src/webfaf/utils.py
@@ -17,6 +17,7 @@ from pyfaf.storage.report import (Report,
                                   ReportHistoryMonthly)
 from pyfaf.queries import user_is_maintainer
 from webfaf.webfaf_main import app
+from six.moves import range
 
 
 class Pagination(object):
@@ -94,9 +95,9 @@ def diff(lhs_seq, rhs_seq, eq=None):
     # in case where strings are the same r has value len(right) == r_e + 1
     j = r_e
 
-    for i in xrange(l, l_e + 1):
+    for i in range(l, l_e + 1):
         pos += 1  # skip first column which is always 0
-        for j in xrange(r, r_e + 1):
+        for j in range(r, r_e + 1):
             if eq(lhs_seq[i], rhs_seq[j]):
                 res = m[pos - matrix_row_len - 1] + 1
             else:


### PR DESCRIPTION
In Python 2, `range()` returns a list, and `xrange()` returns an iterator.
In Python 3, `range()` returns an iterator, and `xrange()` doesn’t exist.
The compatibility is solved by six library.

Signed-off-by: Jan Beran <jberan@redhat.com>