### PR TITLE
migrations: Statement must be first

### DIFF
--- a/src/pyfaf/storage/migrations/script.py.mako
+++ b/src/pyfaf/storage/migrations/script.py.mako
@@ -16,17 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
-
-"""${message}
+"""
+${message}
 
 Revision ID: ${up_revision}
 Revises: ${down_revision}
 Create Date: ${create_date}
-
 """
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}

--- a/src/pyfaf/storage/migrations/versions/133991a89da4_build_to_opsysrelease.py
+++ b/src/pyfaf/storage/migrations/versions/133991a89da4_build_to_opsysrelease.py
@@ -16,16 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, drop_table
-import sqlalchemy as sa
-
-"""assign build to operating system, release and architecture
+"""
+Assign build to operating system, release and architecture
 
 Revision ID: 133991a89da4
 Revises: 17d4911132f8
 Create Date: 2016-09-08 09:08:26.035450
-
 """
+
+from alembic.op import create_table, drop_table
+import sqlalchemy as sa
+
 
 # revision identifiers, used by Alembic.
 revision = '133991a89da4'

--- a/src/pyfaf/storage/migrations/versions/13557f1962e6_ureport_added_certainty.py
+++ b/src/pyfaf/storage/migrations/versions/13557f1962e6_ureport_added_certainty.py
@@ -16,17 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import add_column, drop_column
-import sqlalchemy as sa
-
-
-"""ureport_added_certainty
+"""
+Ureport add certainty
 
 Revision ID: 13557f1962e6
 Revises: 2573150e1470
 Create Date: 2016-08-09 10:01:00.818966
-
 """
+
+from alembic.op import add_column, drop_column
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '13557f1962e6'

--- a/src/pyfaf/storage/migrations/versions/168c63b81f85_report_history_default_value.py
+++ b/src/pyfaf/storage/migrations/versions/168c63b81f85_report_history_default_value.py
@@ -16,15 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import alter_column, execute
-
-"""report_history_default_value
+"""
+Report history default value
 
 Revision ID: 168c63b81f85
 Revises: 183a15e52a4f
 Create Date: 2016-12-13 15:49:32.883743
-
 """
+
+from alembic.op import alter_column, execute
 
 # revision identifiers, used by Alembic.
 revision = '168c63b81f85'

--- a/src/pyfaf/storage/migrations/versions/17d4911132f8_assigning_release_to_repo.py
+++ b/src/pyfaf/storage/migrations/versions/17d4911132f8_assigning_release_to_repo.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, drop_table
-import sqlalchemy as sa
-
-"""assigning release to repository
+"""
+Assigning release to repository
 
 Revision ID: 17d4911132f8
 Revises: 13557f1962e6
 Create Date: 2016-09-08 08:49:52.450697
-
 """
+
+from alembic.op import create_table, drop_table
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '17d4911132f8'

--- a/src/pyfaf/storage/migrations/versions/183a15e52a4f_report_history_unique.py
+++ b/src/pyfaf/storage/migrations/versions/183a15e52a4f_report_history_unique.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import add_column, drop_column
-import sqlalchemy as sa
-
-"""Unique column added into report history
+"""
+Unique column added into report history
 
 Revision ID: 183a15e52a4f
 Revises: 133991a89da4
 Create Date: 2016-09-26 14:35:00.567052
-
 """
+
+from alembic.op import add_column, drop_column
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '183a15e52a4f'

--- a/src/pyfaf/storage/migrations/versions/1b264b21ca91_add_semrel_to_build.py
+++ b/src/pyfaf/storage/migrations/versions/1b264b21ca91_add_semrel_to_build.py
@@ -16,18 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import add_column, get_bind, alter_column, drop_column, create_index
-import sqlalchemy as sa
-
-from pyfaf.storage import custom_types
-
-"""add semrel to build
+"""
+Add semrel to build
 
 Revision ID: 1b264b21ca91
 Revises: 4ff13674a015
 Create Date: 2015-03-02 14:59:34.502070
