### PR TITLE
dumpdir: Fix spelling issues

### DIFF
--- a/src/webfaf/templates/dumpdirs/new.html
+++ b/src/webfaf/templates/dumpdirs/new.html
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-md-12">
       <h2 class="text-center">Submit dump dir archive</h2>
-      <p class="text-center">This page is used for submiting dump dirs that cannot be processed by ABRT's reporting tools (such as gnome-abrt).<br>
+      <p class="text-center">This page is used for submitting dump dirs that cannot be processed by ABRT's reporting tools (such as gnome-abrt).<br>
       If you came here from gnome-abrt that means that reporting failed unexpectedly.<br>
       If you believe it is a bug in ABRT component and want to help developers to resolve this problem consider doing two things:</p>
     </div>
@@ -25,7 +25,7 @@
             </div>
             <div id="collapseTwo" class="panel-collapse collapse in">
               <div class="panel-body">
-                Please archive dump dir into 'tar.gz' file and upload into form belowe.<br>
+                Please archive dump dir into 'tar.gz' file and upload into form below.<br>
                 You can easily jump into dump dir by pressing CTRL+O in gnome-abrt. Please select all files, right click and select compressing  as tar.gz. If you don't have this option please use 'tar -pczf' from commandline.<br>
                 The archive will be seen only by ABRT developers but please still mind your private data.
               <form class="form" enctype="multipart/form-data" action="" method="POST">


### PR DESCRIPTION
I was working on some different issue and someone posted screenshot of this page and first thing I have noticed was "belowe"