### PR TITLE
Refactoring: Remove superfluous parens

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -37,7 +37,7 @@ load-plugins=
 # W0141 = Used builtin function 'filter'
 # W0201 = Attribute defined outside __init__
 # R0201 = Method could be a function
-disable=W0141,W0201,R0201,too-few-public-methods,invalid-name,missing-docstring
+disable=W0141,W0201,R0201,too-few-public-methods,invalid-name,missing-docstring,superfluous-parens
 
 
 [REPORTS]

--- a/src/pyfaf/actions/hash_paths.py
+++ b/src/pyfaf/actions/hash_paths.py
@@ -51,7 +51,7 @@ class HashPaths(Action):
             symbol.normalized_path = hash_path(symbol.normalized_path,
                                                self.prefixes)
 
-            if not (c % 1000):
+            if not c % 1000:
                 db.session.flush()
 
         db.session.flush()

--- a/src/pyfaf/opsys/centos.py
+++ b/src/pyfaf/opsys/centos.py
@@ -163,11 +163,11 @@ class CentOS(System):
         CentOS.packages_checker.check(packages)
         affected = False
         for package in packages:
-            if ("package_role" in package):
-                if (package["package_role"] not in CentOS.pkg_roles):
+            if "package_role" in package:
+                if package["package_role"] not in CentOS.pkg_roles:
                     raise FafError("Only the following package roles are allowed: "
                                    "{0}".format(", ".join(CentOS.pkg_roles)))
-                if (package["package_role"] == "affected"):
+                if package["package_role"] == "affected":
                     affected = True
 
         if not(affected or self.allow_unpackaged):

--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -183,11 +183,11 @@ class Fedora(System):
         affected = False
         Fedora.packages_checker.check(packages)
         for package in packages:
-            if ("package_role" in package):
-                if (package["package_role"] not in Fedora.pkg_roles):
+            if "package_role" in package:
+                if package["package_role"] not in Fedora.pkg_roles:
                     raise FafError("Only the following package roles are allowed: "
                                    "{0}".format(", ".join(Fedora.pkg_roles)))
-                if (package["package_role"] == "affected"):
+                if package["package_role"] == "affected":
                     affected = True
 
         if not (affected or self.allow_unpackaged):
@@ -261,7 +261,7 @@ class Fedora(System):
         url = self.pagure_url + "/rpms/{0}".format(component)
 
         response = json.load(urllib.urlopen(url))
-        if ("error" in response):
+        if "error" in response:
             self.log_error("Unable to get package information for component"
                            " {0}, error was: {1}".format(component, response["error"]))
             return result
@@ -273,7 +273,7 @@ class Fedora(System):
         # Check for watchers
         url += "/watchers"
         response = json.load(urllib.urlopen(url))
-        if ("error" in response):
+        if "error" in response:
             self.log_error("Unable to get package information for component"
                            " {0}, error was: {1}".format(component, response["error"]))
             return result

--- a/src/pyfaf/ureport.py
+++ b/src/pyfaf/ureport.py
@@ -607,7 +607,7 @@ def is_known(ureport, db, return_report=False, opsysrelease_id=None):
 
         found = True
 
-    elif (not known_type):
+    elif not known_type:
         bzs = get_reportbz(db, report.id, opsysrelease_id).all()
         for bz in bzs:
             if not bz.bzbug.private:

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -375,7 +375,7 @@ def item(report_id, want_object=False):
     executable = (db.session.query(ReportExecutable.path)
                   .filter(ReportExecutable.report_id == report_id)
                   .first())
-    if (executable):
+    if executable:
         executable = executable[0]
     else:
         executable = "unknown"
@@ -827,7 +827,7 @@ def new():
                         data["os"]["name"] not in systems and
                         data["os"]["name"].lower() not in systems):
                     _save_unknown_opsys(db, data["os"])
-                if (str(exp) == 'uReport must contain affected package'):
+                if str(exp) == 'uReport must contain affected package':
                     raise InvalidUsage(("Server is not accepting problems "
                                         "from unpackaged files."), 400)
                 raise InvalidUsage("uReport data is invalid.", 400)


### PR DESCRIPTION
Removal of needless parentheses according to `pylint`.

Signed-off-by: Jan Beran <jberan@redhat.com>