### PR TITLE
Fix codespell issues

### DIFF
--- a/config/faf.conf.in
+++ b/config/faf.conf.in
@@ -40,7 +40,7 @@ AcceptAttachments = fedora-bugzilla rhel-bugzilla centos-mantisbt
 # not packaged
 allow-unpackaged = False
 
-# Determines which strategy will be used for searching known or uknown ureport's
+# Determines which strategy will be used for searching known or unknown ureport's
 # and bugzilla bug's, if known is empty, then is used BUG_OS_MINOR_VERSION
 #
 # BUG_OS_MAJOR_VERSION - The report has attached a bug with equivalent OS Major

--- a/config/plugins/fedmsg.conf
+++ b/config/plugins/fedmsg.conf
@@ -1,7 +1,7 @@
 [fedmsg]
 # you must have the endpoint configured
 name = fedora-infrastructure
-# enviroment can be one of "prod", "stg" or "dev"
+# environment can be one of "prod", "stg" or "dev"
 environment = dev
 # Realtime notifications
 realtime_reports = false

--- a/docs/fixture_notes
+++ b/docs/fixture_notes
@@ -15,7 +15,7 @@ Real-world fixtures are also usable for
 retracing and backtrace processing, they
 contain real data (components, builds, rpms, tags, ..).
 
-These data are partialy stored in SQL files
+These data are partially stored in SQL files
 `pyfaf/storage/fixtures/sql` directory. As we also need
 RPM files to test retracing and uReport handling, these
 are packed and stored in some other location than git.

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -1108,7 +1108,7 @@ fi
 - reposync: Do not exit when cannot process one repo
 - webfaf: Better display executable
 - Fix url to FAF report in FedMsg notification
-- save-reports: saving unkonwn components configurable
+- save-reports: saving unknown components configurable
 - actions: Speed up assign_release_to_builds
 - tests: Add test for action cleanup_unassigned
 
@@ -1323,7 +1323,7 @@ fi
 - spec: require PostgreSQL
 - tests: use PostgreSQL for testing
 - webfaf2: show error_name in reports.item
-- pyfaf: add nice error_name propert to Report
+- pyfaf: add nice error_name property to Report
 - pyfaf: python, only update errname with a valid exception name
 - webfaf2: fix error related to package counts in problems.item
 - webfaf2: proper error when report not found by bthash
@@ -1371,7 +1371,7 @@ fi
 - pyfaf: always create new backtrace for report if it has none
 - pyfaf: pass count parameter to os and problem plugins save_ureport
 - webfaf2: add problem filter by type
-- webfaf2: add exclude taint flag fitler to problems.list
+- webfaf2: add exclude taint flag filter to problems.list
 - pyfaf: convert {} to {<number>} in str.format for Python 2.6
 - tests: add test for probable fix solution finder
 - pyfaf: don't return a solution if affected package is newer than prob. fix
@@ -1416,7 +1416,7 @@ fi
 - tests: fix unittest2 / unittest breakage
 - pyfaf: correct saving of pratially invalid version 1 ureports
 - c2p: also skip PAE and debug kernels
-- webfaf2: add missing db paramters in reports.new
+- webfaf2: add missing db parameters in reports.new
 - webui2: remove nonexistent problem.js
 - add report.crash_function, introduce utils/storage
 - webfaf2: add component and crash fn to title

