### PR TITLE
Fix post-SQLAlchemy-1.3 breakage

### DIFF
--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -217,6 +217,7 @@ class CreateProblems(Action):
                     # No possible match found, must be a new problem
                     db_problem = Problem()
                     db.session.add(db_problem)
+                    db.session.flush()
                     created_count += 1
                 else:
                     # Leave the problems for the second phase
@@ -253,6 +254,7 @@ class CreateProblems(Action):
             self.log_debug("Creating problem")
             db_problem = Problem()
             db.session.add(db_problem)
+            db.session.flush()
             created_count += 1
             yield (problem, db_problem, True)
 
@@ -459,6 +461,7 @@ class CreateProblems(Action):
                 if db_report is not None:
                     db_report.problem_id = None
                     db.session.add(db_report)
+                    db.session.flush()
 
             if report_min_count > 0:
                 self.log_debug("Removing problems from low count reports")
@@ -485,6 +488,7 @@ class CreateProblems(Action):
                 db_pcomp.component = db_component
                 db_pcomp.order = order
                 db.session.add(db_pcomp)
+                db.session.flush()
 
     def run(self, cmdline, db):
         if not cmdline.problemtype:

--- a/src/pyfaf/ureport.py
+++ b/src/pyfaf/ureport.py
@@ -226,6 +226,8 @@ def save_ureport2(db, ureport, create_component=False, timestamp=None, count=1):
         db_report_hash.hash = report_hash
         db.session.add(db_report_hash)
 
+        db.session.flush()
+
     if db_report.first_occurrence > timestamp:
         db_report.first_occurrence = timestamp
 

--- a/src/webfaf/problems.py
+++ b/src/webfaf/problems.py
@@ -65,8 +65,8 @@ def query_problems(_, hist_table,
 
     rank_query = (db.session.query(Problem.id.label('id'),
                                    func.sum(hist_table.count).label('rank'))
-                  .join(Report)
-                  .join(hist_table))
+                  .join(Report, Report.problem_id == Problem.id)
+                  .join(hist_table, hist_table.report_id == Report.id))
     if opsysrelease_ids:
         rank_query = rank_query.filter(
             hist_table.opsysrelease_id.in_(opsysrelease_ids))


### PR DESCRIPTION
I’m fairly sure that the missing primary keys wouldn’t be a problem if we had [`autoflush`](https://docs.sqlalchemy.org/en/latest/orm/session_api.html#sqlalchemy.orm.session.Session.params.autoflush) enabled (and [`autocommit`](https://docs.sqlalchemy.org/en/latest/orm/session_transaction.html#autocommit-mode) is considered legacy, so maybe would be beneficial to look into it deeper).

Closes https://github.com/abrt/faf/issues/764