### PR TITLE
py3 compatibility: Replace filter function with a list equivalent

### DIFF
--- a/src/pyfaf/actions/stats.py
+++ b/src/pyfaf/actions/stats.py
@@ -289,8 +289,8 @@ class Stats(Action):
                                  last_date=since)
 
         if not cmdline.include_low_quality:
-            hot = filter(lambda x: x.quality >= 0, hot)
-        hot = filter(lambda p: p.type in self.ptypes, hot)
+            hot = [x for x in hot if x.quality >= 0]
+        hot = [p for p in hot if p.type in self.ptypes]
 
         out = ""
         if hot:
@@ -304,8 +304,8 @@ class Stats(Action):
 
         lt = query_longterm_problems(db, release_ids, history=self.history_type)
         if not cmdline.include_low_quality:
-            lt = filter(lambda x: x.quality >= 0, lt)
-        lt = filter(lambda p: p.type in self.ptypes, lt)
+            lt = [x for x in lt if x.quality >= 0]
+        lt = [p for p in lt if p.type in self.ptypes]
 
         if lt:
             out += "Long-term problems:\n\n"
@@ -358,7 +358,7 @@ class Stats(Action):
                                  last_date=since)
 
         if not cmdline.include_low_quality:
-            hot = filter(lambda x: x.quality >= 0, hot)
+            hot = [x for x in hot if x.quality >= 0]
 
         ptypes = ""
         if len(self.ptypes) != len(problemtypes):
@@ -366,7 +366,7 @@ class Stats(Action):
         out = "Overview of the top {0}{1} crashes over the last {2} days:\n".format(
             cmdline.count, ptypes, num_days)
 
-        hot = filter(lambda p: p.type in self.ptypes, hot)
+        hot = [p for p in hot if p.type in self.ptypes]
 
         for (rank, problem) in enumerate(hot[:cmdline.count]):
             out += "#{0} {1} - {2}x\n".format(
@@ -376,7 +376,7 @@ class Stats(Action):
 
             # Reports with bugzillas for this OpSysRelease go first
             reports = sorted(problem.reports,
-                             cmp=lambda x, y: len(filter(lambda b: b.opsysrelease_id in release_ids, x.bugs)) - len(filter(lambda b: b.opsysrelease_id in release_ids, y.bugs)),
+                             cmp=lambda x, y: len([b for b in x.bugs if b.opsysrelease_id in release_ids]) - len([b for b in y.bugs if b.opsysrelease_id in release_ids]),
                              reverse=True)
 
             if webfaf_installed():

--- a/src/pyfaf/config.py
+++ b/src/pyfaf/config.py
@@ -44,9 +44,8 @@ def get_config_files(directory):
     and return their full paths.
     """
 
-    return filter(lambda fname: fname.endswith(CONFIG_FILE_SUFFIX),
-                  [os.path.abspath(os.path.join(directory, filename))
-                   for filename in os.listdir(directory)])
+    return [fname for fname in [os.path.abspath(os.path.join(directory, filename))
+                   for filename in os.listdir(directory)] if fname.endswith(CONFIG_FILE_SUFFIX)]
 
 
 def load_config_files(config_files):

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -179,7 +179,7 @@ class KerneloopsProblem(ProblemType):
             taintflags = []
 
         if skip_unreliable:
-            frames = filter(lambda f: f["reliable"], koops)
+            frames = [f for f in koops if f["reliable"]]
         else:
             frames = koops
 

--- a/src/pyfaf/solutionfinders/__init__.py
+++ b/src/pyfaf/solutionfinders/__init__.py
@@ -166,7 +166,7 @@ def find_solutions_report(report, db=None, finders=None, osr=None):
             sorted_solutions += solution_list[1]
 
         # Make sure all solutions are proper
-        return filter(lambda s: hasattr(s, "cause"), sorted_solutions)
+        return [s for s in sorted_solutions if hasattr(s, "cause")]
     else:
         return None
 

--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -60,8 +60,7 @@ class OpSys(GenericTable):
 
     @property
     def active_releases(self):
-        return filter(lambda release: release.status == 'ACTIVE',
-                      self.releases)
+        return [release for release in self.releases if release.status == 'ACTIVE']
 
 
 class Url(GenericTable):


### PR DESCRIPTION
In Python 2, `filter(function, iterable)` returns a list and is equivalent
to `[item for item in iterable if function(item)]` if function is not `None`
and `[item for item in iterable if item]` if function is `None`. In Python 3,
the function returns an iterator. The replacement of Python 2 `filter`
function with a proper equivalent solves the Python 3 compatibility.

Signed-off-by: Jan Beran <jberan@redhat.com>