-
 """
+
+from alembic.op import add_column, get_bind, alter_column, drop_column, create_index
+import sqlalchemy as sa
+
+from pyfaf.storage import custom_types
 
 # revision identifiers, used by Alembic.
 revision = '1b264b21ca91'

--- a/src/pyfaf/storage/migrations/versions/1c4d6317721a_support_mirrors.py
+++ b/src/pyfaf/storage/migrations/versions/1c4d6317721a_support_mirrors.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, get_bind, drop_column, drop_table, execute, add_column
-import sqlalchemy as sa
-
-"""Support mirror urls in repositories
+"""
+Support mirror urls in repositories
 
 Revision ID: 1c4d6317721a
 Revises: 183a15e52a4f
 Create Date: 2016-11-22 10:41:15.866893
-
 """
+
+from alembic.op import create_table, get_bind, drop_column, drop_table, execute, add_column
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '1c4d6317721a'

--- a/src/pyfaf/storage/migrations/versions/1c7edfbf8941_drop_reportunknownpackage_running_fields.py
+++ b/src/pyfaf/storage/migrations/versions/1c7edfbf8941_drop_reportunknownpackage_running_fields.py
@@ -16,17 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import (create_foreign_key, create_unique_constraint, execute,
-                        drop_constraint, drop_column, alter_column, add_column)
-import sqlalchemy as sa
 
-"""drop reportunknownpackage.running fields remove installed prefix
+"""
+Drop reportunknownpackage.running fields remove installed prefix
 
 Revision ID: 1c7edfbf8941
 Revises: 43bd2d59838e
 Create Date: 2015-03-18 15:19:28.412310
-
 """
+
+from alembic.op import (create_foreign_key, create_unique_constraint, execute,
+                        drop_constraint, drop_column, alter_column, add_column)
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '1c7edfbf8941'

--- a/src/pyfaf/storage/migrations/versions/21345f007bdf_add_privileged_user_field.py
+++ b/src/pyfaf/storage/migrations/versions/21345f007bdf_add_privileged_user_field.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import add_column, drop_column
-import sqlalchemy as sa
-
-"""Add privileged user field
+"""
+Add privileged user field
 
 Revision ID: 21345f007bdf
 Revises: cef2fcd69ef
 Create Date: 2015-08-18 14:56:02.571419
-
 """
+
+from alembic.op import add_column, drop_column
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '21345f007bdf'

--- a/src/pyfaf/storage/migrations/versions/23bab42e7be7_initial_migration.py
+++ b/src/pyfaf/storage/migrations/versions/23bab42e7be7_initial_migration.py
@@ -17,12 +17,12 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 
-"""Initial migration
+"""
+Initial migration
 
 Revision ID: 23bab42e7be7
 Revises: None
 Create Date: 2014-07-31 10:20:27.506558
-
 """
 
 # revision identifiers, used by Alembic.

--- a/src/pyfaf/storage/migrations/versions/272e6a3deea4_link_probable_fix_to_build.py
+++ b/src/pyfaf/storage/migrations/versions/272e6a3deea4_link_probable_fix_to_build.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import add_column, drop_column
-import sqlalchemy as sa
-
-"""Link probable fix to Build
+"""
+Link probable fix to Build
 
 Revision ID: 272e6a3deea4
 Revises: 82081a3c76b
 Create Date: 2014-12-08 14:44:00.362834
-
 """
+
+from alembic.op import add_column, drop_column
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '272e6a3deea4'

--- a/src/pyfaf/storage/migrations/versions/2dfd5aef57ca_add_eol_bz_resolution.py
+++ b/src/pyfaf/storage/migrations/versions/2dfd5aef57ca_add_eol_bz_resolution.py
@@ -16,15 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import execute
-
-"""add EOL bz resolution
+"""
+Add EOL bz resolution
 
 Revision ID: 2dfd5aef57ca
 Revises: 58f44afc3a3a
 Create Date: 2015-03-05 08:45:52.544974
