### PR TITLE
reports: Fix endpoint for get_hash route

### DIFF
--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -308,10 +308,10 @@ def items():
 
 
 @reports.route("/get_hash/", endpoint="get_hash")
-@reports.route("/get_hash/<os>/", endpoint="os")
-@reports.route("/get_hash/<os>/<release>", endpoint="release")
-@reports.route("/get_hash/<os>/<release>/<since>", endpoint="since")
-@reports.route("/get_hash/<os>/<release>/<since>/<to>", endpoint="to")
+@reports.route("/get_hash/<opsys>/", endpoint="opsys")
+@reports.route("/get_hash/<opsys>/<release>", endpoint="release")
+@reports.route("/get_hash/<opsys>/<release>/<since>", endpoint="since")
+@reports.route("/get_hash/<opsys>/<release>/<since>/<to>", endpoint="to")
 def get_hash(opsys=None, release=None, since=None, to=None):
     if to:
         to = datetime.datetime.strptime(to, "%Y-%m-%d")


### PR DESCRIPTION
The 'os' argument was renamed to 'opsys' in 88d75024267c97bda926f347e875337d49282beb.

Fixes #742

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>