### PR TITLE
py3 compatibility: Adjust imports

### DIFF
--- a/src/pyfaf/__init__.py
+++ b/src/pyfaf/__init__.py
@@ -20,29 +20,29 @@ __all__ = ["checker", "cmdline", "common", "config", "local",
            "queries", "retrace", "rpm", "ureport", "utils", "actions",
            "bugtrackers", "opsys", "problemtypes", "repos"]
 
-import checker
-import cmdline
-import common
-import config
-import local
-import queries
+from . import checker
+from . import cmdline
+from . import common
+from . import config
+from . import local
+from . import queries
 # soft dep on retrace - it pulls elfutils
 # No exception type(s) specifiedo exception type(s) specified
 # pylint: disable-msg=W0702
 try:
-    import retrace
+    from . import retrace
 except:
     # Invalid name "retrace" for type constant
     # pylint: disable-msg=C0103
     retrace = None
     # pylint: enable-msg=C0103
 # pylint: enable-msg=W0702
-import rpm
-import ureport
-import utils
+from . import rpm
+from . import ureport
+from . import utils
 
-import actions
-import bugtrackers
-import opsys
-import problemtypes
-import repos
+from . import actions
+from . import bugtrackers
+from . import opsys
+from . import problemtypes
+from . import repos

--- a/src/pyfaf/storage/__init__.py
+++ b/src/pyfaf/storage/__init__.py
@@ -169,20 +169,20 @@ GenericTable = declarative_base(cls=GenericTableBase)
 # all derived tables
 # must be ordered - the latter may require the former
 # ToDo: rewrite with import_dir
-from project import *
-from opsys import *
-from symbol import *
-from problem import *
-from bugtracker import *
-from bugzilla import *
-from mantisbt import *
-from externalfaf import *
-from report import *
-from llvm import *
-from sf_prefilter import *
-from debug import *
-from user import *
-from task import *
+from .project import *
+from .opsys import *
+from .symbol import *
+from .problem import *
+from .bugtracker import *
+from .bugzilla import *
+from .mantisbt import *
+from .externalfaf import *
+from .report import *
+from .llvm import *
+from .sf_prefilter import *
+from .debug import *
+from .user import *
+from .task import *
 
 
 def column_len(cls, name):

--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from custom_types import Semver
+from .custom_types import Semver
 from . import Boolean
 from . import Column
 from . import DateTime

--- a/src/webfaf/dumpdirs.py
+++ b/src/webfaf/dumpdirs.py
@@ -17,13 +17,13 @@ from flask import (Blueprint, render_template, request, abort, redirect,
                    url_for, flash, jsonify)
 from werkzeug import secure_filename
 from werkzeug.wrappers import Response
-from utils import admin_required, InvalidUsage, request_wants_json
+from webfaf.utils import admin_required, InvalidUsage, request_wants_json
 
 
 dumpdirs = Blueprint("dumpdirs", __name__)
 logger = logging.getLogger("webfaf.dumpdirs")
 
-from forms import NewDumpDirForm
+from webfaf.forms import NewDumpDirForm
 
 
 def check_filename(fn):

--- a/src/webfaf/forms.py
+++ b/src/webfaf/forms.py
@@ -344,4 +344,4 @@ class AssociateBzForm(Form):
 
 
 # has to be at the end to avoid circular imports
-from webfaf_main import db
+from webfaf.webfaf_main import db

--- a/src/webfaf/hub.wsgi
+++ b/src/webfaf/hub.wsgi
@@ -15,6 +15,6 @@ logging.basicConfig(stream=sys.stderr)
 os.environ["WEBFAF_ENVIRON_PRODUCTION"] = "1"
 sys.path.insert(0, os.path.dirname(__file__))
 
-from webfaf_main import app as application
-from webfaf_main import import_blueprint_plugins
+from webfaf.webfaf_main import app as application
+from webfaf.webfaf_main import import_blueprint_plugins
 import_blueprint_plugins(application)

--- a/src/webfaf/login.py
+++ b/src/webfaf/login.py
@@ -7,8 +7,8 @@ from pyfaf.storage.user import User
 login = flask.Blueprint("login", __name__)
 
 
-from webfaf_main import db, oid, app
-from utils import fed_raw_name
+from webfaf.webfaf_main import db, oid, app
+from webfaf.utils import fed_raw_name
 
 
 @login.route("/login/", methods=["GET"])

--- a/src/webfaf/problems.py
+++ b/src/webfaf/problems.py
@@ -26,9 +26,9 @@ from sqlalchemy.sql import text
 
 problems = Blueprint("problems", __name__)
 
