### PR TITLE
py3: Exception does not have message member

### DIFF
--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -181,7 +181,7 @@ class Bugzilla(BugTracker):
 
                 except Exception as e:
                     self.log_error("Exception after multiple attempts: {0}."
-                                   " Ignoring".format(e.message))
+                                   " Ignoring".format(e))
                     continue
 
                 count = len(result)


### PR DESCRIPTION
```
try:
    raise Exception("ABC")
except Exception as e:
    print(e)
    print(e.message)
```

In python2 the above code prints:
```
ABC
ABC
```
but in python3 it prints:
```
ABC   <---------------- print(e)
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
Exception: ABC

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
AttributeError: 'Exception' object has no attribute 'message'
```

Signed-off-by: Matej Marusak <mmarusak@redhat.com>