### PR TITLE
pyfaf: pull-reports refactor

### DIFF
--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -70,7 +70,7 @@ class PullReports(Action):
         os.rename(tmpfilename, self.known_file)
 
     def _list_reports(self):
-        url = "/".join([self.master, "reports"])
+        url = "{0}/reports".format(self.master)
 
         try:
             u = urllib.request.urlopen(url)
@@ -94,7 +94,7 @@ class PullReports(Action):
             u.close()
 
     def _get_report(self, name):
-        url = "/".join([self.master, "report", name])
+        url = "{0}/report/{1}".format(self.master, name)
 
         try:
             u = urllib.request.urlopen(url)

--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -56,7 +56,7 @@ class PullReports(Action):
             self._full_pickle = {}
             return
 
-        with open(self.known_file, "r") as f:
+        with open(self.known_file, "rb") as f:
             self._full_pickle = pickle.load(f)
 
         self.known = self._full_pickle.get(self.master, set())
@@ -64,7 +64,7 @@ class PullReports(Action):
     def _save_known(self):
         self._full_pickle[self.master] = self.known
         tmpfilename = "{0}.tmp".format(self.known_file)
-        with open(tmpfilename, "w") as f:
+        with open(tmpfilename, "wb") as f:
             pickle.dump(self._full_pickle, f)
 
         os.rename(tmpfilename, self.known_file)
@@ -143,7 +143,7 @@ class PullReports(Action):
                 while os.path.isfile(filename):
                     filename = os.path.join(self.incoming_dir, uuid.uuid4().hex)
 
-                with open(filename, "w") as f:
+                with open(filename, "wb") as f:
                     f.write(ureport)
 
                 self.log_debug("Written to {0}".format(filename))

--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -59,11 +59,7 @@ class PullReports(Action):
         with open(self.known_file, "r") as f:
             self._full_pickle = pickle.load(f)
 
-        if self.master not in self._full_pickle:
-            self.known = set()
-            return
-
-        self.known = self._full_pickle[self.master]
+        self.known = self._full_pickle.get(self.master, set())
 
     def _save_known(self):
         self._full_pickle[self.master] = self.known
@@ -120,14 +116,7 @@ class PullReports(Action):
                           .format(name, str(ex)))
             return None
         finally:
-            u.close()
-
-        filename = os.path.join(self.incoming_dir, name)
-        while os.path.isfile(filename):
-            filename = os.path.join(self.incoming_dir, uuid.uuid4().hex)
-
-        with open(filename, "w") as f:
-            f.write(ureport)
+            response.close()
 
     def run(self, cmdline, db):
         if cmdline.master is not None:


### PR DESCRIPTION
After this change, reports that disappear from the master are automatically forgotten after the pull.

Still using pickles, since they're part of the standard library, though safer alternatives exist. Also, the data shouldn't grow uncontrollably now, since the reports are pruned regularly.

Resolves #736