### PR TITLE
py3 compatibility: Replace xmlrpclib module with xmlrpc.client

### DIFF
--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -22,7 +22,13 @@ from __future__ import unicode_literals
 import time
 import datetime
 
-from xmlrpclib import Fault
+import sys
+if sys.version_info.major == 2:
+#Python 2
+    from xmlrpclib import Fault
+else:
+#Python 3+
+    from xmlrpc.client import Fault
 
 import bugzilla
 


### PR DESCRIPTION
The `xmlrpclib` module of Python 2 was moved in `xmlrpc.client` in Python 3.

Signed-off-by: Jan Beran <jberan@redhat.com>