### PR TITLE
spec: Drop requirement on postgresql-server

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -32,7 +32,6 @@ Requires(pre): shadow-utils
 
 Requires: pg-semver
 Requires: postgresql
-Requires: postgresql-server
 Requires: python
 Requires: python-setuptools
 Requires: python-psycopg2 >= 2.5


### PR DESCRIPTION
The database server is not really needed by FAF, as the database may run
somewhere else and FAF only connects to it.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>