### PR TITLE
Merge pull request #796 from mgrabovsky/user-mail-typo

### DIFF
--- a/src/webfaf/webfaf_main.py
+++ b/src/webfaf/webfaf_main.py
@@ -175,7 +175,7 @@ def before_request():
     elif app.config["EVERYONE_IS_ADMIN"]:
         flask.g.user = munch.Munch({
             "username": "admin",
-            "email": "admin@localhost",
+            "mail": "admin@localhost",
             "admin": True
         })
 


### PR DESCRIPTION
This fixes an error when trying to download user data via `/download_data` when `EVERYONE_IS_ADMIN` is set, possibly among other things.