--- a/src/pyfaf/actions/__init__.py
+++ b/src/pyfaf/actions/__init__.py
@@ -52,7 +52,7 @@ class Action(Plugin):
 
     def run(self, cmdline, db, *args, **kwargs):
         """
-        The actual code to execute. Needs to be overriden in subclasses.
+        The actual code to execute. Needs to be overridden in subclasses.
         """
 
         raise NotImplementedError("The `run` method is not implemented in {0} "

--- a/src/pyfaf/actions/assign_release_to_builds.py
+++ b/src/pyfaf/actions/assign_release_to_builds.py
@@ -28,7 +28,7 @@ class AssignReleaseToBuilds(Action):
 
     def __init__(self):
         super(AssignReleaseToBuilds, self).__init__()
-        self.uncommited = 0
+        self.uncommitted = 0
 
     def run(self, cmdline, db):
         # nobody will write the full name
@@ -136,9 +136,9 @@ class AssignReleaseToBuilds(Action):
             bosra.arch = arch
 
             db.session.add(bosra)
-            self.uncommited += 1
-            if self.uncommited > 1000:
-                self.uncommited = 0
+            self.uncommitted += 1
+            if self.uncommitted > 1000:
+                self.uncommitted = 0
                 db.session.flush()
 
 

--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -108,7 +108,7 @@ class CreateProblems(Action):
 
                 thread_sets.add(thread_set)
 
-            # Assing clusters to not yet processed threads
+            # Assign clusters to not yet processed threads
             if 1 <= len(detached_threads) <= max_cluster_size:
                 for thread in detached_threads:
                     thread_map[thread] = detached_threads

--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -225,7 +225,7 @@ class RepoSync(Action):
                         self.log_info("Downloading {0}".format(pkg["url"]))
                         self._download(package, "package", pkg["url"])
                     except Exception as exc:
-                        self.log_error("Exception ({0}) after multiple attemps"
+                        self.log_error("Exception ({0}) after multiple attempts"
                                        " while trying to download {1},"
                                        " skipping.".format(exc, pkg["url"]))
 

--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -228,7 +228,7 @@ class Bugzilla(BugTracker):
                        "{1} and {2}, offset is: {3}".format(target, from_date,
                                                             to_date, offset))
 
-        que = dict(
+        queue = dict(
             chfieldto=to_date.strftime("%Y-%m-%d"),
             chfieldfrom=from_date.strftime("%Y-%m-%d"),
             query_format="advanced",
@@ -236,10 +236,10 @@ class Bugzilla(BugTracker):
             offset=offset,
         )
 
-        que.update(custom_fields)
+        queue.update(custom_fields)
 
         self._connect()
-        return self.bz.query(que)
+        return self.bz.query(queue)
 
     def _convert_datetime(self, bz_datetime):
         """

--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -41,7 +41,7 @@ RE_PLUGIN_NAME = re.compile(r"^[a-zA-Z0-9\-]+$")
 
 class FafLogger(logging.Logger, object):
     """
-    Custom logger class with explicitely defined getChildLogger method.
+    Custom logger class with explicitly defined getChildLogger method.
     We need this because Python 2.6 does not support getChild.
     """
 

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -799,7 +799,7 @@ def get_problem_component(db, db_problem, db_component):
 
 def get_release_ids(db, opsys_name=None, opsys_version=None):
     """
-    Return list of `OpSysRelease` ids optionaly filtered
+    Return list of `OpSysRelease` ids optionally filtered
     by `opsys_name` and `opsys_version`.
     """
 
@@ -809,7 +809,7 @@ def get_release_ids(db, opsys_name=None, opsys_version=None):
 
 def get_releases(db, opsys_name=None, opsys_version=None):
     """
-    Return query of `OpSysRelease` records optionaly filtered
+    Return query of `OpSysRelease` records optionally filtered
     by `opsys_name` and `opsys_version`.
     """
 

--- a/src/pyfaf/solutionfinders/probable_fix_solution_finder.py
+++ b/src/pyfaf/solutionfinders/probable_fix_solution_finder.py
@@ -27,11 +27,11 @@ class ProbableFixSolutionFinder(SolutionFinder):
 
     def _posr_to_solution(self, posr):
         text = ("A new package version is available in which the "
-                "problem has not yet occured. Please update to "
+                "problem has not yet occurred. Please update to "
                 "the following version and delete the ABRT problem:\n{0}"
                 .format(posr.probable_fix))
         html = ("A new package version is available in which the "
-                "problem has not yet occured. Please consider "
+                "problem has not yet occurred. Please consider "
                 "updating to at least the following version:"
                 "<br/><pre>{0}</pre>"
                 .format(posr.probable_fix))

--- a/src/pyfaf/storage/__init__.py
+++ b/src/pyfaf/storage/__init__.py
@@ -208,7 +208,7 @@ class Database(object):
     def __init__(self, debug=False, dry=False, session_kwargs={"autoflush": False, "autocommit": True},
                  create_schema=False):
         if Database.__instance__ and Database.__instancecheck__(Database.__instance__):
-            raise FafError("Database is a singleton and has already been instanciated. "
+            raise FafError("Database is a singleton and has already been instantiated. "
                            "If you have lost the reference, you can access the object "
                            "from Database.__instance__ .")
 

--- a/src/pyfaf/storage/fixtures/__init__.py
+++ b/src/pyfaf/storage/fixtures/__init__.py
@@ -429,7 +429,7 @@ class Generator(object):
                     tar = tarfile.open(cpath, mode='r').extractall(
                         path=config["storage.lobdir"])
 
-                    print('Lob dir restored successfuly from cache')
+                    print('Lob dir restored successfully from cache')
                     return
                 except tarfile.TarError as ex:
                     print('Unable to extract archive: {0}'.format(str(ex)))

--- a/src/pyfaf/utils/decorators.py
+++ b/src/pyfaf/utils/decorators.py
@@ -50,7 +50,7 @@ def retry(tries, delay=3, backoff=2, verbose=False):
                 # pylint: enable-msg=W0703
 
                     if verbose:
-                        print('Exception occured, retrying in {0} seconds'
+                        print('Exception occurred, retrying in {0} seconds'
                               ' {1}/{2}'.format(mdelay, (tries - mtries + 1),
                                                 tries))
 

--- a/src/pyfaf/utils/storage.py
+++ b/src/pyfaf/utils/storage.py
@@ -30,7 +30,7 @@ RE_SIGNAL = re.compile("SIG[^)]+")
 
 def format_reason(rtype, reason, function_name):
     """
-    Return formated `reason` of the crash according to report type `rtype`
+    Return formatted `reason` of the crash according to report type `rtype`
     """
 
     if rtype == "USERSPACE":

--- a/src/webfaf/dumpdirs.py
+++ b/src/webfaf/dumpdirs.py
@@ -171,7 +171,7 @@ def new(url_fname=None):
                                  os.listdir(paths["dumpdir"]))
                     if os.path.isfile(x))
             except Exception as e:
-                raise InvalidUsage("That's embarrasing! We have some"
+                raise InvalidUsage("That's embarrassing! We have some"
                                    " troubles with disk space."
                                    " Please try again later.",
                                    500)

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -590,7 +590,7 @@ def item(report_id, want_object=False):
             tmp_dict['probable_fix_build'] = probably_fixed.Build.serialize
 
             forward['probably_fixed'] = tmp_dict
-        # Avg count occurrence from first to last occurence
+        # Avg count occurrence from first to last occurrence
         forward['avg_count_per_month'] = get_avg_count(report.first_occurrence,
                                                        report.last_occurrence,
                                                        report.count)

--- a/src/webfaf/stats.py
+++ b/src/webfaf/stats.py
@@ -123,7 +123,7 @@ def by_daterange(since, to):
 def by_date(year, month=None, day=None):
     '''
     Render date-based report statistics including reports for passed
-    `year`, optionaly narrowed to specific `month` and `day`.
+    `year`, optionally narrowed to specific `month` and `day`.
     '''
 
     year = int(year)

--- a/src/webfaf/templates/dumpdirs/new.html
+++ b/src/webfaf/templates/dumpdirs/new.html
@@ -9,7 +9,7 @@
       <h2 class="text-center">Submit dump dir archive</h2>
       <p class="text-center">This page is used for submiting dump dirs that cannot be processed by ABRT's reporting tools (such as gnome-abrt).<br>
       If you came here from gnome-abrt that means that reporting failed unexpectedly.<br>
-      If you belive it is a bug in ABRT component and want to help developers to resolve this problem consider doing two things:</p>
+      If you believe it is a bug in ABRT component and want to help developers to resolve this problem consider doing two things:</p>
     </div>
   </div>
   <div class="row">

--- a/src/webfaf/templates/problems/item.html
+++ b/src/webfaf/templates/problems/item.html
@@ -53,7 +53,7 @@ Problem #{{ problem.id }} -
         <dt>Last occurrence</dt>
         <dd>{{ problem.last_occurrence.strftime("%Y-%m-%d") }}</dd>
         {% if problem.probable_fixes %}
-        <dt class="cursor-help" title="List of versions of affected packages where this problem stopped occuring in the given release.">Probable fixes</a></dt>
+        <dt class="cursor-help" title="List of versions of affected packages where this problem stopped occurring in the given release.">Probable fixes</a></dt>
         <dd>{% for pf in problem.probable_fixes %}{{pf}}{% if not loop.last %}<br/>{% endif %}{% endfor %}</dd>
         {% endif %}
         <dt>State</dt>

--- a/src/webfaf/templates/problems/problems_table.html
+++ b/src/webfaf/templates/problems/problems_table.html
@@ -9,7 +9,7 @@
             <th>Crash function</th>
             <th>State</th>
             <th>Bugs</th>
-            <th class="cursor-help" title="Version of the oldest affected package since which the problem stopped occuring in the given release.">Probably fixed</th>
+            <th class="cursor-help" title="Version of the oldest affected package since which the problem stopped occurring in the given release.">Probably fixed</th>
             <th>Count</th>
           </tr>
         </thead>

--- a/tests/checker
+++ b/tests/checker
@@ -19,7 +19,7 @@ class CheckerTestCase(faftests.TestCase):
 
     def test_mandatory(self):
         """
-        Test if mandatory=False is correctly handeled
+        Test if mandatory=False is correctly handled
         """
 
         chk = DictChecker({

--- a/tests/create_problems
+++ b/tests/create_problems
@@ -185,7 +185,7 @@ class CreateProblemsTestCase(faftests.DatabaseCase):
         self.assertEqual(self.db.session.query(Problem).count(), 10)
 
         self.call_action("create-problems", {"report-min-count": 2})
-        # All shall be ingnored
+        # All shall be ignored
         self.assertEqual(self.db.session.query(Problem).count(), 0)
 
         for i in range(10):

--- a/tests/faftests/__init__.py
+++ b/tests/faftests/__init__.py
@@ -65,7 +65,7 @@ class DatabaseCase(TestCase):
     def setUpClass(cls):
         """
         Set up sqlite database in a temp directory.
-        Databse created in this step is restored
+        Database created in this step is restored
         for each test.
         """
 

--- a/tests/utils
+++ b/tests/utils
@@ -73,7 +73,7 @@ class CommonTestCase(faftests.TestCase):
 
     def test_hash_list_encoding(self):
         """
-        hash_list and hashlib.sha1 repsectively shouldn't fail if
+        hash_list and hashlib.sha1 respectively shouldn't fail if
         passed unicode literals
         """
 

--- a/tests/webfaf/reports
+++ b/tests/webfaf/reports
@@ -181,8 +181,8 @@ class ReportTestCase(WebfafTestCase):
 
     def test_report_duplicates(self):
         """
-        Test reporẗ́s duplicates
-        CONSTATNT WICH IS TESTED: EQUAL_UREPORT_EXISTS
+        Test reports duplicates
+        CONSTANT WHICH IS TESTED: EQUAL_UREPORT_EXISTS
         """
         self.clear_reports()
         config.config['ureport.known'] = "EQUAL_UREPORT_EXISTS"
@@ -249,8 +249,8 @@ class ReportTestCase(WebfafTestCase):
 
     def test_report_duplicate_os_minor(self):
         """
-        Test reporẗ́s duplicates
-        CONSTATNT WICH IS TESTED: BUG_OS_MINOR_VERSION
+        Test reports duplicates
+        CONSTANT WHICH IS TESTED: BUG_OS_MINOR_VERSION
         """
         self.clear_reports()
         config.config['ureport.known'] = "BUG_OS_MINOR_VERSION"
@@ -289,8 +289,8 @@ class ReportTestCase(WebfafTestCase):
 
     def test_report_duplicate_os_major(self):
         """
-        Test reporẗ́s duplicates
-        CONSTATNT WICH IS TESTED: BUG_OS_MAJOR_VERSION
+        Test reports duplicates
+        CONSTANT WHICH IS TESTED: BUG_OS_MAJOR_VERSION
         """
         self.clear_reports()
         config.config['ureport.known'] = "BUG_OS_MAJOR_VERSION"


### PR DESCRIPTION
Hi @marusak,

I fixed some [codespell](https://github.com/codespell-project/codespell) issues. See,

```
$ codespell --skip="./src/webfaf/static/*,./.git*,*llvm.py,*sample-1.0-1.fc18.noarch.rpm"
```

You could be checking this in a CI, like CircleCI, [see](https://github.com/grafana/grafana/blob/master/.circleci/config.yml). Thanks!
 