### PR TITLE
proc: Allow to specify encoding for *popen functions

### DIFF
--- a/src/pyfaf/actions/c2p.py
+++ b/src/pyfaf/actions/c2p.py
@@ -49,7 +49,7 @@ class Coredump2Packages(Action):
         missing = []
 
         self.log_info("Executing eu-unstrip")
-        child = safe_popen("eu-unstrip", "-n", "--core", cmdline.COREDUMP)
+        child = safe_popen("eu-unstrip", "-n", "--core", cmdline.COREDUMP, encoding="utf-8")
         if child is None:
             self.log_error("Failed to execute eu-unstrip")
             return 1

--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -180,14 +180,13 @@ def addr2line(binary_path, address, debuginfo_dir):
         child = safe_popen("eu-addr2line",
                            "--executable", binary_path,
                            "--debuginfo-path", debuginfo_dir,
-                           "--functions", addr)
+                           "--functions", addr,
+                           encoding="utf-8")
 
         if child is None:
             raise FafError("eu-add2line failed")
 
         line1, line2 = child.stdout.splitlines()
-        line1 = line1.decode("utf-8")
-        line2 = line2.decode("utf-8")
         line2_parts = line2.split(":", 1)
         line2_srcfile = line2_parts[0]
         line2_srcline = int(line2_parts[1])
@@ -232,7 +231,7 @@ def get_base_address(binary_path):
     as base for calculating relative offsets.
     """
 
-    child = safe_popen("eu-unstrip", "-n", "-e", binary_path)
+    child = safe_popen("eu-unstrip", "-n", "-e", binary_path, encoding="utf-8")
 
     if child is None:
         raise FafError("eu-unstrip failed")
@@ -250,11 +249,11 @@ def demangle(mangled):
     Demangle C++ symbol name.
     """
 
-    child = safe_popen("c++filt", mangled)
+    child = safe_popen("c++filt", mangled, encoding="utf-8")
     if child is None:
         return None
 
-    result = child.stdout.strip().decode('utf-8')
+    result = child.stdout.strip()
     if result != mangled:
         log.debug("Demangled: '{0}' ~> '{1}'".format(mangled, result))
 
@@ -295,7 +294,7 @@ def get_function_offset_map(files):
         if modulename not in result:
             result[modulename] = {}
 
-        child = safe_popen("eu-readelf", "-s", filename)
+        child = safe_popen("eu-readelf", "-s", filename, encoding="utf-8")
         if child is None:
             continue
 

--- a/src/pyfaf/utils/proc.py
+++ b/src/pyfaf/utils/proc.py
@@ -24,17 +24,19 @@ log = log.getChildLogger(__name__)
 __all__ = ["popen", "safe_popen"]
 
 
-def popen(cmd, *args):
+def popen(cmd, *args, encoding=None):
     """
     Execute `proc` process, wait until
     the execution is over, return
     Popen object.
     """
+
     args = list(map(str, args))
 
     proc = subprocess.Popen([cmd] + args, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
-                            close_fds=True)
+                            close_fds=True,
+                            encoding=encoding)
 
     (stdout, stderr) = proc.communicate()
     # replace closed file descriptors with their contents
@@ -43,7 +45,7 @@ def popen(cmd, *args):
     return proc
 
 
-def safe_popen(cmd, *args):
+def safe_popen(cmd, *args, encoding=None):
     """
     Execute `proc` process and check
     its return code. In case of zero function
@@ -53,7 +55,7 @@ def safe_popen(cmd, *args):
     logs an error and returns None.
     """
 
-    proc = popen(cmd, *args)
+    proc = popen(cmd, *args, encoding=encoding)
     # Instance of 'Popen' has no 'returncode' member
     # pylint: disable-msg=E1101
     if proc.returncode != 0:


### PR DESCRIPTION
If encoding is specified the file objects stdin, stdout and stderr will be opened
in text mode using the encoding specified in the call.

Should have changed it in https://github.com/abrt/faf/pull/751 already.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>