-
 """
+
+from alembic.op import execute
 
 # revision identifiers, used by Alembic.
 revision = '2dfd5aef57ca'

--- a/src/pyfaf/storage/migrations/versions/2e5f6d8b68f5_add_contact_email_tables.py
+++ b/src/pyfaf/storage/migrations/versions/2e5f6d8b68f5_add_contact_email_tables.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, drop_table
-import sqlalchemy as sa
-
-"""add contact email tables
+"""
+Add contact email tables
 
 Revision ID: 2e5f6d8b68f5
 Revises: 272e6a3deea4
 Create Date: 2015-01-07 09:13:07.655796
-
 """
+
+from alembic.op import create_table, drop_table
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '2e5f6d8b68f5'

--- a/src/pyfaf/storage/migrations/versions/31d0249e8d4c_create_users_table.py
+++ b/src/pyfaf/storage/migrations/versions/31d0249e8d4c_create_users_table.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, drop_table
-import sqlalchemy as sa
-
-"""create users table
+"""
+Create users table
 
 Revision ID: 31d0249e8d4c
 Revises: 7fa8b3134f0
 Create Date: 2014-09-24 14:49:20.793855
-
 """
+
+from alembic.op import create_table, drop_table
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '31d0249e8d4c'

--- a/src/pyfaf/storage/migrations/versions/43bd2d59838e_add_mantisbt.py
+++ b/src/pyfaf/storage/migrations/versions/43bd2d59838e_add_mantisbt.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, create_index, drop_table, drop_index, f
-import sqlalchemy as sa
-
-"""add mantisbt
+"""
+Add mantisbt
 
 Revision ID: 43bd2d59838e
 Revises: 2dfd5aef57ca
 Create Date: 2015-04-01 10:06:03.059696
-
 """
+
+from alembic.op import create_table, create_index, drop_table, drop_index, f
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '43bd2d59838e'

--- a/src/pyfaf/storage/migrations/versions/47cf82727ed1_acl_permissions.py
+++ b/src/pyfaf/storage/migrations/versions/47cf82727ed1_acl_permissions.py
@@ -16,17 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import get_bind, add_column, drop_constraint, create_primary_key, drop_column
-import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
-"""ACL permissions
+"""
+ACL permissions
 
 Revision ID: 47cf82727ed1
 Revises: 2e5f6d8b68f5
 Create Date: 2015-01-29 13:51:42.674771
-
 """
+
+from alembic.op import get_bind, add_column, drop_constraint, create_primary_key, drop_column
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "47cf82727ed1"

--- a/src/pyfaf/storage/migrations/versions/48550f308625_add_symbolsource_retrace_fail_count.py
+++ b/src/pyfaf/storage/migrations/versions/48550f308625_add_symbolsource_retrace_fail_count.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import add_column, drop_column
-import sqlalchemy as sa
-
-"""Add SymbolSource retrace_fail_count
+"""
+Add SymbolSource retrace_fail_count
 
 Revision ID: 48550f308625
 Revises: 1c7edfbf8941
 Create Date: 2015-04-27 10:26:28.975738
-
 """
+
+from alembic.op import add_column, drop_column
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '48550f308625'

--- a/src/pyfaf/storage/migrations/versions/4ff13674a015_add_semver_to_build.py
+++ b/src/pyfaf/storage/migrations/versions/4ff13674a015_add_semver_to_build.py
@@ -16,18 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import add_column, get_bind, alter_column, create_index, drop_column
-import sqlalchemy as sa
-
-from pyfaf.storage import custom_types
-
-"""add semver to build
+"""
+Add semver to build
 
 Revision ID: 4ff13674a015
 Revises: 47cf82727ed1
 Create Date: 2015-02-19 15:25:42.932876
