### PR TITLE
webfaf: Speed up component list queries

### DIFF
--- a/src/webfaf/forms.py
+++ b/src/webfaf/forms.py
@@ -6,7 +6,7 @@ from hashlib import sha1
 
 from flask import g
 
-from sqlalchemy import asc, distinct
+from sqlalchemy import asc
 
 from wtforms import (Form,
                      SubmitField,
@@ -81,9 +81,10 @@ class TagListField(TextField):
 
 
 def component_list():
-    sub = db.session.query(distinct(Report.component_id)).subquery()
+    sub = (db.session.query(Report.component_id)
+           .filter(Report.component_id == OpSysComponent.id))
     comps = (db.session.query(OpSysComponent.id, OpSysComponent.name)
-             .filter(OpSysComponent.id.in_(sub))
+             .filter(sub.exists())
              .all())
     merged = defaultdict(list)
     for iden, name in comps:

--- a/src/webfaf/webfaf_main.py
+++ b/src/webfaf/webfaf_main.py
@@ -12,7 +12,6 @@ from flask_sqlalchemy import SQLAlchemy
 from werkzeug.contrib.fixers import ProxyFix
 from werkzeug.local import LocalProxy
 from werkzeug.contrib.cache import MemcachedCache, SimpleCache, NullCache
-from sqlalchemy import distinct
 
 from pyfaf.storage.user import User
 from pyfaf.storage import OpSysComponent, Report
@@ -135,9 +134,10 @@ def about():
 @app.route('/component_names.json')
 @cache(hours=24)
 def component_names_json():
-    sub = db.session.query(distinct(Report.component_id)).subquery()
+    sub = (db.session.query(Report.component_id)
+           .filter(Report.component_id == OpSysComponent.id))
     comps = (db.session.query(OpSysComponent.name)
-             .filter(OpSysComponent.id.in_(sub))
+             .filter(sub.exists())
              .distinct(OpSysComponent.name)
              .all())
     comps = [comp[0] for comp in comps]


### PR DESCRIPTION
The modified queries produce SQL:

In `webfaf_main`:
```sql
SELECT DISTINCT ON (opsyscomponents.name) opsyscomponents.name AS opsyscomponents_name
FROM opsyscomponents
WHERE EXISTS
  (SELECT 1 FROM reports
   WHERE reports.component_id = opsyscomponents.id)
```
In `forms`:
```sql
SELECT opsyscomponents.id AS opsyscomponents_id, opsyscomponents.name AS opsyscomponents_name
FROM opsyscomponents
WHERE EXISTS
  (SELECT 1 FROM reports
   WHERE reports.component_id = opsyscomponents.id)
```
Fixes #761

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>