### PR TITLE
tests: Replace createrepo usage with createrepo_c

### DIFF
--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -324,7 +324,7 @@ class ActionsTestCase(faftests.DatabaseCase):
         shutil.copyfile(self.rpm,
                         os.path.join(self.tmpdir, os.path.basename(self.rpm)))
 
-        proc = popen("createrepo", "--verbose", self.tmpdir)
+        proc = popen("createrepo_c", "--verbose", self.tmpdir)
         self.assertTrue(b"Workers Finished" in proc.stdout or b"Pool finished" in proc.stdout)
 
         self.call_action_ordered_args("repoadd", [
@@ -392,7 +392,7 @@ class ActionsTestCase(faftests.DatabaseCase):
         shutil.copyfile(self.rpm,
                         os.path.join(self.tmpdir, os.path.basename(self.rpm)))
 
-        proc = popen("createrepo", "--verbose", self.tmpdir)
+        proc = popen("createrepo_c", "--verbose", self.tmpdir)
         self.assertTrue(b"Workers Finished" in proc.stdout or b"Pool finished" in proc.stdout)
 
         self.call_action_ordered_args("repoadd", [
@@ -739,7 +739,7 @@ class ActionsTestCase(faftests.DatabaseCase):
         shutil.copyfile(self.rpm,
                         os.path.join(self.tmpdir, os.path.basename(self.rpm)))
 
-        proc = popen("createrepo", "--verbose", self.tmpdir)
+        proc = popen("createrepo_c", "--verbose", self.tmpdir)
         self.assertTrue(b"Workers Finished" in proc.stdout or b"Pool finished" in proc.stdout)
 
         self.call_action_ordered_args("repoadd", [

--- a/tests/test_dnf.py
+++ b/tests/test_dnf.py
@@ -32,7 +32,7 @@ class DnfTestCase(faftests.TestCase):
         tmpdir = tempfile.mkdtemp()
         shutil.copyfile(rpm, os.path.join(tmpdir, os.path.basename(rpm)))
 
-        proc = popen("createrepo", "--verbose", tmpdir)
+        proc = popen("createrepo_c", "--verbose", tmpdir)
         self.assertTrue(b"Workers Finished" in proc.stdout or b"Pool finished" in proc.stdout)
 
         dnf = Dnf("test_repo_name", tmpdir)

--- a/tests/test_rpm_metadata.py
+++ b/tests/test_rpm_metadata.py
@@ -91,7 +91,7 @@ class RpmMetadataTestCase(faftests.TestCase):
         shutil.copyfile(self.rpm,
                         os.path.join(self.tmpdir, os.path.basename(self.rpm)))
 
-        proc = popen("createrepo", "--verbose", self.tmpdir)
+        proc = popen("createrepo_c", "--verbose", self.tmpdir)
         self.assertTrue(b"Workers Finished" in proc.stdout or b"Pool finished" in proc.stdout)
 
     def tearDown(self):


### PR DESCRIPTION
It’s been obsoleted, so might as well not rely on the symlink.

Right now the symlinks aren’t created because of this (has since been
fixed):
https://github.com/rpm-software-management/createrepo_c/commit/b6f74272654bbd03448d590bc7dcb2788e331701

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>