### PR TITLE
webfaf:config: Disable SQLALCHEMY_TRACK_MODIFICATIONS

### DIFF
--- a/src/webfaf/config.py
+++ b/src/webfaf/config.py
@@ -13,6 +13,7 @@ class Config(object):
     TESTING = False
     SECRET_KEY = 'NOT_A_RANDOM_STRING'
     SQLALCHEMY_DATABASE_URI = dburl
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
     OPENID_ENABLED = str2bool(config.get("openid.enabled", "false"))
     OPENID_FS_STORE = os.path.join(paths["spool"], "openid_store")
     OPENID_PRIVILEGED_TEAMS = [s.strip() for s in config.get("openid.privileged_teams", "").split(",")]


### PR DESCRIPTION
We do not use flask-sqlalchemy signals[1], we are safe to disable this option.

Fixes #744

[1] http://flask-sqlalchemy.pocoo.org/dev/signals/

See also:
http://flask-sqlalchemy.pocoo.org/2.3/config/

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>