### PR TITLE
Fixes 710 : Display report-bug association error message

### DIFF
--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -309,7 +309,7 @@ class Bugzilla(BugTracker):
         bug_dict = self._preprocess_bug(bug)
         if not bug_dict:
             self.log_error("Bug pre-processing failed")
-            return None
+            raise FafError("Bug pre-processing failed")
 
         self.log_debug("Saving bug #{0}: {1}".format(bug_dict["bug_id"],
                                                      bug_dict["summary"]))
@@ -331,7 +331,8 @@ class Bugzilla(BugTracker):
         if not tracker:
             self.log_error("Tracker with name '{0}' is not installed"
                            .format(self.name))
-            return None
+            raise FafError("Tracker with name '{0}' is not installed"
+                           .format(self.name))
 
         opsysrelease = queries.get_osrelease(db, bug_dict["product"],
                                              bug_dict["version"])
@@ -340,7 +341,9 @@ class Bugzilla(BugTracker):
             self.log_error("Unable to save this bug due to unknown "
                            "release '{0} {1}'".format(bug_dict["product"],
                                                       bug_dict["version"]))
-            return None
+            raise FafError("Unable to save this bug due to unknown "
+                           "release '{0} {1}'".format(bug_dict["product"],
+                                                      bug_dict["version"]))
 
         relcomponent = queries.get_component_by_name_release(
             db, opsysrelease, bug_dict["component"])
@@ -348,7 +351,8 @@ class Bugzilla(BugTracker):
         if not relcomponent:
             self.log_error("Unable to save this bug due to unknown "
                            "component '{0}'".format(bug_dict["component"]))
-            return None
+            raise FafError("Unable to save this bug due to unknown "
+                           "component '{0}'".format(bug_dict["component"]))
 
         component = relcomponent.component
 
@@ -360,7 +364,7 @@ class Bugzilla(BugTracker):
             downloaded = self._download_user(bug_dict["reporter"])
             if not downloaded:
                 self.log_error("Unable to download user, skipping.")
-                return None
+                raise FafError("Unable to download user, skipping.")
 
             reporter = self._save_user(db, downloaded)
 

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -650,7 +650,8 @@ def associate_bug(report_id):
                     bug = tracker.download_bug_to_storage_no_retry(db, bug_id)
                 except Exception as e:
                     flash("Failed to fetch bug. {0}".format(str(e)), "danger")
-                    raise
+                    return redirect(url_for("reports.associate_bug",
+                                            report_id=report_id))
 
             if bug:
                 newReportBz = ReportBz()
@@ -662,8 +663,6 @@ def associate_bug(report_id):
 
                 flash("Bug successfully associated.", "success")
                 return redirect(url_for("reports.item", report_id=report_id))
-
-            flash("Failed to fetch bug.", "danger")
 
     bthash_url = url_for("reports.bthash_forward",
                          bthash=report.hashes[0].hash,

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -10,7 +10,7 @@ import datetime
 import faftests
 from faftests import mockzilla
 
-
+from pyfaf.common import FafError
 from pyfaf.bugtrackers import bugzilla
 
 from pyfaf.storage.bugtracker import Bugtracker
@@ -193,35 +193,36 @@ class BugzillaTestCase(faftests.DatabaseCase):
 
     def test_save_bug_missing_component(self):
         """
-        Check if download_bug_to_storage returns None
+        Check if download_bug_to_storage raises error
         if there's missing component.
         """
         self.db.session.query(OpSysReleaseComponent).delete()
         self.db.session.query(OpSysComponent).delete()
         self.create_dummy_bug()
-        dbbug = self.bz.download_bug_to_storage(self.db, 1)
-        self.assertIsNone(dbbug)
+        with self.assertRaises(FafError):
+            self.bz.download_bug_to_storage(self.db, 1)
+
 
     def test_save_bug_missing_release(self):
         """
-        Check if download_bug_to_storage returns None
+        Check if download_bug_to_storage raises error
         if there's missing OpSysRelease.
         """
         self.db.session.query(OpSysReleaseComponent).delete()
         self.db.session.query(OpSysRelease).delete()
         self.create_dummy_bug()
-        dbbug = self.bz.download_bug_to_storage(self.db, 1)
-        self.assertIsNone(dbbug)
+        with self.assertRaises(FafError):
+            self.bz.download_bug_to_storage(self.db, 1)
 
     def test_save_bug_missing_tracker(self):
         """
-        Check if download_bug_to_storage returns None
+        Check if download_bug_to_storage raises error
         if tracker is not installed.
         """
         self.db.session.query(Bugtracker).delete()
         self.create_dummy_bug()
-        dbbug = self.bz.download_bug_to_storage(self.db, 1)
-        self.assertIsNone(dbbug)
+        with self.assertRaises(FafError):
+            self.bz.download_bug_to_storage(self.db, 1)
 
     def test_comment_handling(self):
         """


### PR DESCRIPTION
When an error occurs while associating a report to a bug, the flash message is very generic and the actual message is written to the server logs.

This patch will send the error message upstream along with adding it to the server logs.

Resolves: #710 

I am very much doubtful about the tests. Kindly let me improve on your suggestions. 

Thanks for the help throughout.