### PR TITLE
dumpdirs: Use bytes for rw operations on gzipped files

### DIFF
--- a/src/webfaf/dumpdirs.py
+++ b/src/webfaf/dumpdirs.py
@@ -75,7 +75,7 @@ def item(dirname):
         if not os.path.isfile(archive_path):
             abort(404)
 
-        archive = open(archive_path)
+        archive = open(archive_path, 'rb')
         archive_size = os.path.getsize(archive_path)
 
         cd = "attachment; filename={0}".format(itm)
@@ -190,8 +190,8 @@ def new(url_fname=None):
             if os.path.exists(fpath):
                 raise InvalidUsage("Dump dir archive already exists.", 409)
 
-            with open(fpath, 'w') as dest:
-                dest.write(archive_file.read().decode("utf-8"))
+            with open(fpath, 'wb') as dest:
+                dest.write(archive_file.read())
 
             if request_wants_json():
                 response = jsonify({"ok": "ok"})


### PR DESCRIPTION
This is fixes following error, where gzip's magic number is 0x1f 0x8b.

UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>