### PR TITLE
webfaf: Right-align and pretty-print counts in tables

### DIFF
--- a/src/webfaf/static/css/style.css
+++ b/src/webfaf/static/css/style.css
@@ -1507,3 +1507,7 @@ li.empty-line:last-child {
 .input-group span.twitter-typeahead {
   height: inherit;
 }
+
+.cell-count {
+  text-align: right;
+}

--- a/src/webfaf/templates/_helpers.html
+++ b/src/webfaf/templates/_helpers.html
@@ -10,7 +10,7 @@
     {% for row, cnt in data %}
       <tr class="package {%- if loop.index > row_limit and data|length > row_limit+1 %} hide {%- endif %}">
         <td>{{ row }}</td>
-        <td>{{ cnt|readable_int }}</td>
+        <td class="cell-count">{{ cnt|readable_int }}</td>
       </tr>
       {% if data|length > row_limit+1 and loop.index == row_limit %}
         <tr>
@@ -39,7 +39,7 @@
 
       <tr class="package {%- if loop.index > row_limit and data|length > row_limit+1 %} hide {%- endif %}">
         <td>{{ name }}</td>
-        <td>{{ cnt.unique }} / {{ cnt.count }}</td>
+        <td class="cell-count">{{ cnt.unique|readable_int }} / {{ cnt.count|readable_int }}</td>
       </tr>
       {% if data|length > row_limit+1 and loop.index == row_limit %}
         <tr>
@@ -71,7 +71,7 @@
       {% for name, cnt, versions in data %}
         <tr class="package {%- if loop.index > row_limit and data|length > row_limit+1 %} hide {%- endif %} {%- if loop.index % 2 == 0 %} stripe {%- endif %}">
           <td>{{ name }}</td>
-          <td>{{ cnt|readable_int }}</td>
+          <td class="cell-count">{{ cnt|readable_int }}</td>
         </tr>
         {% for version, cnt in versions %}
           <tr class="version hide">

--- a/src/webfaf/templates/problems/list_table_rows.html
+++ b/src/webfaf/templates/problems/list_table_rows.html
@@ -30,6 +30,6 @@
         {{ problem.probable_fixes|join(", ") }}
       {%- endif %}
     </td>
-    <td>{{ problem.count }}</td>
+    <td class="cell-count">{{ problem.count|readable_int }}</td>
   </tr>
 {%- endfor %}

--- a/src/webfaf/templates/reports/item.html
+++ b/src/webfaf/templates/reports/item.html
@@ -101,7 +101,7 @@
               {% for name, count in unique_ocurrence_os.items() %}
                 {%- set unique_count = unique_count|default(0,true) + count.unique|default(0,true) -%}
                 {% if loop.last %}
-                  {{ unique_count }}
+                  {{ unique_count|readable_int }}
                 {% endif %}
               {% endfor %}
             </dd>

--- a/src/webfaf/templates/reports/list_table_rows.html
+++ b/src/webfaf/templates/reports/list_table_rows.html
@@ -15,6 +15,6 @@
     <td><span class='label label-default'>{{report.type}}</span></td>
     <td>{{report.last_occurrence.strftime("%Y-%m-%d")}}</td>
     <td>{{report.first_occurrence.strftime("%Y-%m-%d")}}</td>
-    <td>{{report.count}}</td>
+    <td class="cell-count">{{report.count|readable_int}}</td>
 </tr>
 {% endfor %}


### PR DESCRIPTION
The numbers are more readable if the thousands are separated and the columns are right-aligned.