### PR TITLE
defer loading pickle of known pulled reports in pull_reports

### DIFF
--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -49,8 +49,6 @@ class PullReports(Action):
 
         self.known_file = os.path.join(self.basedir, "reports",
                                        PullReports.KNOWN_FILE_NAME)
-        self._load_known()
-
         self.incoming_dir = os.path.join(self.basedir, "reports", "incoming")
         try:
             ensure_dirs([self.incoming_dir])
@@ -140,7 +138,7 @@ class PullReports(Action):
     def run(self, cmdline, db):
         if cmdline.master is not None:
             self.master = cmdline.master
-            self._load_known()
+        self._load_known()
 
         self.log_info("Pulling reports from {0}".format(self.master))
 


### PR DESCRIPTION
__init__() of the action is run always - even when you do not run the action itself, but some other
since load_known() loads pickle, which can be 100 MB, the memory structure can grow to up to 4 GB, which is wasting of
memory, when we actually do not need the data.