### PR TITLE
opsys: Make OpSys orderable

### DIFF
--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -58,6 +58,9 @@ class OpSys(GenericTable):
     def __str__(self):
         return self.name
 
+    def __lt__(self, other):
+        return self.name < other.name
+
     @property
     def active_releases(self):
         return [release for release in self.releases if release.status == 'ACTIVE']


### PR DESCRIPTION
In Python3 comparing unorderable types rises TypeError.

Related to c7196d4dddc6db4252eeaba6f501684739653d37

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>