### PR TITLE
python: Add srcline to stacktraces

### DIFF
--- a/src/pyfaf/problemtypes/python.py
+++ b/src/pyfaf/problemtypes/python.py
@@ -145,6 +145,9 @@ class PythonProblem(ProblemType):
             frame.file_line = db_frame.symbolsource.offset
             frame.file_name = db_frame.symbolsource.path
 
+            if db_frame.symbolsource.srcline is not None:
+                frame.line_contents = db_frame.symbolsource.srcline
+
             stacktrace.frames.append(frame)
 
         return stacktrace


### PR DESCRIPTION
Wrong indentation in commit e40e33e177624c830a816df05b3aae8ec8bddf2 caused that line was
removed as part of Python2 cleanup in commit 71aca54f28452ffa957922d712e83b5611156cea

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>