### PR TITLE
pull_reports: Update method name

### DIFF
--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -130,7 +130,7 @@ class PullReports(Action):
 
         filename = os.path.join(self.incoming_dir, name)
         while os.path.isfile(filename):
-            filename = os.path.join(self.incoming_dir, uuid.uuid4().get_hex())
+            filename = os.path.join(self.incoming_dir, uuid.uuid4().hex)
 
         with open(filename, "w") as f:
             f.write(ureport)
@@ -158,7 +158,7 @@ class PullReports(Action):
 
                 filename = os.path.join(self.incoming_dir, report)
                 while os.path.isfile(filename):
-                    filename = os.path.join(self.incoming_dir, uuid.uuid4().get_hex())
+                    filename = os.path.join(self.incoming_dir, uuid.uuid4().hex)
 
                 with open(filename, "w") as f:
                     f.write(ureport)


### PR DESCRIPTION
In python2 version of uuid there is method `get_hex()` as well as
property `hex` which do the same. In python3 version the method was
removed.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>