### PR TITLE
py3 compatibility: Replace cPickle module with pickle module

### DIFF
--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -16,7 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-import cPickle as pickle
+import sys
+if sys.version_info.major == 2:
+#Python 2
+    import cPickle as pickle
+else:
+#Python 3+
+    import pickle
+
 import json
 import os
 import urllib2

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -18,7 +18,14 @@
 
 from __future__ import unicode_literals
 
-import cPickle as pickle
+import sys
+if sys.version_info.major == 2:
+#Python 2
+    import cPickle as pickle
+else:
+#Python 3+
+    import pickle
+
 import os
 import shutil
 import satyr


### PR DESCRIPTION
The `cPickle` and `pickle` modules of Python 2 were merged in `pickle` module in Python 3.

Signed-off-by: Jan Beran <jberan@redhat.com>