### PR TITLE
opsys: Add tilde to allowed chars in Version

### DIFF
--- a/src/pyfaf/opsys/centos.py
+++ b/src/pyfaf/opsys/centos.py
@@ -50,7 +50,7 @@ class CentOS(System):
                                              maxlen=column_len(Package,
                                                                "name")),
             "epoch":           IntChecker(minval=0),
-            "version":         StringChecker(pattern=r"^[a-zA-Z0-9_\.\+]+$",
+            "version":         StringChecker(pattern=r"^[a-zA-Z0-9_\.\+~]+$",
                                              maxlen=column_len(Build, "version")),
             "release":         StringChecker(pattern=r"^[a-zA-Z0-9_\.\+]+$",
                                              maxlen=column_len(Build, "release")),

--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -59,7 +59,7 @@ class Fedora(System):
                                              maxlen=column_len(Package,
                                                                "name")),
             "epoch":           IntChecker(minval=0),
-            "version":         StringChecker(pattern=r"^[a-zA-Z0-9_\.\+]+$",
+            "version":         StringChecker(pattern=r"^[a-zA-Z0-9_\.\+~]+$",
                                              maxlen=column_len(Build, "version")),
             "release":         StringChecker(pattern=r"^[a-zA-Z0-9_\.\+]+$",
                                              maxlen=column_len(Build, "release")),


### PR DESCRIPTION
According to new Versioning Guidelines [1], 'Version' can now include tilde(~) character.

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_versioning_prereleases_with_tilde

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>