### PR TITLE
webfaf: Repair "About" page

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -61,9 +61,9 @@ BuildRequires: python3-flask
 BuildRequires: python3-flask-wtf
 BuildRequires: python3-flask-openid
 BuildRequires: python3-openid-teams
-BuildRequires: python3-flask-rstpages
 BuildRequires: python3-flask-sqlalchemy
 BuildRequires: python3-jinja2
+BuildRequires: python3-markdown2
 BuildRequires: python3-munch
 BuildRequires: python3-dateutil
 BuildRequires: python3-ratelimitingfilter
@@ -86,11 +86,11 @@ Requires: httpd
 Requires: python3-mod_wsgi
 Requires: python3-flask
 Requires: python3-flask-wtf
-Requires: python3-flask-rstpages
 Requires: python3-flask-sqlalchemy
 Requires: python3-flask-openid
 Requires: python3-openid-teams
 Requires: python3-jinja2
+Requires: python3-markdown2
 Requires: python3-munch
 Requires: python3-dateutil
 Requires: python3-ratelimitingfilter
@@ -871,7 +871,7 @@ fi
 %{python3_sitelib}/webfaf/templates/500.html
 %{python3_sitelib}/webfaf/templates/about.md
 %{python3_sitelib}/webfaf/templates/base.html
-%{python3_sitelib}/webfaf/templates/rstpage.html
+%{python3_sitelib}/webfaf/templates/mdpage.html
 
 %dir %{python3_sitelib}/webfaf/templates/dumpdirs
 %{python3_sitelib}/webfaf/templates/dumpdirs/list.html

--- a/src/webfaf/config.py
+++ b/src/webfaf/config.py
@@ -19,8 +19,7 @@ class Config(object):
     OPENID_PRIVILEGED_TEAMS = [s.strip() for s in config.get("openid.privileged_teams", "").split(",")]
     PROXY_SETUP = False
     MAX_CONTENT_LENGTH = int(config["dumpdir.maxdumpdirsize"])
-    RSTPAGES_SRC = os.path.join(WEBFAF_DIR, "templates")
-    RSTPAGES_RST_SETTINGS = {'initial_header_level': 3}
+    TEMPLATES_DIR = os.path.join(WEBFAF_DIR, "templates")
     ADMINS = config.get("mail.admins", "").split(",")
     MAIL_SERVER = config.get("mail.server", "localhost")
     MAIL_PORT = config.get("mail.port", "25")

--- a/src/webfaf/templates/Makefile.am
+++ b/src/webfaf/templates/Makefile.am
@@ -14,7 +14,7 @@ template_DATA = \
   500.html \
   about.md \
   base.html \
-  rstpage.html
+  mdpage.html
 
 templatedir = $(pythondir)/webfaf/templates
 

--- a/src/webfaf/templates/about.md.in
+++ b/src/webfaf/templates/about.md.in
@@ -1,1 +1,1 @@
-# placeholder. this file is replaced with README.rst from project root
+# Placeholder. This file is replaced with README.md from project root during build.

--- a/src/webfaf/templates/mdpage.html
+++ b/src/webfaf/templates/mdpage.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}{{ mddoc.title }}{% endblock %}
+
+{% block body %}
+<h3>{{ mddoc.title }}</h3>
+{{ mddoc.body | safe }}
+{% endblock %}

--- a/src/webfaf/templates/rstpage.html
+++ b/src/webfaf/templates/rstpage.html
@@ -1,8 +1,0 @@
-{% extends "base.html" %}
-
-{% block title %}{{ rstdoc.title }}{% endblock %}
-
-{% block body %}
-<h3>{{ rstdoc.title }}</h3>
-{{ rstdoc.body }}
-{% endblock %}

--- a/src/webfaf/webfaf_main.py
+++ b/src/webfaf/webfaf_main.py
@@ -4,10 +4,10 @@ from logging.handlers import SMTPHandler
 import json
 
 from ratelimitingfilter import RateLimitingFilter
+import markdown2
 import munch
 import flask
 from flask import Flask, Response, current_app, send_from_directory
-from flask_rstpages import RSTPages
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.contrib.fixers import ProxyFix
 from werkzeug.local import LocalProxy
@@ -127,8 +127,10 @@ def root():
 @app.route('/about')
 @cache(hours=24)
 def about():
-    rstdoc = RSTPages().get("about")
-    return flask.render_template("rstpage.html", rstdoc=rstdoc)
+    path = flask.safe_join(app.config['TEMPLATES_DIR'], "about.md")
+    html = markdown2.markdown_path(path)
+    mddoc = {"body": html, "title": "About FAF"}
+    return flask.render_template("mdpage.html", mddoc=mddoc)
 
 
 @app.route('/component_names.json')

--- a/src/webfaf/webfaf_main.py
+++ b/src/webfaf/webfaf_main.py
@@ -129,7 +129,7 @@ def root():
 def about():
     path = flask.safe_join(app.config['TEMPLATES_DIR'], "about.md")
     html = markdown2.markdown_path(path)
-    mddoc = {"body": html, "title": "About FAF"}
+    mddoc = {"body": html, "title": "About ABRT Analytics"}
     return flask.render_template("mdpage.html", mddoc=mddoc)
 
 


### PR DESCRIPTION
Since there are no more RST pages, switched dependency on Flask-RSTPages
for markdown2, which renders Markdown documents to HTML.

Closes #766