### PR TITLE
queries: Use is_/isnot for None comparisons

### DIFF
--- a/src/pyfaf/actions/fedmsg_notify.py
+++ b/src/pyfaf/actions/fedmsg_notify.py
@@ -60,8 +60,8 @@ class FedmsgNotify(Action):
                  .outerjoin(q_today, Report.id == q_today.c.t_report_id)
                  .outerjoin(q_yesterday, Report.id == q_yesterday.c.y_report_id)
                  .filter(or_(Report.max_certainty.isnot(None), Report.max_certainty != 100))
-                 .filter(or_(and_(q_yesterday.c.sum_yesterday is None,
-                                  q_today.c.sum_today is not None),
+                 .filter(or_(and_(q_yesterday.c.sum_yesterday.is_(None),
+                                  q_today.c.sum_today.isnot(None)),
                              q_today.c.sum_today != q_yesterday.c.sum_yesterday))
                 )
 
@@ -126,8 +126,8 @@ class FedmsgNotify(Action):
                  .query(Problem, q_today.c.sum_today, q_yesterday.c.sum_yesterday)
                  .outerjoin(q_today, Problem.id == q_today.c.t_problem_id)
                  .outerjoin(q_yesterday, Problem.id == q_yesterday.c.y_problem_id)
-                 .filter(or_(and_(q_yesterday.c.sum_yesterday is None,
-                                  q_today.c.sum_today is not None),
+                 .filter(or_(and_(q_yesterday.c.sum_yesterday.is_(None),
+                                  q_today.c.sum_today.isnot(None)),
                              q_today.c.sum_today != q_yesterday.c.sum_yesterday))
                 )
 

--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -495,10 +495,10 @@ class CoredumpProblem(ProblemType):
 
         q = (db.session.query(SymbolSource)
              .filter(SymbolSource.id.in_(core_syms))
-             .filter(SymbolSource.build_id is not None)
-             .filter((SymbolSource.symbol is None) |
-                     (SymbolSource.source_path is None) |
-                     (SymbolSource.line_number is None)))
+             .filter(SymbolSource.build_id.isnot(None))
+             .filter((SymbolSource.symbol_id.is_(None)) |
+                     (SymbolSource.source_path.is_(None)) |
+                     (SymbolSource.line_number.is_(None))))
         return q
 
     def find_packages_for_ssource(self, db, db_ssource):

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -550,9 +550,9 @@ class KerneloopsProblem(ProblemType):
 
         q = (db.session.query(SymbolSource)
              .filter(SymbolSource.id.in_(koops_syms))
-             .filter((SymbolSource.source_path is None) |
-                     (SymbolSource.line_number is None))
-             .filter(SymbolSource.symbol_id is not None))
+             .filter((SymbolSource.source_path.is_(None)) |
+                     (SymbolSource.line_number.is_(None)))
+             .filter(SymbolSource.symbol_id.isnot(None)))
         return q
 
     def find_packages_for_ssource(self, db, db_ssource):

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=singleton-comparison
 import datetime
 import functools
 from sqlalchemy import func, desc
@@ -125,7 +124,7 @@ def get_backtraces_by_type(db, reporttype, query_all=True):
              .filter(st.Report.type == reporttype))
 
     if not query_all:
-        query = query.filter((st.ReportBacktrace.crashfn == None) |
+        query = query.filter((st.ReportBacktrace.crashfn.is_(None)) |
                              (st.ReportBacktrace.crashfn == "??"))
 
     return query
@@ -348,7 +347,7 @@ def get_sf_prefilter_btpaths(db, db_opsys=None):
     """
 
     return (db.session.query(st.SfPrefilterBacktracePath)
-            .filter((st.SfPrefilterBacktracePath.opsys == None) |
+            .filter((st.SfPrefilterBacktracePath.opsys_id.is_(None)) |
                     (st.SfPrefilterBacktracePath.opsys == db_opsys))
             .all())
 
@@ -382,7 +381,7 @@ def get_sf_prefilter_pkgnames(db, db_opsys=None):
     """
 
     return (db.session.query(st.SfPrefilterPackageName)
-            .filter((st.SfPrefilterPackageName.opsys == None) |
+            .filter((st.SfPrefilterPackageName.opsys_id.is_(None)) |
                     (st.SfPrefilterPackageName.opsys == db_opsys))
             .all())
 
@@ -973,7 +972,7 @@ def get_reports_for_problems(db, report_type):
                               func.min(st.Report.id).label('min_id'))
              .filter(st.Report.type == report_type))
 
