### PR TITLE
Define message schema and move to fedora-messaging from fedmsg

### DIFF
--- a/config/plugins/fedmsg.conf
+++ b/config/plugins/fedmsg.conf
@@ -1,8 +1,4 @@
 [fedmsg]
-# you must have the endpoint configured
-name = fedora-infrastructure
-# environment can be one of "prod", "stg" or "dev"
-environment = dev
 # Realtime notifications
 realtime_reports = false
 realtime_problems = false

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,7 @@ AC_CONFIG_FILES([
     src/pyfaf/storage/fixtures/Makefile
     src/pyfaf/storage/fixtures/sql/Makefile
     src/pyfaf/utils/Makefile
+    src/schema/Makefile
     src/webfaf/Makefile
     src/webfaf/blueprints/Makefile
     src/webfaf/static/Makefile

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -311,6 +311,18 @@ Requires: python2-koji
 %description opsys-fedora
 A plugin for %{name} implementing support for Fedora operating system.
 
+%package schema
+Summary: A plugin implementing fedora-messaging Message schema of %{faf}.
+%if 0%{?rhel} && 0%{?rhel} == 7
+Requires: python2-fedora-messaging
+%endif
+%if 0%{?fedora} || 0%{?rhel} > 7
+Requires: python3-fedora-messaging
+%endif
+
+%description schema
+A plugin implementing fedora-messaging Message schema of %{faf}.
+
 %package action-sar
 Summary: %{name}'s sar plugin
 Requires: %{name} = %{faf_version}
@@ -1321,6 +1333,15 @@ fi
 %{python3_sitelib}/pyfaf/opsys/__pycache__/fedora.*.pyc
 %else
 %{python_sitelib}/pyfaf/opsys/fedora.py*
+%endif
+
+%files schema
+%if %{with python3}
+%{python3_sitelib}/faf_schema/
+%{python3_sitelib}/faf_schema*.egg-info/
+%else
+%{python_sitelib}/faf_schema/
+%{python_sitelib}/faf_schema*.egg-info/
 %endif
 
 %files action-sar

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -94,7 +94,7 @@ BuildRequires: python3-rpm
 BuildRequires: python3-sqlalchemy
 BuildRequires: python3-koji
 BuildRequires: python3-zeep
-BuildRequires: python3-fedmsg
+BuildRequires: python3-fedora-messaging
 BuildRequires: python3-pycurl
 BuildRequires: python3-celery >= 3.1
 %else
@@ -110,8 +110,8 @@ BuildRequires: rpm-python
 BuildRequires: python-sqlalchemy >= 0.8
 BuildRequires: python2-koji
 BuildRequires: python-suds
-BuildRequires: fedmsg
 BuildRequires: python-celery >= 3.1
+BuildRequires: python2-fedora-messaging
 %endif
 %if %{with dnf}
 %if %{with python3}
@@ -312,7 +312,7 @@ Requires: python2-koji
 A plugin for %{name} implementing support for Fedora operating system.
 
 %package schema
-Summary: A plugin implementing fedora-messaging Message schema of %{faf}.
+Summary: A plugin implementing fedora-messaging Message schema of %{name}.
 %if 0%{?rhel} && 0%{?rhel} == 7
 Requires: python2-fedora-messaging
 %endif
@@ -321,7 +321,7 @@ Requires: python3-fedora-messaging
 %endif
 
 %description schema
-A plugin implementing fedora-messaging Message schema of %{faf}.
+A plugin implementing fedora-messaging Message schema of %{name}.
 
 %package action-sar
 Summary: %{name}'s sar plugin
@@ -537,7 +537,7 @@ Requires: %{name} = %{faf_version}
 Requires: %{name}-fedmsg = %{faf_version}
 
 %description action-fedmsg-notify
-A plugin for %{name} implementing notification into Fedmsg
+A plugin for %{name} implementing notification into Fedora Messaging
 
 %package action-cleanup-packages
 Summary: %{name}'s cleanup-packages plugin
@@ -674,24 +674,25 @@ Requires: %{name}-bugtracker-mantis = %{faf_version}
 A plugin adding support for Mantis used by CentOS
 
 %package fedmsg
-Summary: %{name}'s Fedmsg support
+Summary: %{name}'s Fedora Messaging support
 Requires: %{name} = %{faf_version}
+Requires: %{name}-schema = %{faf_version}
 %if %{with python3}
-Requires: python3-fedmsg
+Requires: python3-fedora-messaging
 %else
-Requires: fedmsg
+Requires: python2-fedora-messaging
 %endif
 
 %description fedmsg
-Base for Fedmsg support.
+Base for Fedora Messaging support.
 
 %package fedmsg-realtime
-Summary: %{name}'s support for realtime Fedmsg notification sending
+Summary: %{name}'s support for realtime Fedora Messaging notification sending
 Requires: %{name} = %{faf_version}
 Requires: %{name}-fedmsg = %{faf_version}
 
 %description fedmsg-realtime
-Support for sending Fedmsg notifications as reports are saved.
+Support for sending Fedora Messaging notifications as reports are saved.
 
 %package celery-tasks
 Summary: %{name}'s task queue based on Celery

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = bin pyfaf webfaf
+SUBDIRS = bin pyfaf webfaf schema

--- a/src/schema/Makefile.am
+++ b/src/schema/Makefile.am
@@ -1,0 +1,15 @@
+EXTRA_DIST = \
+    faf_schema \
+    README \
+    setup.cfg \
+    setup.py
+
+all:
+
+all-local:
+	$(PYTHON) setup.py build --verbose
+
+install-exec-local:
+	$(PYTHON) setup.py install --root $(DESTDIR) \
+		--single-version-externally-managed \
+		--verbose

--- a/src/schema/README
+++ b/src/schema/README
@@ -1,0 +1,3 @@
+A schema package for messages sent by FAF.
+
+To find out more information about FAF visit https://github.com/abrt/faf.

--- a/src/schema/faf_schema/__init__.py
+++ b/src/schema/faf_schema/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/src/schema/faf_schema/schema.py
+++ b/src/schema/faf_schema/schema.py
@@ -1,0 +1,132 @@
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from fedora_messaging import message
+
+
+class FafMessage(message.Message):
+    """
+    A base class of a Fedora message that defines a message schema for
+    messages published by FAF.
+    """
+
+    def __str__(self):
+        """ Return human readable message """
+        return "ABRT report for package {pkg} has reached {count} occurrences".format(pkg=self.components,
+                                                                                      count=self.occurance)
+
+    @property
+    def summary(self):
+        """ Summary of the crash report. """
+        return "Property 'summary' not implemented in the FafMessage."
+
+    @property
+    def components(self):
+        """ Components of the crash report. """
+        return []
+
+    @property
+    def occurance(self):
+        """ Occurance count of the crash report. """
+        return "Property 'occurance' not implemented in the FafMessage."
+
+
+class FafProblemMessage(FafMessage):
+    """
+    A sub-class of a Fedora message that defines a message schema for
+    messages published by FAF to notify about a problem.
+    """
+    body_schema = {
+        "id": "http://fedoraproject.org/message-schema/faf#",
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "desctription": "Schema for FAF server for problems",
+        "type": "object",
+        "properties": {
+            "components": {
+                "type": "array",
+                "items": {"type": "string"}
+            },
+            "count": {"type": "number"},
+            "first_occurrence": {"type": "string"},
+            "function": {"type": "string"},
+            "level": {"type": "number"},
+            "problem_id": {"type": "number"},
+            "type": {"type": "string"},
+            "url": {"type": "string"}
+        },
+        "required": ["components", "count", "first_occurrence", "function", "level",
+                     "problem_id", "type"]
+    }
+
+    @property
+    def summary(self):
+        """ Summary of the crash report. """
+        return "ABRT report for package {pkg} has reached {count} occurrences".format(pkg=self.components,
+                                                                                      count=self.occurance)
+
+    @property
+    def components(self):
+        """ Components of the crash report. """
+        return self._body["components"]
+
+    @property
+    def occurance(self):
+        """ Occurance count of the crash report. """
+        return self._body["count"]
+
+
+class FafReportMessage(FafMessage):
+    """
+    A sub-class of a Fedora message that defines a message schema for
+    messages published by FAF to notify about a crash report.
+    """
+    body_schema = {
+        "id": "http://fedoraproject.org/message-schema/faf#",
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "desctription": "Schema for FAF server for crash reports",
+        "type": "object",
+        "properties": {
+            "components": {
+                "type": "array",
+                "items": {"type": "string"}
+            },
+            "count": {"type": "number"},
+            "first_occurrence": {"type": "string"},
+            "function": {"type": "string"},
+            "level": {"type": "number"},
+            "problem_id": {"type": "number"},
+            "report_id": {"type": "number"},
+            "type": {"type": "string"},
+            "url": {"type": "string"}
+        },
+        "required": ["components", "count", "first_occurrence", "function", "level",
+                     "report_id", "type"]
+    }
+
+    @property
+    def summary(self):
+        """ Summary of the crash report. """
+        return "ABRT report for package {pkg} has reached {count} occurrences".format(pkg=self.components,
+                                                                                      count=self.occurance)
+    @property
+    def components(self):
+        """ Components of the crash report. """
+        return self._body["components"]
+
+    @property
+    def occurance(self):
+        """ Occurance count of the crash report. """
+        return self._body["count"]

--- a/src/schema/faf_schema/tests/__init__.py
+++ b/src/schema/faf_schema/tests/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/src/schema/faf_schema/tests/test_schema.py
+++ b/src/schema/faf_schema/tests/test_schema.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Unit tests for the message schema."""
+import unittest
+
+from jsonschema import ValidationError
+from .. import schema
+
+
+class FafReportMessageTests(unittest.TestCase):
+    """A set of unit tests to ensure the schema works as expected."""
+
+    msg_class = schema.FafReportMessage
+
+    def setUp(self):
+        self.minimal_message = {
+            'components': ['evolution'],
+            'count': 7,
+            'first_occurrence': '2015-04-10',
+            'function': 'main',
+            'level': 1,
+            'report_id': 4321,
+            'type': 'core'
+        }
+        self.full_message = {
+            'components': ['evolution-full'],
+            'count': 7,
+            'first_occurrence': '2015-04-10',
+            'function': 'main',
+            'level': 1,
+            'problem_id': 54321,
+            'report_id': 54321,
+            'type': 'core',
+            'url': 'http://example.org/faf/reports/1234/'
+        }
+
+    def test_minimal_message(self):
+        """
+        Assert the message schema validates a message with the minimal number
+        of required fields.
+        """
+        message = self.msg_class(body=self.minimal_message)
+
+        message.validate()
+
+    def test_full_message(self):
+        """Assert a message with all fields passes validation."""
+        message = self.msg_class(body=self.full_message)
+
+        message.validate()
+
+    def test_missing_fields(self):
+        """Assert an exception is actually raised on validation failure."""
+        del self.minimal_message["type"]
+        message = self.msg_class(body=self.minimal_message)
+
+        self.assertRaises(ValidationError, message.validate)
+
+
+class FafProblemMessageTests(FafReportMessageTests):
+    """A set of unit tests to ensure the schema works as expected."""
+
+    msg_class = schema.FafProblemMessage
+
+    def setUp(self):
+        self.minimal_message = {
+            'components': ['evolution'],
+            'count': 7,
+            'first_occurrence': '2015-04-10',
+            'function': 'main',
+            'level': 1,
+            'problem_id': 4321,
+            'type': 'core'
+        }
+        self.full_message = {
+            'components': ['evolution-full'],
+            'count': 7,
+            'first_occurrence': '2015-04-10',
+            'function': 'main',
+            'level': 1,
+            'problem_id': 54321,
+            'type': 'core',
+            'url': 'http://example.org/faf/reports/1234/'
+        }
+
+    def test_missing_fields(self):
+        """Assert an exception is actually raised on validation failure."""
+        del self.minimal_message["problem_id"]
+        message = self.msg_class(body=self.minimal_message)
+
+        self.assertRaises(ValidationError, message.validate)

--- a/src/schema/setup.cfg
+++ b/src/schema/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/src/schema/setup.py
+++ b/src/schema/setup.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+import os
+
+from setuptools import setup, find_packages
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, "README")) as fd:
+    README = fd.read()
+
+three_up = os.path.abspath(os.path.join(__file__, "../../.."))
+with open(os.path.join(three_up, "faf-version")) as fver:
+    VERSION = fver.read()
+
+setup(
+    name="faf_schema",
+    version=VERSION,
+    description="A schema package for messages sent by FAF",
+    long_description=README,
+    url="https://github.com/abrt/faf/",
+    # Possible options are at https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+    license="GPLv3+",
+    maintainer="ABRT Team",
+    maintainer_email="crash-catcher@lists.fedorahosted.org",
+    platforms=["Fedora", "GNU/Linux"],
+    keywords="fedora",
+    packages=find_packages(exclude=("faf_schema.tests", "faf_schema.tests.*")),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=["fedora_messaging"],
+    test_suite="faf_schema.tests",
+    entry_points={
+        "fedora.messages": [
+            "faf.FafReportMessage=faf_schema.schema:FafReportMessage",
+            "faf.FafProblemMessage=faf_schema.schema:FafProblemMessage",
+        ]
+    },
+)


### PR DESCRIPTION
Adds `faf-schema` subpackage that defines message schema for the `fedora-messaging`
infrastructure. The `fedora-messaging` library is designed to be a replacement for
the `fedmsg` library.

Message schema should be treated as immutable. Once defined, they should not be altered. 
Instead, define a new schema class, mark the old one as deprecated, and remove it after an appropriate transition period.[1]

Docs:
[1] fedora-messaging.readthedocs.io/en/latest/messages.html#schema-are-immutable
fedora-messaging.readthedocs.io/en/latest/publishing.html
fedora-messaging.readthedocs.io/en/latest/tutorial/conversion.html