### PR TITLE
pyfaf: repos: rpm_metadata: Flatten URL argument

### DIFF
--- a/src/pyfaf/repos/rpm_metadata.py
+++ b/src/pyfaf/repos/rpm_metadata.py
@@ -122,7 +122,7 @@ class RpmMetadata(Repo):
 
     name = "rpmmetadata"
 
-    def __init__(self, name, *urls):
+    def __init__(self, name, urls, *args):
         """
         Following `url` schemes are supported:
         http://, ftp://, file:// (used if full

--- a/tests/test_rpm_metadata.py
+++ b/tests/test_rpm_metadata.py
@@ -118,7 +118,7 @@ class RpmMetadataTestCase(faftests.TestCase):
         repository without any protocol in URL correctly.
         """
 
-        rpm_metadata = RpmMetadata("test_repo_absolute", self.tmpdir)
+        rpm_metadata = RpmMetadata("test_repo_absolute", [self.tmpdir])
         rpm_metadata.cachedir = self.cachedir
 
         pkgs = rpm_metadata.list_packages(["noarch"])
@@ -133,7 +133,7 @@ class RpmMetadataTestCase(faftests.TestCase):
         repository with file:// protocol in URL correctly.
         """
 
-        rpm_metadata = RpmMetadata("test_repo_file", "file://" + self.tmpdir)
+        rpm_metadata = RpmMetadata("test_repo_file", ["file://" + self.tmpdir])
         rpm_metadata.cachedir = self.cachedir
 
         pkgs = rpm_metadata.list_packages(["noarch"])
@@ -148,7 +148,7 @@ class RpmMetadataTestCase(faftests.TestCase):
             time.sleep(1)
 
             rpm_metadata = RpmMetadata("test_repo_http",
-                                       "http://localhost:53135/")
+                                       ["http://localhost:53135/"])
             rpm_metadata.cachedir = self.cachedir
 
             pkgs = rpm_metadata.list_packages(["noarch"])
@@ -182,7 +182,7 @@ class RpmMetadataTestCase(faftests.TestCase):
             time.sleep(1)
 
             rpm_metadata = RpmMetadata("test_repo_http",
-                                       "http://localhost:53535/")
+                                       ["http://localhost:53535/"])
             rpm_metadata.cachedir = self.cachedir
             rpm_metadata.cacheperiod = -1
 


### PR DESCRIPTION
As the constructor collects all remaining positional arguments as URLs,
we end up receiving a tuple (usually 1-tuple) with a list as the first
element. In places where the URLs are iterated as a list, this will
quickly break things that expect strings and not lists.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>