### PR TITLE
pyfaf, webfaf: Display version number

### DIFF
--- a/src/bin/faf
+++ b/src/bin/faf
@@ -56,6 +56,7 @@ def fix_ld_library_path():
 fix_ld_library_path()
 
 # pylint: disable=wrong-import-position
+import pyfaf
 from pyfaf.cmdline import CmdlineParser
 from pyfaf.config import config
 from pyfaf.common import Plugin, log, load_plugins
@@ -74,7 +75,14 @@ def main():
     cmdline_parser = CmdlineParser(toplevel=True,
                                    desc="Perform a FAF action",
                                    prog=sys.argv[0])
+    cmdline_parser.add_argument("-V", "--version", action="store_true",
+                                help="show version information and exit")
     cmdline = cmdline_parser.parse_args()
+
+    # print version and quit
+    if cmdline.version:
+        print("ABRT Analytics v{}".format(pyfaf.__version__))
+        sys.exit(0)
 
     # Catching too general exception Exception
     # pylint: disable-msg=W0703

--- a/src/pyfaf/Makefile.am
+++ b/src/pyfaf/Makefile.am
@@ -23,3 +23,8 @@ pyfaf_PYTHON = \
     ureport_compat.py
 
 pyfafdir = $(pythondir)/pyfaf
+
+__init__.py: __init__.py.in
+	sed -e 's|@fafversion@|'$$(cat $(top_builddir)/faf-version)'|' $< > $@
+
+EXTRA_DIST = $(pyfaf_PYTHON) __init__.py.in

--- a/src/pyfaf/__init__.py.in
+++ b/src/pyfaf/__init__.py.in
@@ -19,6 +19,7 @@
 __all__ = ["checker", "cmdline", "common", "config", "local",
            "queries", "retrace", "rpm", "ureport", "utils", "actions",
            "bugtrackers", "opsys", "problemtypes", "repos"]
+__version__ = "@fafversion@"
 
 from . import checker
 from . import cmdline

--- a/src/webfaf/config.py
+++ b/src/webfaf/config.py
@@ -1,5 +1,6 @@
 import os
 from sqlalchemy.engine.url import _parse_rfc1738_args
+import pyfaf
 from pyfaf.config import config, paths
 from pyfaf.common import get_connect_string
 from pyfaf.utils.parse import str2bool
@@ -39,6 +40,7 @@ class Config(object):
     THROTTLING_RATE = int(config.get("throttle.rate", 1))
     THROTTLING_TIMEFRAME = int(config.get("throttle.timeframe", 30))
     THROTTLING_BURST = int(config.get("throttle.burst", 1))
+    FAF_VERSION = pyfaf.__version__
 
 
 class ProductionConfig(Config):

--- a/src/webfaf/templates/base.html
+++ b/src/webfaf/templates/base.html
@@ -118,7 +118,7 @@
       <div id="footer">
         <div class="container">
           {% block footer %}{% endblock %}
-          ABRT Analytics |
+          ABRT Analytics v{{ config["FAF_VERSION"] }} |
           <a href="{{ url_for('about') }}">
             About
           </a>


### PR DESCRIPTION
Display version information in web interface and add a flag (`-V`/`--verbose`) for `faf` CLI to print the same.

The number is taken from `faf-version` and stored in `faf.conf` during the build process.

Closes #664