### PR TITLE
 webfaf: add omitted </td> in backtrace table

### DIFF
--- a/src/webfaf/templates/_helpers.html
+++ b/src/webfaf/templates/_helpers.html
@@ -334,8 +334,9 @@
       {{ frame.symbolsource.line_number}}
     {%- endif %}
   {%- else %}
-    {{ frame.symbolsource.func_offset|memory_address or '-' }}</td>
+    {{ frame.symbolsource.func_offset|memory_address or '-' }}
   {%- endif %}
+</td>
 {%- endmacro %}
 
 {% macro show_backtrace(backtrace, type, oops) -%}


### PR DESCRIPTION
I noticed the lack of this, because I tried pasting the "invalid" HTML thru the jekyll blog engine.
Jekyll's markdown parser caused the entire table content to be hidden.
(This happens because jekyll ends up escaping the final `</table>`).