### PR TITLE
fedmsg: Convert components names to list

### DIFF
--- a/src/pyfaf/actions/fedmsg_notify.py
+++ b/src/pyfaf/actions/fedmsg_notify.py
@@ -76,7 +76,7 @@ class FedmsgNotify(Action):
                         msg_body = {
                             "report_id": db_report.id,
                             "function": db_report.crash_function,
-                            "components": [db_report.component.name],
+                            "components": list(db_report.component.name),
                             "first_occurrence": db_report.first_occurrence
                                                 .strftime("%Y-%m-%d"),
                             "count": sum_today,
@@ -142,7 +142,7 @@ class FedmsgNotify(Action):
                         msg_body = {
                             "problem_id": db_problem.id,
                             "function": db_problem.crash_function,
-                            "components": db_problem.unique_component_names,
+                            "components": list(db_problem.unique_component_names),
                             "first_occurrence": db_problem.first_occurrence
                                                 .strftime("%Y-%m-%d"),
                             "count": sum_today,

--- a/src/pyfaf/storage/events_fedmsg.py
+++ b/src/pyfaf/storage/events_fedmsg.py
@@ -52,7 +52,7 @@ if notify_reports or notify_problems:
                         msg_body = {
                             "report_id": db_report.id,
                             "function": db_report.crash_function,
-                            "components": [db_report.component.name],
+                            "components": list(db_report.component.name),
                             "first_occurrence": db_report.first_occurrence
                                                 .strftime("%Y-%m-%d"),
                             "count": newcount,
@@ -85,7 +85,7 @@ if notify_reports or notify_problems:
                         msg_body = {
                             "problem_id": db_report.problem.id,
                             "function": db_report.problem.crash_function,
-                            "components": db_report.problem.unique_component_names,
+                            "components": list(db_report.problem.unique_component_names),
                             "first_occurrence": db_report.problem.first_occurrence
                                                 .strftime("%Y-%m-%d"),
                             "count": newcount,


### PR DESCRIPTION
Validator from faf messaging schema requires component names to be a list of string values.

https://github.com/abrt/faf/blob/8b9a3444273fcc4476eec01baf808098c3637084/src/schema/faf_schema/schema.py#L58

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>