### PR TITLE
storage: Create joined idex for semver and semrel

### DIFF
--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -17,7 +17,7 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql.schema import Column, ForeignKey, UniqueConstraint
+from sqlalchemy.sql.schema import Column, ForeignKey, UniqueConstraint, Index
 from sqlalchemy.types import Boolean, DateTime, Enum, Integer, String
 
 from .custom_types import Semver
@@ -187,9 +187,10 @@ class Build(GenericTable):
     epoch = Column(Integer, nullable=False, index=True)
     version = Column(String(64), nullable=False, index=True)
     release = Column(String(64), nullable=False, index=True)
-    semver = Column(Semver, nullable=False, index=True)  # semantic version
-    semrel = Column(Semver, nullable=False, index=True)  # semantic release
+    semver = Column(Semver, nullable=False)  # semantic version
+    semrel = Column(Semver, nullable=False)  # semantic release
     projrelease = relationship(ProjRelease)
+    Index("ix_builds_semver_semrel", semver, semrel)
 
     def nvr(self):
         return "{0}-{1}-{2}".format(self.base_package_name, self.version, self.release)

--- a/src/pyfaf/storage/report.py
+++ b/src/pyfaf/storage/report.py
@@ -20,7 +20,7 @@ from collections import namedtuple
 from string import ascii_uppercase #pylint: disable=deprecated-module
 
 from sqlalchemy.orm import backref, relationship
-from sqlalchemy.sql.schema import Column, ForeignKey, UniqueConstraint
+from sqlalchemy.sql.schema import Column, ForeignKey, UniqueConstraint, Index
 from sqlalchemy.types import Boolean, Date, DateTime, Enum, Integer, String
 
 from pyfaf.utils.storage import format_reason, most_common_crash_function
@@ -352,8 +352,9 @@ class ReportUnknownPackage(GenericTable):
     count = Column(Integer, nullable=False)
     report = relationship(Report, backref="unknown_packages")
     arch = relationship(Arch, primaryjoin="Arch.id==ReportUnknownPackage.arch_id")
-    semver = Column(Semver, nullable=False, index=True)  # semantic version
-    semrel = Column(Semver, nullable=False, index=True)  # semantic release
+    semver = Column(Semver, nullable=False)  # semantic version
+    semrel = Column(Semver, nullable=False)  # semantic release
+    Index("ix_reportunknownpackages_semver_semrel", semver, semrel)
 
     def nvr(self):
         return "{0}-{1}-{2}".format(self.name, self.version, self.release)


### PR DESCRIPTION
Indexes created by sqlalchemy were different from those defined in migration script
from 33463768031f0e408fc06d74596450656eacdc05.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>