### PR TITLE
spec: Drop requirement on pg-semver

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -30,7 +30,6 @@ BuildArch: noarch
 
 Requires(pre): shadow-utils
 
-Requires: pg-semver
 Requires: postgresql
 Requires: python
 Requires: python-setuptools


### PR DESCRIPTION
The database server is not really needed by FAF, as the database may run
somewhere else and FAF only connects to it.
Continuation of 710821b

Signed-off-by: Matej Marusak <mmarusak@redhat.com>