### PR TITLE
Fix issues related to SQLAlchemy 1.3

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -146,7 +146,7 @@ notes=FIXME,XXX,TODO
 max-line-length=120
 
 # Maximum number of lines in a module
-max-module-lines=1450
+max-module-lines=1750
 
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab).

--- a/src/pyfaf/actions/fedmsg_notify.py
+++ b/src/pyfaf/actions/fedmsg_notify.py
@@ -105,7 +105,7 @@ class FedmsgNotify(Action):
                 db.session
                 .query(Problem.id.label("y_problem_id"),
                        func.sum(ReportHistoryDaily.count).label("sum_yesterday"))
-                .join(Report)
+                .join(Report, Report.problem_id == Problem.id)
                 .outerjoin(ReportHistoryDaily)
                 .filter(ReportHistoryDaily.day < cmdline.date)
                 .group_by(Problem.id)
@@ -116,7 +116,7 @@ class FedmsgNotify(Action):
                 db.session
                 .query(Problem.id.label("t_problem_id"),
                        func.sum(ReportHistoryDaily.count).label("sum_today"))
-                .join(Report)
+                .join(Report, Report.problem_id == Problem.id)
                 .outerjoin(ReportHistoryDaily)
                 .filter(ReportHistoryDaily.day <= cmdline.date)
                 .group_by(Problem.id)

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -250,6 +250,8 @@ def get_history_day(db, db_report, db_osrelease, day):
     Return pyfaf.storage.ReportHistoryDaily object for a given
     report, opsys release and day or None if not found.
     """
+    if not db_report.id:
+        return None
 
     return (db.session.query(st.ReportHistoryDaily)
             .filter(st.ReportHistoryDaily.report == db_report)
@@ -263,6 +265,8 @@ def get_history_month(db, db_report, db_osrelease, month):
     Return pyfaf.storage.ReportHistoryMonthly object for a given
     report, opsys release and month or None if not found.
     """