-
 """
+
+from alembic.op import add_column, get_bind, alter_column, create_index, drop_column
+import sqlalchemy as sa
+
+from pyfaf.storage import custom_types
 
 # revision identifiers, used by Alembic.
 revision = '4ff13674a015'

--- a/src/pyfaf/storage/migrations/versions/50d3e87e4b2a_add_reporturl.py
+++ b/src/pyfaf/storage/migrations/versions/50d3e87e4b2a_add_reporturl.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, drop_table
-import sqlalchemy as sa
-
-"""add_reporturl
+"""
+Add reporturl
 
 Revision ID: 50d3e87e4b2a
 Revises: 21345f007bdf
 Create Date: 2015-10-15 14:27:16.769105
-
 """
+
+from alembic.op import create_table, drop_table
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '50d3e87e4b2a'

--- a/src/pyfaf/storage/migrations/versions/5695a1c595c3_reportreleasedesktops.py
+++ b/src/pyfaf/storage/migrations/versions/5695a1c595c3_reportreleasedesktops.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, drop_table
-import sqlalchemy as sa
-
-"""Added reportreleasedesktops table
+"""
+Added reportreleasedesktops table
 
 Revision ID: 5695a1c595c3
 Revises: 23bab42e7be7
 Create Date: 2014-08-22 12:21:50.973673
-
 """
+
+from alembic.op import create_table, drop_table
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '5695a1c595c3'

--- a/src/pyfaf/storage/migrations/versions/58f44afc3a3a_drop_running_package_from_reportpackages.py
+++ b/src/pyfaf/storage/migrations/versions/58f44afc3a3a_drop_running_package_from_reportpackages.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import drop_constraint, drop_column, add_column
-import sqlalchemy as sa
-
-"""drop running_package from reportpackages
+"""
+Drop running_package from reportpackages
 
 Revision ID: 58f44afc3a3a
 Revises: 1b264b21ca91
 Create Date: 2015-03-03 17:56:36.903726
-
 """
+
+from alembic.op import drop_constraint, drop_column, add_column
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '58f44afc3a3a'

--- a/src/pyfaf/storage/migrations/versions/71905f91e7b7_add_archived_reports.py
+++ b/src/pyfaf/storage/migrations/versions/71905f91e7b7_add_archived_reports.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, drop_table
-import sqlalchemy as sa
-
-"""add_archived_reports
+"""
+Add archived reports
 
 Revision ID: 71905f91e7b7
 Revises: 9301a426f19d
 Create Date: 2017-03-08 16:56:11.355916
-
 """
+
+from alembic.op import create_table, drop_table
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '71905f91e7b7'

--- a/src/pyfaf/storage/migrations/versions/729a154b1609_index_reportpackages.py
+++ b/src/pyfaf/storage/migrations/versions/729a154b1609_index_reportpackages.py
@@ -16,13 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+Create index on reportpackages table
+
+Revision ID: 729a154b1609
+Revises: f43edd5b636d
+Create Date: 2018-06-12 14:53:06.150898
+"""
+
 from alembic.op import create_index, drop_index, f
-
-# Create index on reportpackages table
-# Revision ID: 729a154b1609
-# Revises: f43edd5b636d
-# Create Date: 2018-06-12 14:53:06.150898
-
 
 # revision identifiers, used by Alembic.
 revision = '729a154b1609'

--- a/src/pyfaf/storage/migrations/versions/7fa8b3134f0_probable_fix_by_opsy.py
+++ b/src/pyfaf/storage/migrations/versions/7fa8b3134f0_probable_fix_by_opsy.py
@@ -16,17 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, drop_column, add_column, drop_table
-import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
-"""Probable fix by OpSysRelease
+"""
+Probable fix by OpSysRelease
 
 Revision ID: 7fa8b3134f0
 Revises: 5695a1c595c3
 Create Date: 2014-08-26 10:50:55.926760
-
 """
+
+from alembic.op import create_table, drop_column, add_column, drop_table
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '7fa8b3134f0'

--- a/src/pyfaf/storage/migrations/versions/82081a3c76b_rename_kb_to_sf_prefilter.py
+++ b/src/pyfaf/storage/migrations/versions/82081a3c76b_rename_kb_to_sf_prefilter.py
@@ -16,15 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import rename_table
-
-"""Rename Kb to SF-prefilter
+"""
+Rename Kb to SF-prefilter
 
 Revision ID: 82081a3c76b
 Revises: 31d0249e8d4c
 Create Date: 2014-10-21 12:34:28.849585
-
 """