-    query = query.filter(st.Report.problem_id != None)
+    query = query.filter(st.Report.problem_id.isnot(None))
 
     query = (query.group_by(st.Report.problem_id).subquery())
 
@@ -987,7 +986,7 @@ def get_unassigned_reports(db, report_type, min_count=0):
     """
     query = (db.session.query(st.Report)
              .filter(st.Report.type == report_type)
-             .filter(st.Report.problem_id == None))
+             .filter(st.Report.problem_id.is_(None)))
     if min_count > 0:
         query = query.filter(st.Report.count >= min_count)
     return query.all()
@@ -1097,9 +1096,9 @@ def get_ssources_for_retrace(db, problemtype):
             .join(st.ReportBacktrace)
             .join(st.Report)
             .filter(st.Report.type == problemtype)
-            .filter((st.SymbolSource.symbol == None) |
-                    (st.SymbolSource.source_path == None) |
-                    (st.SymbolSource.line_number == None))
+            .filter((st.SymbolSource.symbol_id.is_(None)) |
+                    (st.SymbolSource.source_path.is_(None)) |
+                    (st.SymbolSource.line_number.is_(None)))
             .all())
 
 

--- a/src/webfaf/problems.py
+++ b/src/webfaf/problems.py
@@ -222,7 +222,7 @@ def query_problems(_, hist_table,
         pf_query = (
             db.session.query(ProblemOpSysRelease.problem_id.label("problem_id"))
             .filter(ProblemOpSysRelease.opsysrelease_id.in_(probable_fix_osr_ids))
-            .filter(ProblemOpSysRelease.probable_fix_build_id != None) #pylint: disable=singleton-comparison
+            .filter(ProblemOpSysRelease.probable_fix_build_id.isnot(None))
             .distinct(ProblemOpSysRelease.problem_id)
             .subquery())
         final_query = final_query.filter(Problem.id == pf_query.c.problem_id)
@@ -289,7 +289,7 @@ def query_problems(_, hist_table,
             db.session.query(Report.problem_id.label("problem_id"))
             .outerjoin(ReportBz)
             .outerjoin(BzBug)
-            .filter(or_(ReportBz.report_id == None, BzBug.status != "CLOSED")) #pylint: disable=singleton-comparison
+            .filter(or_(ReportBz.report_id.is_(None), BzBug.status != "CLOSED"))
             .group_by(Report.problem_id)
             .having(func.count(ReportBz.report_id) == 0)
             )
@@ -298,7 +298,7 @@ def query_problems(_, hist_table,
             db.session.query(Report.problem_id.label("problem_id"))
             .outerjoin(ReportMantis)
             .outerjoin(MantisBug)
-            .filter(or_(ReportMantis.report_id == None, MantisBug.status != "CLOSED")) #pylint: disable=singleton-comparison
+            .filter(or_(ReportMantis.report_id.is_(None), MantisBug.status != "CLOSED"))
             .group_by(Report.problem_id)
             .having(func.count(ReportMantis.report_id) == 0)
             )

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -267,7 +267,7 @@ def load_packages(_, report_id, package_type=None):
         .outerjoin(installed_packages, ReportPackage.id ==
                    installed_packages.c.iid)
         .filter(ReportPackage.report_id == report_id)
-        .filter(installed_packages.c.iid is not None))
+        .filter(installed_packages.c.iid.isnot(None)))
 
     unknown_packages = (
         db.session.query(


### PR DESCRIPTION
Using the Python's 'is' operator to compare the columns to NULL produced wrong queries.
Instead the sqlalchemy defined 'is_' and 'isnot' functions should be used to do the
comparisons.

In some cases this also required to use real column names from tables.
ie.: opsys to opsys_id

See:
https://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.operators.ColumnOperators.is_
https://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.operators.ColumnOperators.isnot

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>