### PR TITLE
py3 compatibility: Replace ConfigParser module with configparser

### DIFF
--- a/src/pyfaf/actions/repoimport.py
+++ b/src/pyfaf/actions/repoimport.py
@@ -17,7 +17,14 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import ConfigParser
+
+import sys
+if sys.version_info.major == 2:
+#Python 2
+    import ConfigParser as configparser
+else:
+#Python 3+
+    import configparser
 
 import pyfaf.repos
 from pyfaf.actions import Action
@@ -40,10 +47,10 @@ class RepoImport(Action):
         baseurl (required) and gpgcheck are stored.
         """
 
-        parser = ConfigParser.SafeConfigParser()
+        parser = configparser.SafeConfigParser()
         try:
             parser.readfp(fp)
-        except ConfigParser.Error as exc:
+        except configparser.Error as exc:
             self.log_error("Exception while parsing repository file: "
                            "'{0}'".format(exc))
             return None

--- a/src/pyfaf/config.py
+++ b/src/pyfaf/config.py
@@ -18,7 +18,15 @@
 
 import os
 import logging
-import ConfigParser
+
+import sys
+if sys.version_info.major == 2:
+#Python 2
+    import ConfigParser as configparser
+else:
+#Python 3+
+    import configparser
+
 from pyfaf.local import etc, var
 
 __all__ = ["config"]
@@ -47,7 +55,7 @@ def load_config_files(config_files):
     """
 
     result = {}
-    parser = ConfigParser.SafeConfigParser()
+    parser = configparser.SafeConfigParser()
     parser.read(config_files)
 
     for section in parser.sections():


### PR DESCRIPTION
The `ConfigParser` module of Python 2 is renamed to `configparser` in Python 3.

Signed-off-by: Jan Beran <jberan@redhat.com>