### PR TITLE
reposync: Enable matching repositories by name

### DIFF
--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -38,6 +38,9 @@ class RepoSync(Action):
             if cmdline.NAME and repo.name not in cmdline.NAME:
                 continue
 
+            if cmdline.match_repos not in repo.name:
+                continue
+
             if not repo.type in repo_types:
                 self.log_error("No plugin installed to handle repository type "
                                "{0}, skipping.".format(repo.type))
@@ -325,3 +328,6 @@ class RepoSync(Action):
         parser.add_argument("--name-prefix", default="",
                             help="Process only packages whose name "
                                  "starts with the prefix")
+        parser.add_argument("--match-repos", default="",
+                            help="Process only repos which name "
+                                 "contain given string")


### PR DESCRIPTION
This commit introduces way how to pick only specific repositories to be
reposynced.

For example, if there are repositories with following names:
fedora-29-x86_64
fedora-29-i386
fedora-27-x86_64
fedora-27-i386
fedora-29-updates-x86_64
fedora-29-updates-i386
fedora-27-updates-x86_64
fedora-27-updates-i386

And only want to reposync all repositories for fedora-29 run
`reposync --match-repo fedora-29`

Signed-off-by: Matej Marusak <mmarusak@redhat.com>