### PR TITLE
py3 compatibility: Ensure map function to return a list

### DIFF
--- a/src/pyfaf/storage/fixtures/data.py
+++ b/src/pyfaf/storage/fixtures/data.py
@@ -73,6 +73,6 @@ COMPS = {
     }
 
 _LIBS = ['gtk', 'gdk', 'dbus', 'xul', 'GL', 'jvm', 'freetype']
-LIBS = map(lambda x: 'lib%s' % x, _LIBS)
+LIBS = ['lib%s' % x for x in _LIBS]
 
 FUNS = dir(__builtins__)

--- a/src/pyfaf/storage/problem.py
+++ b/src/pyfaf/storage/problem.py
@@ -96,7 +96,7 @@ class Problem(GenericTable):
 
     @property
     def reports_count(self):
-        return sum(map(lambda x: x.count, self.reports))
+        return sum([x.count for x in self.reports])
 
     @property
     def quality(self):
@@ -123,7 +123,7 @@ class Problem(GenericTable):
         '''
         List of all backtraces assigned to this problem.
         '''
-        return sum(map(lambda x: x.backtraces, self.reports), [])
+        return sum([x.backtraces for x in self.reports], [])
 
     @property
     def sorted_backtraces(self):
@@ -198,7 +198,7 @@ class Problem(GenericTable):
         """
         List of list of all ReportURLs assigned to this problem.
         """
-        urls = [x for x in map(lambda x: x.urls, self.reports) if x]
+        urls = [x for x in [x.urls for x in self.reports] if x]
         urls.sort(key=lambda x: x[0].saved, reverse=True)
         return urls
 

--- a/src/pyfaf/utils/format.py
+++ b/src/pyfaf/utils/format.py
@@ -27,15 +27,13 @@ def as_table(headers, data, margin=1, separator=' '):
     Return `headers` and `data` lists formatted as table.
     '''
 
-    headers = map(str, headers)
-    data = map(lambda x: map(str, x), data)
+    headers = list(map(str, headers))
+    data = [map(str, x) for x in data]
 
     widths = reduce(
-        lambda x, y: map(
-            lambda a_b: max(a_b[0], a_b[1]), list(zip(x, y))
-        ),
-        map(lambda x: map(len, x), data) + [map(len, headers)],
-        map(lambda _: 0, headers))
+        lambda x, y: [max(a_b[0], a_b[1]) for a_b in list(zip(x, y))],
+        [map(len, x) for x in data] + [map(len, headers)],
+        [0 for _ in headers])
 
     fmt = ''
     for num, width in enumerate(widths):
@@ -44,4 +42,4 @@ def as_table(headers, data, margin=1, separator=' '):
 
     # Used * or ** magic
     # pylint: disable-msg=W0142
-    return ''.join(map(lambda row: fmt.format(*row), [headers] + data))
+    return ''.join([fmt.format(*row) for row in [headers] + data])

--- a/src/pyfaf/utils/proc.py
+++ b/src/pyfaf/utils/proc.py
@@ -30,7 +30,7 @@ def popen(cmd, *args):
     the execution is over, return
     Popen object.
     """
-    args = map(str, args)
+    args = list(map(str, args))
 
     proc = subprocess.Popen([cmd] + args, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,

--- a/src/webfaf/config.py
+++ b/src/webfaf/config.py
@@ -15,8 +15,7 @@ class Config(object):
     SQLALCHEMY_DATABASE_URI = dburl
     OPENID_ENABLED = str2bool(config.get("openid.enabled", "false"))
     OPENID_FS_STORE = os.path.join(paths["spool"], "openid_store")
-    OPENID_PRIVILEGED_TEAMS = map(lambda s: s.strip(),
-                                  config.get("openid.privileged_teams", "").split(","))
+    OPENID_PRIVILEGED_TEAMS = [s.strip() for s in config.get("openid.privileged_teams", "").split(",")]
     PROXY_SETUP = False
     MAX_CONTENT_LENGTH = int(config["dumpdir.maxdumpdirsize"])
     RSTPAGES_SRC = os.path.join(WEBFAF_DIR, "templates")

--- a/src/webfaf/forms.py
+++ b/src/webfaf/forms.py
@@ -99,13 +99,12 @@ def component_names_to_ids(component_names):
     """
     component_ids = []
     if component_names:
-        component_names = map(lambda x: x.strip(),
-                              component_names.split(','))
+        component_names = [x.strip() for x in component_names.split(',')]
         if len(component_names) > 0 and len(component_names[0]) > 0:
-            component_ids = map(itemgetter(0),
+            component_ids = list(map(itemgetter(0),
                                 (db.session.query(OpSysComponent.id)
                                  .filter(OpSysComponent.name.in_(component_names))
-                                 .all()))
+                                 .all())))
 
         # Some components were searched for but non was found in DB
         if not component_ids:


### PR DESCRIPTION
`map()` built-in function returns a list on Python 2, but an iterator
on Python 3. In some context, the problem is solved by adding the `list()`
function. If the first argument to `map()` is a lambda function, then it
is converted to an equivalent list comprehension.

Signed-off-by: Jan Beran <jberan@redhat.com>