### PR TITLE
webfaf:utils: Convert generator object to list

### DIFF
--- a/src/webfaf/utils.py
+++ b/src/webfaf/utils.py
@@ -34,7 +34,7 @@ class Pagination(object):
             self.get_args["offset"] = self.offset + self.limit
             return (url_for(self.request.endpoint,
                             **dict(list(self.request.view_args.items()))) +
-                    "?"+urllib.parse.urlencode(self.get_args.items(multi=True)))
+                    "?"+urllib.parse.urlencode(list(self.get_args.items(multi=True))))
 
         return None
 
@@ -43,7 +43,7 @@ class Pagination(object):
             self.get_args["offset"] = max(self.offset - self.limit, 0)
             return (url_for(self.request.endpoint,
                             **dict(list(self.request.view_args.items()))) +
-                    "?"+urllib.parse.urlencode(self.get_args.items(multi=True)))
+                    "?"+urllib.parse.urlencode(list(self.get_args.items(multi=True))))
 
         return None
 


### PR DESCRIPTION
Fixes:
TypeError: object of type 'generator' has no len()
Traceback (most recent call last):
File "/usr/lib64/python3.7/urllib/parse.py", line 873, in urlencode
    if len(query) and not isinstance(query[0], tuple):
TypeError: object of type 'generator' has no len()
...
TypeError: not a valid non-string sequence or mapping object

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>