+    if not db_report.id:
+        return None
 
     return (db.session.query(st.ReportHistoryMonthly)
             .filter(st.ReportHistoryMonthly.report == db_report)
@@ -310,6 +314,8 @@ def get_history_week(db, db_report, db_osrelease, week):
     Return pyfaf.storage.ReportHistoryWeekly object for a given
     report, opsys release and week or None if not found.
     """
+    if not db_report.id:
+        return None
 
     return (db.session.query(st.ReportHistoryWeekly)
             .filter(st.ReportHistoryWeekly.report == db_report)
@@ -743,6 +749,8 @@ def get_problem_component(db, db_problem, db_component):
     Return pyfaf.storage.ProblemComponent object from problem and component
     or None if not found.
     """
+    if not db_problem.id:
+        return None
 
     return (db.session.query(st.ProblemComponent)
             .filter(st.ProblemComponent.problem == db_problem)
@@ -858,6 +866,8 @@ def get_report_release_desktop(db, db_report, db_release, desktop):
     Return `pyfaf.storage.ReportReleaseDesktop` object for given
     report, release and desktop or None if not found.
     """
+    if not db_report.id:
+        return None
 
     return (db.session.query(st.ReportReleaseDesktop)
             .filter(st.ReportReleaseDesktop.report == db_report)
@@ -897,6 +907,8 @@ def get_reportarch(db, report, arch):
     Return pyfaf.storage.ReportArch object from pyfaf.storage.Report
     and pyfaf.storage.Arch or None if not found.
     """
+    if not report.id:
+        return None
 
     return (db.session.query(st.ReportArch)
             .filter(st.ReportArch.report == report)
@@ -909,6 +921,8 @@ def get_reportexe(db, report, executable):
     Return pyfaf.storage.ReportExecutable object from pyfaf.storage.Report
     and the absolute path of executable or None if not found.
     """
+    if not report.id:
+        return None
 
     return (db.session.query(st.ReportExecutable)
             .filter(st.ReportExecutable.report == report)
@@ -921,6 +935,8 @@ def get_reportosrelease(db, report, osrelease):
     Return pyfaf.storage.ReportOpSysRelease object from pyfaf.storage.Report
     and pyfaf.storage.OpSysRelease or None if not found.
     """
+    if not report.id:
+        return None
 
     return (db.session.query(st.ReportOpSysRelease)
             .filter(st.ReportOpSysRelease.report == report)
@@ -933,6 +949,8 @@ def get_reportpackage(db, report, package):
     Return pyfaf.storage.ReportPackage object from pyfaf.storage.Report
     and pyfaf.storage.Package or None if not found.
     """
+    if not report.id:
+        return None
 
     return (db.session.query(st.ReportPackage)
             .filter(st.ReportPackage.report == report)
@@ -945,6 +963,8 @@ def get_reportreason(db, report, reason):
     Return pyfaf.storage.ReportReason object from pyfaf.storage.Report
     and the textual reason or None if not found.
     """
+    if not report.id:
+        return None
 
     return (db.session.query(st.ReportReason)
             .filter(st.ReportReason.report == report)
@@ -1131,6 +1151,8 @@ def get_symbolsource(db, symbol, filename, offset):
     Return pyfaf.storage.SymbolSource object from pyfaf.storage.Symbol,
     file name and offset or None if not found.
     """
+    if not symbol.id:
+        return None
 
     return (db.session.query(st.SymbolSource)
             .filter(st.SymbolSource.symbol == symbol)
@@ -1167,6 +1189,8 @@ def get_unknown_package(db, db_report, role, name,
     Return pyfaf.storage.ReportUnknownPackage object from pyfaf.storage.Report,
     package role and NEVRA or None if not found.
     """
+    if not db_report.id:
+        return None
 
     db_arch = get_arch_by_name(db, arch)
     return (db.session.query(st.ReportUnknownPackage)

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -624,7 +624,7 @@ def query_problems(db, hist_table, opsysrelease_ids, component_ids,
 
     rank_query = (db.session.query(st.Problem.id.label('id'),
                                    func.sum(hist_table.count).label('rank'))
-                  .join(st.Report)
+                  .join(st.Report, st.Report.problem_id == st.Problem.id)
                   .join(hist_table)
                   .filter(hist_table.opsysrelease_id.in_(opsysrelease_ids)))
 
@@ -842,7 +842,7 @@ def get_report_count_by_component(db, opsys_name=None, opsys_version=None,
     comps = (
         db.session.query(st.OpSysComponent,
                          func.sum(hist_table.count).label('cnt'))
-        .join(st.Report)
+        .join(st.Report, st.Report.component_id == st.OpSysComponent.id)
         .join(hist_table)
         .group_by(st.OpSysComponent)
         .order_by(desc('cnt')))
@@ -880,7 +880,7 @@ def get_report_stats_by_component(db, component, opsys_name=None,
 
     stats = (db.session.query(st.Report,
                               func.sum(hist_table.count).label('cnt'))
-             .join(hist_table)
+             .join(hist_table, hist_table.report_id == st.Report.id)
              .join(st.OpSysComponent)
              .filter(st.OpSysComponent.id == component.id)
              .group_by(st.Report)

--- a/src/webfaf/blueprints/symbol_transfer.py
+++ b/src/webfaf/blueprints/symbol_transfer.py
@@ -68,9 +68,11 @@ def process_symbol(build_id, path, offset, problem_type, create_symbol_auth_key)
                     db_report_hash.report = db_report
                     db.session.add(db_report_hash)
 
-                db_rbt = (db.session.query(ReportBacktrace)
-                          .filter(ReportBacktrace.report == db_report)
-                          .first())
+                db_rbt = None
+                if db_report.id:
+                    db_rbt = (db.session.query(ReportBacktrace)
+                              .filter(ReportBacktrace.report == db_report)
+                              .first())
                 if db_rbt is None:
                     db_rbt = ReportBacktrace()
                     db_rbt.report = db_report
@@ -89,9 +91,11 @@ def process_symbol(build_id, path, offset, problem_type, create_symbol_auth_key)
             db_ssource.offset = offset
             db.session.add(db_ssource)
 
-            max_order = (db.session.query(func.max(ReportBtFrame.order))
-                         .filter(ReportBtFrame.thread == db_thread)
-                         .scalar() or 0)
+            max_order = 0
+            if db_thread.id:
+                max_order = (db.session.query(func.max(ReportBtFrame.order))
+                             .filter(ReportBtFrame.thread == db_thread)
+                             .scalar() or 0)
             db_frame = ReportBtFrame()
             db_frame.thread = db_thread
             db_frame.symbolsource = db_ssource

--- a/src/webfaf/problems.py
+++ b/src/webfaf/problems.py
@@ -65,7 +65,7 @@ def query_problems(_, hist_table,
 
     rank_query = (db.session.query(Problem.id.label('id'),
                                    func.sum(hist_table.count).label('rank'))
-                  .join(Report)
+                  .join(Report, Report.problem_id == Problem.id)
                   .join(hist_table))
     if opsysrelease_ids:
         rank_query = rank_query.filter(


### PR DESCRIPTION
First issue is with ambiguity of JOINs. That is, the JOIN would implicitly be against the first entity that matches. The new behavior requests that this ambiguity is resolved. The solution is to provide an ON clause [2].

Second issue is that we were performing queries that were essentially of this form:
```
session.query(A).filter(A.user == User(id=None))
```
Which emits SQL resembling:
```
... a WHERE ? = a.user_id
(None,)
```
This will always return False in SQL. This produced a warning before [1]. With [3] it no longer works.

Fixes #764 
Closes #767 

Reference for the SQLAlchemy changes version: 
[1] - [warnings-emitted-when-comparing-objects-with-none-values-to-relationships](docs.sqlalchemy.org/en/latest/changelog/migration_10.html#warnings-emitted-when-comparing-objects-with-none-values-to-relationships)
[2] - [query-join-handles-ambiguity-in-deciding-the-left-side-more-explicitly](docs.sqlalchemy.org/en/latest/changelog/migration_13.html#query-join-handles-ambiguity-in-deciding-the-left-side-more-explicitly)
[3] - [improvement-to-the-behavior-of-many-to-one-query-expressions](https://docs.sqlalchemy.org/en/latest/changelog/migration_13.html#improvement-to-the-behavior-of-many-to-one-query-expressions)
