### PR TITLE
Replace deprecated warn method with warning method

### DIFF
--- a/src/bin/faf
+++ b/src/bin/faf
@@ -122,8 +122,8 @@ def main():
             exit(0)
 
         if not isinstance(exitcode, int):
-            log.warn("Action returned a suspicious exit code. Expected "
-                     "'int', got '{0}'".format(type(exitcode).__name__))
+            log.warning("Action returned a suspicious exit code. Expected "
+                        "'int', got '{0}'".format(type(exitcode).__name__))
             exit(1)
 
         exit(exitcode)

--- a/src/pyfaf/solutionfinders/prefilter_solution_finder.py
+++ b/src/pyfaf/solutionfinders/prefilter_solution_finder.py
@@ -59,8 +59,8 @@ class PrefilterSolutionFinder(SolutionFinder):
             try:
                 parser = re.compile(db_btpath.pattern)
             except re.error as ex:
-                log.warn("Unable to compile pattern '{0}': {1}"
-                         .format(db_btpath.pattern, str(ex)))
+                log.warning("Unable to compile pattern '{0}': {1}"
+                            .format(db_btpath.pattern, str(ex)))
                 continue
 
             result[parser] = db_btpath.solution
@@ -80,8 +80,8 @@ class PrefilterSolutionFinder(SolutionFinder):
             try:
                 parser = re.compile(db_pkgname.pattern)
             except re.error as ex:
-                log.warn("Unable to compile pattern '{0}': {1}"
-                         .format(db_pkgname.pattern, str(ex)))
+                log.warning("Unable to compile pattern '{0}': {1}"
+                            .format(db_pkgname.pattern, str(ex)))
                 continue
 
             result[parser] = db_pkgname.solution
@@ -104,13 +104,13 @@ class PrefilterSolutionFinder(SolutionFinder):
 
         osname = ureport["os"]["name"]
         if osname not in systems:
-            log.warn("Operating system '{0}' is not supported".format(osname))
+            log.warning("Operating system '{0}' is not supported".format(osname))
         else:
             osplugin = systems[osname]
             db_opsys = get_opsys_by_name(db, osplugin.nice_name)
             if db_opsys is None:
-                log.warn("Operaring system '{0}' is not installed in storage"
-                         .format(osplugin.nice_name))
+                log.warning("Operaring system '{0}' is not installed in storage"
+                            .format(osplugin.nice_name))
             else:
                 pkgname_parsers = self._get_pkgname_parsers(db, db_opsys=db_opsys)
                 for parser, solution in pkgname_parsers.items():
@@ -119,7 +119,7 @@ class PrefilterSolutionFinder(SolutionFinder):
 
         ptype = ureport["problem"]["type"]
         if ptype not in problemtypes:
-            log.warn("Problem type '{0}' is not supported".format(ptype))
+            log.warning("Problem type '{0}' is not supported".format(ptype))
         else:
             problemplugin = problemtypes[ptype]
             btpath_parsers = self._get_btpath_parsers(db, db_opsys=db_opsys)

--- a/src/pyfaf/storage/__init__.py
+++ b/src/pyfaf/storage/__init__.py
@@ -228,7 +228,7 @@ class Database(object):
 
     def _flush_session(self, *args, **kwargs):
         if self._dry:
-            log.warn("Dry run enabled, not flushing the database")
+            log.warning("Dry run enabled, not flushing the database")
         else:
             self.session._flush_orig(*args, **kwargs)
 

--- a/src/pyfaf/utils/web.py
+++ b/src/pyfaf/utils/web.py
@@ -22,7 +22,7 @@ def server_url():
     if webfaf_installed():
         return config.get("hub.url", None)
 
-    logging.warn("Unable to get web server URL, webfaf not available")
+    logging.warning("Unable to get web server URL, webfaf not available")
     return None
 
 
@@ -34,7 +34,7 @@ def server_name():
     if webfaf_installed():
         return config.get("hub.server_name", None)
 
-    logging.warn("Unable to get web server name, webfaf not available")
+    logging.warning("Unable to get web server name, webfaf not available")
     return None
 
 
@@ -47,7 +47,7 @@ def require_https():
         from pyfaf.utils.parse import str2bool
         return str2bool(config.get("hub.require_https", "true"))
 
-    logging.warn("Unable to get require https option, webfaf not available")
+    logging.warning("Unable to get require https option, webfaf not available")
     return True
 
 
@@ -66,5 +66,5 @@ def reverse(view, **kwargs):
             kwargs["_external"] = True
             return url_for(view, **kwargs)
 
-    logging.warn("Unable to get web server URL, webfaf not available")
+    logging.warning("Unable to get web server URL, webfaf not available")
     return None


### PR DESCRIPTION
The 'warning' method is functionally identical to deprecated 'warn' method.

https://docs.python.org/3/library/logging.html#logging.Logger.warning

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>