### PR TITLE
docker: Replace apachectl with httpd to start the server

### DIFF
--- a/docker/files/usr/bin/run_faf
+++ b/docker/files/usr/bin/run_faf
@@ -35,4 +35,4 @@ else
 fi
 
 /usr/sbin/uwsgi --ini /etc/uwsgi.ini --logto /var/log/faf/uwsgi_logs &
-apachectl -DFOREGROUND
+/usr/sbin/httpd -DFOREGROUND


### PR DESCRIPTION
With new version of httpd `apachectl` no longer accepts the `-DFOREGROUND` option.
`apachectl: The "-DFOREGROUND" option is not supported.`

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>