### PR TITLE
logrotate: Improvements to logrotate config

### DIFF
--- a/config/faf
+++ b/config/faf
@@ -1,4 +1,4 @@
-/var/log/faf/* {
+/var/log/faf/*.log {
     missingok
     notifempty
     rotate 5


### PR DESCRIPTION
Only log rotate *.log files, otherwise this will happen:

save-reports.log.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.gz.1.1

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>