### PR TITLE
add pylintrc to tar.gz

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,8 @@ SUBDIRS = config src tests
 EXTRA_DIST = autogen.sh gen-version faf-version faf.spec.in \
              init-scripts/faf-celery-beat.service \
              init-scripts/faf-celery-worker.service \
-             init-scripts/faf-celery-tmpfiles.conf
+             init-scripts/faf-celery-tmpfiles.conf \
+             pylintrc
 
 
 


### PR DESCRIPTION
so it can be actually used during buildtime