### PR TITLE
tests: actions: Pass --verbose to createrepo

### DIFF
--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -319,7 +319,7 @@ class ActionsTestCase(faftests.DatabaseCase):
         shutil.copyfile(self.rpm,
                         os.path.join(self.tmpdir, os.path.basename(self.rpm)))
 
-        proc = popen("createrepo", self.tmpdir)
+        proc = popen("createrepo", "--verbose", self.tmpdir)
         self.assertTrue(b"Workers Finished" in proc.stdout or b"Pool finished" in proc.stdout)
 
         self.call_action_ordered_args("repoadd", [
@@ -387,7 +387,7 @@ class ActionsTestCase(faftests.DatabaseCase):
         shutil.copyfile(self.rpm,
                         os.path.join(self.tmpdir, os.path.basename(self.rpm)))
 
-        proc = popen("createrepo", self.tmpdir)
+        proc = popen("createrepo", "--verbose", self.tmpdir)
         self.assertTrue(b"Workers Finished" in proc.stdout or b"Pool finished" in proc.stdout)
 
         self.call_action_ordered_args("repoadd", [
@@ -734,7 +734,7 @@ class ActionsTestCase(faftests.DatabaseCase):
         shutil.copyfile(self.rpm,
                         os.path.join(self.tmpdir, os.path.basename(self.rpm)))
 
-        proc = popen("createrepo", self.tmpdir)
+        proc = popen("createrepo", "--verbose", self.tmpdir)
         self.assertTrue(b"Workers Finished" in proc.stdout or b"Pool finished" in proc.stdout)
 
         self.call_action_ordered_args("repoadd", [


### PR DESCRIPTION
Without it, the messages in assertions will never be shown:
https://github.com/rpm-software-management/createrepo_c/commit/4c2f4f48f259c19219d4d640884c5df7a7d4fc5e

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>