### PR TITLE
save-reports: Enable matching reports to save

### DIFF
--- a/tests/save_reports
+++ b/tests/save_reports
@@ -57,6 +57,17 @@ class ActionsTestCase(faftests.DatabaseCase):
         self.assertEqual(self.call_action("save-reports"), 0)
         self.after_save_reports()
 
+    def test_save_by_pattern(self):
+        self.assertEqual(self.call_action("save-reports", {"pattern": "ureport1*"}), 0)
+        self.assertEqual(self.db.session.query(Report).count(), 1)
+        self.assertEqual(self.call_action("save-reports", {"pattern": "foobar"}), 0)
+        self.assertEqual(self.db.session.query(Report).count(), 1)
+        self.assertEqual(self.call_action("save-reports", {"pattern": "ureport_k*"}), 0)
+        self.assertEqual(self.db.session.query(Report).count(), 3)
+        self.assertEqual(self.call_action("save-reports", {"pattern": "*"}), 0)
+        self.after_save_reports()
+
+
     def test_save_reports_speedup(self):
         self.assertEqual(self.call_action("save-reports", {"speedup": ""}), 0)
         self.after_save_reports()


### PR DESCRIPTION
This may be helpful when there is way to many reports to process. `--speedup` takes way too long to lock files and also only one process works on saving.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>