-from webfaf_main import db
-from forms import ProblemFilterForm, BacktraceDiffForm, component_names_to_ids
-from utils import (request_wants_json, metric,
+from webfaf.webfaf_main import db
+from webfaf.forms import ProblemFilterForm, BacktraceDiffForm, component_names_to_ids
+from webfaf.utils import (request_wants_json, metric,
                    is_problem_maintainer, stream_template)
 
 

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -58,7 +58,7 @@ from pyfaf import queries
 from flask import (Blueprint, render_template, request, abort, redirect,
                    url_for, flash, jsonify, g)
 from sqlalchemy import literal, desc, or_
-from utils import (Pagination,
+from webfaf.utils import (Pagination,
                    diff as seq_diff,
                    InvalidUsage,
                    metric,
@@ -68,8 +68,8 @@ from utils import (Pagination,
 
 reports = Blueprint("reports", __name__)
 
-from webfaf_main import db, flask_cache
-from forms import (ReportFilterForm, NewReportForm, NewAttachmentForm,
+from webfaf.webfaf_main import db, flask_cache
+from webfaf.forms import (ReportFilterForm, NewReportForm, NewAttachmentForm,
                    component_names_to_ids, AssociateBzForm)
 
 

--- a/src/webfaf/stats.py
+++ b/src/webfaf/stats.py
@@ -1,12 +1,12 @@
 import datetime
 
 from pyfaf import queries
-from utils import cache, request_wants_json
+from webfaf.utils import cache, request_wants_json
 
 from flask import (Blueprint, render_template, abort, redirect,
                    url_for, jsonify)
 
-from webfaf_main import db
+from webfaf.webfaf_main import db
 import six
 
 stats = Blueprint("stats", __name__)

--- a/src/webfaf/summary.py
+++ b/src/webfaf/summary.py
@@ -8,9 +8,9 @@ from sqlalchemy import func
 
 summary = Blueprint("summary", __name__)
 
-from webfaf_main import db, flask_cache
-from forms import SummaryForm, component_names_to_ids
-from utils import date_iterator
+from webfaf.webfaf_main import db, flask_cache
+from webfaf.forms import SummaryForm, component_names_to_ids
+from webfaf.utils import date_iterator
 
 
 def index_plot_data_cache(summary_form):

--- a/src/webfaf/webfaf_main.py
+++ b/src/webfaf/webfaf_main.py
@@ -48,18 +48,18 @@ if app.config["OPENID_ENABLED"]:
     from flask_openid import OpenID
     from openid_teams import teams
     oid = OpenID(app, safe_roots=[], extension_responses=[teams.TeamsResponse])
-    from login import login
+    from webfaf.login import login
     app.register_blueprint(login)
 
-from dumpdirs import dumpdirs
+from webfaf.dumpdirs import dumpdirs
 app.register_blueprint(dumpdirs, url_prefix="/dumpdirs")
-from reports import reports
+from webfaf.reports import reports
 app.register_blueprint(reports, url_prefix="/reports")
-from problems import problems
+from webfaf.problems import problems
 app.register_blueprint(problems, url_prefix="/problems")
-from stats import stats
+from webfaf.stats import stats
 app.register_blueprint(stats, url_prefix="/stats")
-from summary import summary
+from webfaf.summary import summary
 app.register_blueprint(summary, url_prefix="/summary")
 
 
@@ -104,13 +104,13 @@ app.context_processor(lambda: dict(
     current_menu=LocalProxy(lambda: current_app.extensions.get(
         "menu", {"public": [], "admin": []}))))
 
-from filters import problem_label, fancydate, timestamp, memory_address
+from webfaf.filters import problem_label, fancydate, timestamp, memory_address
 app.jinja_env.filters['problem_label'] = problem_label
 app.jinja_env.filters['fancydate'] = fancydate
 app.jinja_env.filters['timestamp'] = timestamp
 app.jinja_env.filters['memory_address'] = memory_address
 
-from utils import cache, fed_raw_name, WebfafJSONEncoder
+from webfaf.utils import cache, fed_raw_name, WebfafJSONEncoder
 app.json_encoder = WebfafJSONEncoder
 
 

--- a/tests/sample_plugin_dir/_noplugin.py
+++ b/tests/sample_plugin_dir/_noplugin.py
@@ -1,4 +1,4 @@
-from base import Base
+from .base import Base
 
 
 class NSub(Base):

--- a/tests/sample_plugin_dir/plugin.py
+++ b/tests/sample_plugin_dir/plugin.py
@@ -1,4 +1,4 @@
-from base import Base
+from .base import Base
 
 
 class Sub(Base):

--- a/tests/webfaf/webfaftests/__init__.py
+++ b/tests/webfaf/webfaftests/__init__.py
@@ -12,7 +12,7 @@ sys.path.insert(0, webfaf_path)
 os.environ["PATH"] = "{0}:{1}".format(webfaf_path, os.environ["PATH"])
 
 import faftests
-from webfaf_main import app
+from webfaf.webfaf_main import app
 
 
 class WebfafTestCase(faftests.DatabaseCase):


### PR DESCRIPTION
In Python 3, imports can be either absolute or explicitly relative;
implicit relative imports are forbidden.

Signed-off-by: Jan Beran <jberan@redhat.com>