### PR TITLE
retrace: Decode output of popen

### DIFF
--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -258,7 +258,7 @@ def demangle(mangled):
     if child is None:
         return None
 
-    result = child.stdout.strip()
+    result = child.stdout.strip().decode('utf-8')
     if result != mangled:
         log.debug("Demangled: '{0}' ~> '{1}'".format(mangled, result))
 


### PR DESCRIPTION
Strings were printed out as hex characters (ie. f = \x66).

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>