### PR TITLE
centos: Use findall to search for (in)active releases

### DIFF
--- a/src/pyfaf/opsys/centos.py
+++ b/src/pyfaf/opsys/centos.py
@@ -198,9 +198,9 @@ class CentOS(System):
     def get_releases(self):
         result = {}
 
-        for release in re.split(r"\s*[,;]\s*|\s+", self.inactive_releases):
+        for release in re.findall(r"[\w\.]+", self.inactive_releases):
             result[release] = {"status": "EOL"}
-        for release in re.split(r"\s*[,;]\s*|\s+", self.active_releases):
+        for release in re.findall(r"[\w\.]+", self.active_releases):
             result[release] = {"status": "ACTIVE"}
 
         return result


### PR DESCRIPTION
re.split produces an empty string ('') when the (in)active release variable is empty.
That causes creation of CentOS with empty ('') release.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>