### PR TITLE
spec: fix of unowned __pycache__ directories

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -834,6 +834,7 @@ fi
 %{python3_sitelib}/pyfaf/queries.py
 %{python3_sitelib}/pyfaf/ureport.py
 %{python3_sitelib}/pyfaf/ureport_compat.py
+%{python3_sitelib}/pyfaf/__pycache__
 %{python3_sitelib}/pyfaf/__pycache__/__init__.*.pyc
 %{python3_sitelib}/pyfaf/__pycache__/checker.*.pyc
 %{python3_sitelib}/pyfaf/__pycache__/cmdline.*.pyc
@@ -858,6 +859,7 @@ fi
 %{python3_sitelib}/pyfaf/actions/releaselist.py
 %{python3_sitelib}/pyfaf/actions/releasemod.py
 %{python3_sitelib}/pyfaf/actions/match_unknown_packages.py
+%{python3_sitelib}/pyfaf/actions/__pycache__
 %{python3_sitelib}/pyfaf/actions/__pycache__/__init__.*.pyc
 %{python3_sitelib}/pyfaf/actions/__pycache__/init.*.pyc
 %{python3_sitelib}/pyfaf/actions/__pycache__/componentadd.*.pyc
@@ -872,24 +874,29 @@ fi
 
 %dir %{python3_sitelib}/pyfaf/bugtrackers
 %{python3_sitelib}/pyfaf/bugtrackers/__init__.py
+%{python3_sitelib}/pyfaf/bugtrackers/__pycache__
 %{python3_sitelib}/pyfaf/bugtrackers/__pycache__/__init__.*.pyc
 
 %dir %{python3_sitelib}/pyfaf/opsys
 %{python3_sitelib}/pyfaf/opsys/__init__.py
+%{python3_sitelib}/pyfaf/opsys/__pycache__
 %{python3_sitelib}/pyfaf/opsys/__pycache__/__init__.*.pyc
 
 %dir %{python3_sitelib}/pyfaf/problemtypes
 %{python3_sitelib}/pyfaf/problemtypes/__init__.py
+%{python3_sitelib}/pyfaf/problemtypes/__pycache__
 %{python3_sitelib}/pyfaf/problemtypes/__pycache__/__init__.*.pyc
 
 %dir %{python3_sitelib}/pyfaf/repos
 %{python3_sitelib}/pyfaf/repos/__init__.py
 %{python3_sitelib}/pyfaf/repos/rpm_metadata.py
+%{python3_sitelib}/pyfaf/repos/__pycache__
 %{python3_sitelib}/pyfaf/repos/__pycache__/__init__.*.pyc
 %{python3_sitelib}/pyfaf/repos/__pycache__/rpm_metadata.*.pyc
 
 %dir %{python3_sitelib}/pyfaf/solutionfinders
 %{python3_sitelib}/pyfaf/solutionfinders/__init__.py
+%{python3_sitelib}/pyfaf/solutionfinders/__pycache__
 %{python3_sitelib}/pyfaf/solutionfinders/__pycache__/__init__.*.pyc
 
 %dir %{python3_sitelib}/pyfaf/storage
@@ -911,6 +918,7 @@ fi
 %{python3_sitelib}/pyfaf/storage/user.py
 %{python3_sitelib}/pyfaf/storage/jsontype.py
 %{python3_sitelib}/pyfaf/storage/task.py
+%{python3_sitelib}/pyfaf/storage/__pycache__
 %{python3_sitelib}/pyfaf/storage/__pycache__/__init__.*.pyc
 %{python3_sitelib}/pyfaf/storage/__pycache__/bugzilla.*.pyc
 %{python3_sitelib}/pyfaf/storage/__pycache__/bugtracker.*.pyc
@@ -934,6 +942,7 @@ fi
 %{python3_sitelib}/pyfaf/storage/fixtures/__init__.py
 %{python3_sitelib}/pyfaf/storage/fixtures/data.py
 %{python3_sitelib}/pyfaf/storage/fixtures/randutils.py
+%{python3_sitelib}/pyfaf/storage/fixtures/__pycache__
 %{python3_sitelib}/pyfaf/storage/fixtures/__pycache__/__init__.*.pyc
 %{python3_sitelib}/pyfaf/storage/fixtures/__pycache__/data.*.pyc
 %{python3_sitelib}/pyfaf/storage/fixtures/__pycache__/randutils.*.pyc
@@ -950,6 +959,7 @@ fi
 %{python3_sitelib}/pyfaf/utils/storage.py
 %{python3_sitelib}/pyfaf/utils/user.py
 %{python3_sitelib}/pyfaf/utils/web.py
+%{python3_sitelib}/pyfaf/utils/__pycache__
 %{python3_sitelib}/pyfaf/utils/__pycache__/__init__.*.pyc
 %{python3_sitelib}/pyfaf/utils/__pycache__/contextmanager.*.pyc
 %{python3_sitelib}/pyfaf/utils/__pycache__/date.*.pyc
@@ -1090,6 +1100,7 @@ fi
 %{python3_sitelib}/webfaf/user.py
 %{python3_sitelib}/webfaf/utils.py
 %{python3_sitelib}/webfaf/webfaf_main.py
+%{python3_sitelib}/webfaf/__pycache__
 %{python3_sitelib}/webfaf/__pycache__/__init__.*.pyc
 %{python3_sitelib}/webfaf/__pycache__/config.*.pyc
 %{python3_sitelib}/webfaf/__pycache__/dumpdirs.*.pyc
@@ -1106,6 +1117,7 @@ fi
 
 %dir %{python3_sitelib}/webfaf/blueprints
 %{python3_sitelib}/webfaf/blueprints/__init__.py
+%{python3_sitelib}/webfaf/blueprints/__pycache__
 %{python3_sitelib}/webfaf/blueprints/__pycache__/__init__.*.pyc
 
 %dir %{python3_sitelib}/webfaf/templates
@@ -1696,8 +1708,10 @@ fi
 %{python3_sitelib}/pyfaf/storage/migrations/__init__.py
 %{python3_sitelib}/pyfaf/storage/migrations/env.py
 %{python3_sitelib}/pyfaf/storage/migrations/versions/*.py
+%{python3_sitelib}/pyfaf/storage/migrations/__pycache__
 %{python3_sitelib}/pyfaf/storage/migrations/__pycache__/__init__.*.pyc
 %{python3_sitelib}/pyfaf/storage/migrations/__pycache__/env.*.pyc
+%{python3_sitelib}/pyfaf/storage/migrations/versions/__pycache__
 %{python3_sitelib}/pyfaf/storage/migrations/versions/__pycache__/*.pyc
 %else
 %{python_sitelib}/pyfaf/storage/migrations/alembic.ini
@@ -1740,6 +1754,7 @@ fi
 %if %{with python3}
 %{python3_sitelib}/pyfaf/celery_tasks/__init__.py
 %{python3_sitelib}/pyfaf/celery_tasks/schedulers.py
+%{python3_sitelib}/pyfaf/celery_tasks/__pycache__
 %{python3_sitelib}/pyfaf/celery_tasks/__pycache__/__init__.*.pyc
 %{python3_sitelib}/pyfaf/celery_tasks/__pycache__/schedulers.*.pyc
 %else


### PR DESCRIPTION
Fix of issue #721 when after uninstallation, faf leaves behind
`__pycache__` directories.

Signed-off-by: Jan Beran <jberan@localhost.localdomain>