### PR TITLE
py3 compatibility: Replacement of basestring with six.string_types

### DIFF
--- a/src/pyfaf/actions/c2p.py
+++ b/src/pyfaf/actions/c2p.py
@@ -25,6 +25,7 @@ from pyfaf.queries import get_packages_by_file, get_packages_by_file_builds_arch
 from pyfaf.actions import Action
 from pyfaf.retrace import usrmove
 from pyfaf.utils.proc import safe_popen
+import six
 
 
 class Coredump2Packages(Action):
@@ -157,7 +158,7 @@ class Coredump2Packages(Action):
 
             if soname is None:
                 if (build_id in build_id_maps and
-                        isinstance(build_id_maps[build_id], basestring) and
+                        isinstance(build_id_maps[build_id], six.string_types) and
                         build_id_maps[build_id] in debuginfo_maps):
                     nvra = debuginfo_maps[build_id_maps[build_id]].nvra()
                     self.log_info("No shared object name for '{0}' ({1})"

--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -40,6 +40,7 @@ from pyfaf.storage.bugzilla import (BzBug,
                                     BzBugHistory)
 
 from pyfaf.bugtrackers import BugTracker
+import six
 
 __all__ = ["Bugzilla"]
 
@@ -594,7 +595,7 @@ class Bugzilla(BugTracker):
             new.user = user
             db.session.add(new)
 
-            if not isinstance(comment["text"], basestring):
+            if not isinstance(comment["text"], six.string_types):
                 comment["text"] = str(comment["text"])
 
             # save_lob is inherited method which cannot

--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -40,6 +40,7 @@ from pyfaf.storage import (Arch,
                            ReportUnknownPackage,
                            column_len)
 from pyfaf.utils.parse import str2bool
+import six
 
 
 __all__ = ["Fedora"]
@@ -312,7 +313,7 @@ class Fedora(System):
         Convert faf's release to branch name
         """
 
-        if not isinstance(release, basestring):
+        if not isinstance(release, six.string_types):
             release = str(release)
 
         # "rawhide" is called "master"

--- a/src/pyfaf/repos/yum.py
+++ b/src/pyfaf/repos/yum.py
@@ -24,6 +24,7 @@ import yum
 
 from pyfaf.common import get_temp_dir
 from pyfaf.repos import Repo
+import six
 
 
 class Yum(Repo):
@@ -54,7 +55,7 @@ class Yum(Repo):
         self.yum_base.repos.disableRepo("*")
 
         for i, url in enumerate(urls):
-            if isinstance(url, basestring):
+            if isinstance(url, six.string_types):
                 if url.startswith("/"):
                     url = "file://{0}".format(url)
                 # call str() on url, because if url is unicode,


### PR DESCRIPTION
`basestring` is an abstract type in Python 2, a superclass for both
`str` and `unicode` string types. In Python 3, there is only one
string type of `str`. The compatibility is solved by six library.

Signed-off-by: Jan Beran <jberan@redhat.com>