### PR TITLE
py3 compatibility: Replace Queue module with queue module

### DIFF
--- a/src/pyfaf/actions/retrace.py
+++ b/src/pyfaf/actions/retrace.py
@@ -16,7 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-import Queue
+import sys
+if sys.version_info.major == 2:
+#Python 2
+    import Queue as queue
+else:
+#Python 3+
+    import queue
+
 import collections
 import multiprocessing
 
@@ -123,7 +130,7 @@ class Retrace(Action):
                     self.log_debug(str(ex))
 
             inqueue = collections.deque(tasks)
-            outqueue = Queue.Queue(cmdline.workers)
+            outqueue = queue.Queue(cmdline.workers)
             total = len(tasks)
 
             workers = [RetraceWorker(i, inqueue, outqueue)
@@ -139,7 +146,7 @@ class Retrace(Action):
                     wait = any(w.is_alive() for w in workers)
                     try:
                         task = outqueue.get(wait, 1)
-                    except Queue.Empty:
+                    except queue.Empty:
                         if any(w.is_alive() for w in workers):
                             continue
 

--- a/tests/rpm_metadata
+++ b/tests/rpm_metadata
@@ -9,7 +9,15 @@ except ImportError:
 import os
 import glob
 import time
-import Queue
+
+import sys
+if sys.version_info.major == 2:
+#Python 2
+    import Queue as queue
+else:
+#Python 3+
+    import queue
+
 import shutil
 import logging
 import tempfile
@@ -54,7 +62,7 @@ class DummyHTTPServerThread(threading.Thread):
 
         self.port = port
         self._stop = threading.Event()
-        self.rqueue = Queue.Queue()
+        self.rqueue = queue.Queue()
         DummyHTTPServerThread.Handler.directory = directory
         DummyHTTPServerThread.Handler.requests = 0
 


### PR DESCRIPTION
The `Queue` module of Python 2 was renamed to `queue` module in Python 3.

Signed-off-by: Jan Beran <jberan@redhat.com>