### PR TITLE
py3 compatibility: Replacement of iteritems with six.iteritems

### DIFF
--- a/src/pyfaf/utils/storage.py
+++ b/src/pyfaf/utils/storage.py
@@ -21,6 +21,7 @@
 
 import re
 from collections import defaultdict
+import six
 
 __all__ = ["format_reason", "most_common_crash_function"]
 
@@ -66,5 +67,5 @@ def most_common_crash_function(backtraces):
     for bt in backtraces:
         if bt.crash_function:
             crash_functions[bt.crash_function] += 1
-    result = max(crash_functions.iteritems(), key=lambda x: x[1])
+    result = max(six.iteritems(crash_functions), key=lambda x: x[1])
     return result[0]

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -23,6 +23,7 @@ from wtforms import (Form,
 
 from webfaf.forms import TagListField
 from webfaf.utils import Pagination, admin_required
+import six
 
 url_prefix = "/celery_tasks"
 
@@ -204,7 +205,7 @@ class ActionFormBase(Form):
 
     def to_cmdline_dict(self):
         res = {}
-        for name, kwargs in self.argparse_fields.iteritems():
+        for name, kwargs in six.iteritems(self.argparse_fields):
             data = getattr(self, name).data
             if kwargs.get("type"):
                 # Call the optional type processor, e.g. int
@@ -213,7 +214,7 @@ class ActionFormBase(Form):
         return res
 
     def from_cmdline_dict(self, cmdline):
-        for name, kwargs in self.argparse_fields.iteritems():
+        for name, kwargs in six.iteritems(self.argparse_fields):
             getattr(self, name).process_data(cmdline.get(name))
 
 


### PR DESCRIPTION
`six.iteritems()` replaces `dictionary.iteritems()` on Python 2
and `dictionary.items()` on Python 3.

Signed-off-by: Jan Beran <jberan@redhat.com>