### PR TITLE
docker: Tag build images

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,15 +3,17 @@ DB_PASS="NotSoSecretPassword"
 
 build:
 	docker build -t faf-image -f Dockerfile ../
+	docker tag faf-image abrt/faf-image
 
 build_local:
 	docker build -t faf-image-local -f Dockerfile_local ../
 
 build_db:
 	docker build -t postgres-semver -f Dockerfile_db ../
+	docker tag postgres-semver abrt/postgres-semver
 
 run:
-	docker run --name faf -dit -e PGHOST=$(DB_IP) -e PGUSER=faf -e PGPASSWORD=scrt -e PGPORT=5432 -e PGDATABASE=faf -p 8080:8080 faf-image
+	docker run --name faf -dit -e PGHOST=$(DB_IP) -e PGUSER=faf -e PGPASSWORD=scrt -e PGPORT=5432 -e PGDATABASE=faf -p 8080:8080 abrt/faf-image
 
 run_local:
 	docker run --name faf -dit -e PGHOST=$(DB_IP) -e PGUSER=faf -e PGPASSWORD=scrt -e PGPORT=5432 -e PGDATABASE=faf -p 8080:8080 faf-image-local


### PR DESCRIPTION
We release our images under abrt/ organization on dockerhub.
Building with this prefix make it weird to use, as there are different
names for build and for released images.

For example `make run` worked only with build image, but could not find
the released image.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>