### PR TITLE
retrace: Fix addr2line splitting

### DIFF
--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -187,7 +187,8 @@ def addr2line(binary_path, address, debuginfo_dir):
             raise FafError("eu-add2line failed")
 
         line1, line2 = child.stdout.splitlines()
-        line2_parts = line2.split(":", 1)
+        # format of the line2 is filename:lineno[:columnno]
+        line2_parts = line2.split(":")
         line2_srcfile = line2_parts[0]
         line2_srcline = int(line2_parts[1])
 


### PR DESCRIPTION
The line can be of format file:lineno[:columnno].

[sourceware.org/git/?p=elfutils.git;a=blob;f=src/addr2line.c;h=69d8d99589b27ea500df26d873847a3caa03d0a3;hb=HEAD#l798](https://sourceware.org/git/?p=elfutils.git;a=blob;f=src/addr2line.c;h=69d8d99589b27ea500df26d873847a3caa03d0a3;hb=HEAD#l798)

Fixes #770

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>