### PR TITLE
fedmsg: Fix component names in fed-messaging msgs

### DIFF
--- a/src/pyfaf/actions/fedmsg_notify.py
+++ b/src/pyfaf/actions/fedmsg_notify.py
@@ -76,7 +76,7 @@ class FedmsgNotify(Action):
                         msg_body = {
                             "report_id": db_report.id,
                             "function": db_report.crash_function,
-                            "components": list(db_report.component.name),
+                            "components": [db_report.component.name],
                             "first_occurrence": db_report.first_occurrence
                                                 .strftime("%Y-%m-%d"),
                             "count": sum_today,

--- a/src/pyfaf/storage/events_fedmsg.py
+++ b/src/pyfaf/storage/events_fedmsg.py
@@ -52,7 +52,7 @@ if notify_reports or notify_problems:
                         msg_body = {
                             "report_id": db_report.id,
                             "function": db_report.crash_function,
-                            "components": list(db_report.component.name),
+                            "components": [db_report.component.name],
                             "first_occurrence": db_report.first_occurrence
                                                 .strftime("%Y-%m-%d"),
                             "count": newcount,


### PR DESCRIPTION
Calling "list()" on db_report.component.name (abrt) created ["a","b","r","t"].

Because:
"db_report.component.name" returns the name of the component (str), ie. "abrt".
"db_problem.unique_component_names" returns a set of components, ie. {"abrt", "faf"}.

Fixes mistake in 1e6808dd0

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>