+
+from alembic.op import rename_table
 
 # revision identifiers, used by Alembic.
 revision = '82081a3c76b'

--- a/src/pyfaf/storage/migrations/versions/89d35a57f82b_add_new_value_to_repo_types_enum.py
+++ b/src/pyfaf/storage/migrations/versions/89d35a57f82b_add_new_value_to_repo_types_enum.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import execute, get_bind
-import sqlalchemy as sa
-
-"""add new value to repo_types enum
+"""
+Add new value to repo_types enum
 
 Revision ID: 89d35a57f82b
 Revises: 50d3e87e4b2a
 Create Date: 2016-05-30 10:55:33.988264
-
 """
+
+from alembic.op import execute, get_bind
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '89d35a57f82b'

--- a/src/pyfaf/storage/migrations/versions/9301a426f19d_associates_to_opsys.py
+++ b/src/pyfaf/storage/migrations/versions/9301a426f19d_associates_to_opsys.py
@@ -16,18 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-
-"""Do not connect associates to release but only to opsys (may take a while)
+"""
+Do not connect associates to release but only to opsys (may take a while)
 
 Revision ID: 9301a426f19d
 Revises: acd3d9bf85d1
 Create Date: 2018-03-16 14:04:57.590176
-
 """
+
 from alembic.op import get_bind, create_table, drop_table
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
-
 
 # revision identifiers, used by Alembic.
 revision = '9301a426f19d'
@@ -48,6 +47,7 @@ def upgrade():
                  sa.ForeignKeyConstraint(['associatepeople_id'], ['associatepeople.id'], ),
                 )
 
+    # pylint: disable=pointless-string-statement
     """
     The following code would convert current permissions.
     However it is biblically slow (the first query) and it seems like better idea

--- a/src/pyfaf/storage/migrations/versions/acd3d9bf85d1_ignore_private_bz.py
+++ b/src/pyfaf/storage/migrations/versions/acd3d9bf85d1_ignore_private_bz.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import add_column, drop_column
-import sqlalchemy as sa
-
-"""Ignore private bugzilla bugz
+"""
+Ignore private bugzilla bugz
 
 Revision ID: acd3d9bf85d1
 Revises: 168c63b81f85
 Create Date: 2017-07-25 09:03:53.335397
-
 """
+
+from alembic.op import add_column, drop_column
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'acd3d9bf85d1'

--- a/src/pyfaf/storage/migrations/versions/cef2fcd69ef_celery_tasks.py
+++ b/src/pyfaf/storage/migrations/versions/cef2fcd69ef_celery_tasks.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, drop_table
-import sqlalchemy as sa
-
-"""Celery tasks
+"""
+Celery tasks
 
 Revision ID: cef2fcd69ef
 Revises: 48550f308625
 Create Date: 2015-06-01 12:22:13.499460
-
 """
+
+from alembic.op import create_table, drop_table
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'cef2fcd69ef'

--- a/src/pyfaf/storage/migrations/versions/f43edd5b636d_enable_problem_components_reassign.py
+++ b/src/pyfaf/storage/migrations/versions/f43edd5b636d_enable_problem_components_reassign.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from alembic.op import create_table, create_index, drop_index, drop_table, f
-import sqlalchemy as sa
-
-"""enable problem components reassign
+"""
+Enable problem components reassign
 
 Revision ID: f43edd5b636d
 Revises: 71905f91e7b7
 Create Date: 2017-04-09 18:04:25.575450
-
 """
+
+from alembic.op import create_table, create_index, drop_index, drop_table, f
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'f43edd5b636d'


### PR DESCRIPTION
If the statement is not before import, then the explaining text is not
printed while migrating.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>