### PR TITLE
dumpdirs: Modify a route to accept uploads of dumpdirs

### DIFF
--- a/src/webfaf/dumpdirs.py
+++ b/src/webfaf/dumpdirs.py
@@ -107,7 +107,7 @@ def item(dirname):
 
 
 @dumpdirs.route("/new/", methods=("GET", "POST", "PUT"))
-@dumpdirs.route("/new/<string:url_fname>/", methods=("GET", "POST", "PUT"))
+@dumpdirs.route("/new/<string:url_fname>", methods=("GET", "POST", "PUT"), strict_slashes=False)
 def new(url_fname=None):
     """
     Handle dump dir archive uploads


### PR DESCRIPTION
If a dumpdir is sent to 'retrace.fp.org/faf/dumpdirs/new/xyz.tar' the server returns 
'301 MOVED PERMANENTLY'
and the request is redirected to 'retrace.fp.org/faf/dumpdirs/new/xyz.tar/' (see [1]).

This causes Flask to not process the upload instead return FormDataRoutingRedirect error.

When 'strict_slashes' are disabled the redirect is not triggered.

[1] http://werkzeug.pocoo.org/docs/0.14/routing/#rule-format

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>