### PR TITLE
Celery issues

### DIFF
--- a/src/pyfaf/actions/archadd.py
+++ b/src/pyfaf/actions/archadd.py
@@ -43,4 +43,5 @@ class ArchAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", nargs="+", help="name of new architecture")
+        parser.add_argument("NAME", nargs="+", validators=[("InputRequired", {})],
+                            help="name of new architecture")

--- a/src/pyfaf/actions/assign_release_to_builds.py
+++ b/src/pyfaf/actions/assign_release_to_builds.py
@@ -144,9 +144,9 @@ class AssignReleaseToBuilds(Action):
 
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys_pos_arg(helpstr="operating system to be assigned")
-        parser.add_opsys_release_pos_arg(helpstr="release to be assigned")
-        parser.add_arch_pos_arg(helpstr="architecture to be assigned")
+        parser.add_opsys(positional=True, helpstr="operating system to be assigned")
+        parser.add_opsys_release(positional=True, helpstr="release to be assigned")
+        parser.add_arch(positional=True, helpstr="architecture to be assigned")
         parser.add_argument("--expression", dest='expression',
                             help="sql 'like' statement will be used with given"
                                  " expession")

--- a/src/pyfaf/actions/assign_release_to_builds.py
+++ b/src/pyfaf/actions/assign_release_to_builds.py
@@ -144,9 +144,9 @@ class AssignReleaseToBuilds(Action):
 
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("OPSYS", help="operating system to be assigned")
-        parser.add_argument("RELEASE", help="release to be assigned")
-        parser.add_argument("ARCH", help="architecture to be assigned")
+        parser.add_opsys_pos_arg(helpstr="operating system to be assigned")
+        parser.add_opsys_release_pos_arg(helpstr="release to be assigned")
+        parser.add_arch_pos_arg(helpstr="architecture to be assigned")
         parser.add_argument("--expression", dest='expression',
                             help="sql 'like' statement will be used with given"
                                  " expession")

--- a/src/pyfaf/actions/assign_release_to_builds.py
+++ b/src/pyfaf/actions/assign_release_to_builds.py
@@ -144,8 +144,8 @@ class AssignReleaseToBuilds(Action):
 
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(positional=True, helpstr="operating system to be assigned")
-        parser.add_opsys_release(positional=True, helpstr="release to be assigned")
+        parser.add_opsys(positional=True, required=True, helpstr="operating system to be assigned")
+        parser.add_opsys_release(positional=True, required=True, helpstr="release to be assigned")
         parser.add_arch(positional=True, helpstr="architecture to be assigned")
         parser.add_argument("--expression", dest='expression',
                             help="sql 'like' statement will be used with given"

--- a/src/pyfaf/actions/check_repo.py
+++ b/src/pyfaf/actions/check_repo.py
@@ -62,7 +62,7 @@ class CheckRepo(Action):
 
     def run(self, cmdline, db):
         repos = []
-        for reponame in cmdline.REPONAME:
+        for reponame in cmdline.REPO:
             repo = (db.session.query(Repo)
                     .filter(Repo.name == reponame)
                     .first())
@@ -71,7 +71,7 @@ class CheckRepo(Action):
             else:
                 print("Repository '{0}' does not exists".format(reponame))
 
-        if not cmdline.REPONAME:
+        if not cmdline.REPO:
             for repo in db.session.query(Repo):
                 repos.append(repo)
 
@@ -85,5 +85,4 @@ class CheckRepo(Action):
             print("Everything is OK!")
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("REPONAME",
-                            help="Repo name to be checked", nargs='*')
+        parser.add_repo(multiple=True, helpstr="Name of the repo to be checked")

--- a/src/pyfaf/actions/cleanup_packages.py
+++ b/src/pyfaf/actions/cleanup_packages.py
@@ -106,7 +106,7 @@ class CleanupPackages(Action):
 
     def tweak_cmdline_parser(self, parser):
         opsys_group = parser.add_argument_group("Required together")
-        opsys_group.add_argument("OPSYS", nargs='?', help="operating system")
-        opsys_group.add_argument("RELEASE", nargs='?', help="release")
+        opsys_group.add_opsys_pos_arg(helpstr="operating system")
+        opsys_group.add_opsys_release_pos_arg(helpstr="release")
         arch_group = parser.add_argument_group("Individual")
-        arch_group.add_argument("--arch", help="architecture")
+        arch_group.add_arch(helpstr="architecture")

--- a/src/pyfaf/actions/cleanup_packages.py
+++ b/src/pyfaf/actions/cleanup_packages.py
@@ -29,18 +29,8 @@ class CleanupPackages(Action):
     name = "cleanup-packages"
 
     def run(self, cmdline, db):
-        # in case we're using the web UI:
-        if not hasattr(cmdline, "dry_run"):
-            cmdline.dry_run = False
-
-        # nobody will write the full name
-        if cmdline.OPSYS == "rhel":
-            cmdline.OPSYS = "Red Hat Enterprise Linux"
-
-        # check if operating system is known
-        if not get_opsys_by_name(db, cmdline.OPSYS):
-            self.log_error("Selected operating system '{0}' is not supported."
-                           .format(cmdline.OPSYS))
+        if not cmdline.OPSYS and not cmdline.RELEASE and not cmdline.arch:
+            self.log_error("None of the arguments were specified.")
             return 1
 
         if (cmdline.OPSYS or cmdline.RELEASE) and cmdline.arch:
@@ -50,6 +40,10 @@ class CleanupPackages(Action):
         if cmdline.OPSYS and not cmdline.RELEASE:
             self.log_error("Missing RELEASE argument.")
             return 1
+
+        # in case we're using the web UI:
+        if not hasattr(cmdline, "dry_run"):
+            cmdline.dry_run = False
 
         if cmdline.OPSYS:
             # nobody will write the full name
@@ -112,12 +106,10 @@ class CleanupPackages(Action):
                         .filter(Package.build_id == build.build_id)
                         .all()):
                 self.delete_package(pkg, cmdline.dry_run)
-                self.delete_package(pkg)
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        opsys_group = parser.add_argument_group("Required together")
-        opsys_group.add_opsys(positional=True, helpstr="operating system")
-        opsys_group.add_opsys_release(positional=True, helpstr="release")
-        arch_group = parser.add_argument_group("Individual")
-        arch_group.add_arch(helpstr="architecture")
+        #TODO: use two argument groups: OS and release, and architecture # pylint: disable=fixme
+        parser.add_opsys(positional=True, helpstr="operating system")
+        parser.add_opsys_release(positional=True, helpstr="release")
+        parser.add_arch(helpstr="architecture")

--- a/src/pyfaf/actions/cleanup_packages.py
+++ b/src/pyfaf/actions/cleanup_packages.py
@@ -106,7 +106,7 @@ class CleanupPackages(Action):
 
     def tweak_cmdline_parser(self, parser):
         opsys_group = parser.add_argument_group("Required together")
-        opsys_group.add_opsys_pos_arg(helpstr="operating system")
-        opsys_group.add_opsys_release_pos_arg(helpstr="release")
+        opsys_group.add_opsys(positional=True, helpstr="operating system")
+        opsys_group.add_opsys_release(positional=True, helpstr="release")
         arch_group = parser.add_argument_group("Individual")
         arch_group.add_arch(helpstr="architecture")

--- a/src/pyfaf/actions/componentadd.py
+++ b/src/pyfaf/actions/componentadd.py
@@ -77,6 +77,6 @@ class ComponentAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(helpstr="operating system")
+        parser.add_opsys(required=True, helpstr="operating system")
         parser.add_opsys_release(multiple=True, helpstr="operating system release")
-        parser.add_argument("COMPONENT", help="Component name")
+        parser.add_argument("COMPONENT", validators=[("InputRequired", {})], help="Component name")

--- a/src/pyfaf/actions/componentadd.py
+++ b/src/pyfaf/actions/componentadd.py
@@ -77,6 +77,6 @@ class ComponentAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys()
-        parser.add_opsys_release(multiple=True)
+        parser.add_opsys(helpstr="operating system")
+        parser.add_opsys_release(multiple=True, helpstr="operating system release")
         parser.add_argument("COMPONENT", help="Component name")

--- a/src/pyfaf/actions/delete_invalid_ureports.py
+++ b/src/pyfaf/actions/delete_invalid_ureports.py
@@ -25,6 +25,10 @@ class DeleteInvalidUReports(Action):
     name = "delete-invalid-ureports"
 
     def run(self, cmdline, db):
+        # in case we're using the web UI:
+        if not hasattr(cmdline, "dry_run"):
+            cmdline.dry_run = False
+
         if cmdline.age:
             age = int(cmdline.age)
             if age < 0:

--- a/src/pyfaf/actions/extfafadd.py
+++ b/src/pyfaf/actions/extfafadd.py
@@ -52,5 +52,7 @@ class ExternalFafAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", help="Nice name of the instance")
-        parser.add_argument("BASEURL", help="API root")
+        parser.add_argument("NAME", validators=[("InputRequired", {})],
+                            help="Nice name of the instance")
+        parser.add_argument("BASEURL", validators=[("URL", {"require_tld": False})],
+                            help="API root")

--- a/src/pyfaf/actions/extfafclonebz.py
+++ b/src/pyfaf/actions/extfafclonebz.py
@@ -19,6 +19,7 @@
 import datetime
 import re
 import urllib
+
 from pyfaf.actions import Action
 from pyfaf.bugtrackers import bugtrackers
 from pyfaf.bugtrackers.bugzilla import Bugzilla
@@ -174,7 +175,9 @@ class ExternalFafCloneBZ(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_bugtracker()
-        parser.add_argument("NEW_PRODUCT", help="Product to clone bugs against")
-        parser.add_argument("NEW_VERSION", help="Version of the product")
+        parser.add_argument("NEW_PRODUCT", validators=[("InputRequired", {})],
+                            help="Product to clone bugs against")
+        parser.add_argument("NEW_VERSION", validators=[("InputRequired", {})],
+                            help="Version of the product")
         parser.add_argument("--baseurl",
                             help="Prefix for referencing local bugs")

--- a/src/pyfaf/actions/extfafclonebz.py
+++ b/src/pyfaf/actions/extfafclonebz.py
@@ -173,4 +173,4 @@ class ExternalFafCloneBZ(Action):
         parser.add_argument("NEW_PRODUCT", help="Product to clone bugs against")
         parser.add_argument("NEW_VERSION", help="Version of the product")
         parser.add_argument("--baseurl",
-                            help="Prefix for referrencing local bugs")
+                            help="Prefix for referencing local bugs")

--- a/src/pyfaf/actions/extfafclonebz.py
+++ b/src/pyfaf/actions/extfafclonebz.py
@@ -81,6 +81,10 @@ class ExternalFafCloneBZ(Action):
                       "create a large number of bugs in the selected Bugzilla "
                       "instance so be sure you really know what you are doing.")
 
+        # in case we're using the web UI:
+        if not hasattr(cmdline, "dry_run"):
+            cmdline.dry_run = False
+
         if cmdline.baseurl is not None:
             self.baseurl = cmdline.baseurl
 

--- a/src/pyfaf/actions/extfafdelete.py
+++ b/src/pyfaf/actions/extfafdelete.py
@@ -53,7 +53,6 @@ class ExternalFafDelete(Action):
         db.session.flush()
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("INSTANCE_ID", action="append", type=int,
-                            default=[], help="FAF instance ID to delete")
+        parser.add_ext_instance(multiple=True, helpstr="Instance to delete")
         parser.add_argument("--cascade", action="store_true", default=False,
                             help="Delete reports assigned to the instance")

--- a/src/pyfaf/actions/extfaflink.py
+++ b/src/pyfaf/actions/extfaflink.py
@@ -117,6 +117,4 @@ class ExternalFafLink(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("INSTANCE_ID", type=int,
-                            help=("ID of the external FAF "
-                                  "instance to link against"))
+        parser.add_ext_instance(helpstr="ID of the external FAF instance to link against")

--- a/src/pyfaf/actions/extfafmodify.py
+++ b/src/pyfaf/actions/extfafmodify.py
@@ -56,6 +56,6 @@ class ExternalFafModify(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("INSTANCE_ID", type=int, help="Instance to modify")
+        parser.add_ext_instance(helpstr="Instance to modify")
         parser.add_argument("--name", help="Update the nice name")
         parser.add_argument("--baseurl", help="Update the base URL - API root")

--- a/src/pyfaf/actions/find_components.py
+++ b/src/pyfaf/actions/find_components.py
@@ -91,4 +91,4 @@ class FindComponents(Action):
             db.session.flush()
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(multiple=True)
+        parser.add_opsys(multiple=True, helpstr="operating system")

--- a/src/pyfaf/actions/mark_probably_fixed.py
+++ b/src/pyfaf/actions/mark_probably_fixed.py
@@ -293,5 +293,5 @@ class MarkProbablyFixed(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(multiple=True)
-        parser.add_opsys_release(multiple=True)
+        parser.add_opsys(multiple=True, helpstr="operating system")
+        parser.add_opsys_release(multiple=True, helpstr="operating system release")

--- a/src/pyfaf/actions/opsysadd.py
+++ b/src/pyfaf/actions/opsysadd.py
@@ -42,4 +42,5 @@ class OpSysAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument('NAME', help='name of new operating system')
+        parser.add_argument('NAME', validators=[("InputRequired", [])],
+                            help='name of new operating system')

--- a/src/pyfaf/actions/opsysdel.py
+++ b/src/pyfaf/actions/opsysdel.py
@@ -25,28 +25,29 @@ class OpSysDel(Action):
 
 
     def run(self, cmdline, db):
-        opsys = get_opsys_by_name(db, cmdline.NAME)
+        for opsys in cmdline.OPSYS:
+            db_opsys = get_opsys_by_name(db, opsys)
 
-        if not opsys:
-            self.log_error("Operating system '{0}' not found"
-                           .format(cmdline.NAME))
-            return 1
+            if not db_opsys:
+                self.log_warn("Operating system '{0}' not found"
+                              .format(db_opsys))
+                continue
 
-        if opsys.releases:
-            self.log_error("Unable to delete operating system with associated"
-                           " releases. Following is the list of associated "
-                           " releases:")
-            for release in opsys.releases:
-                self.log_error(release)
+            if db_opsys.releases:
+                self.log_warn("Unable to delete operating system with associated"
+                              " releases. Following is the list of associated "
+                              " releases:")
+                for release in db_opsys.releases:
+                    self.log_warn(release)
 
-            return 1
+                continue
 
-        self.log_info("Removing operating system '{0}'".format(cmdline.NAME))
+            self.log_info("Removing operating system '{0}'".format(opsys))
 
-        db.session.delete(opsys)
-        db.session.flush()
+            db.session.delete(db_opsys)
+            db.session.flush()
 
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument('NAME', help='name of new operating system')
+        parser.add_opsys_pos_arg(multiple=True, helpstr="operating system to delete")

--- a/src/pyfaf/actions/opsysdel.py
+++ b/src/pyfaf/actions/opsysdel.py
@@ -50,4 +50,4 @@ class OpSysDel(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(positional=True, multiple=True, helpstr="operating system to delete")
+        parser.add_opsys(positional=True, required=True, multiple=True, helpstr="operating system to delete")

--- a/src/pyfaf/actions/opsysdel.py
+++ b/src/pyfaf/actions/opsysdel.py
@@ -50,4 +50,4 @@ class OpSysDel(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys_pos_arg(multiple=True, helpstr="operating system to delete")
+        parser.add_opsys(positional=True, multiple=True, helpstr="operating system to delete")

--- a/src/pyfaf/actions/pull_associates.py
+++ b/src/pyfaf/actions/pull_associates.py
@@ -128,4 +128,4 @@ class PullAssociates(Action):
                 db.session.flush()
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(multiple=True)
+        parser.add_opsys(multiple=True, helpstr="operating system")

--- a/src/pyfaf/actions/pull_bug.py
+++ b/src/pyfaf/actions/pull_bug.py
@@ -38,5 +38,5 @@ class PullBug(Action):
         parser.add_bugtracker(required=True,
                               help="pull bug from this bug tracker")
 
-        parser.add_argument("BUG_ID",
+        parser.add_argument("BUG_ID", validators=[("InputRequired", {})],
                             help="download bug with this ID")

--- a/src/pyfaf/actions/pull_components.py
+++ b/src/pyfaf/actions/pull_components.py
@@ -148,5 +148,5 @@ class PullComponents(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(multiple=True)
-        parser.add_opsys_release(multiple=True)
+        parser.add_opsys(multiple=True, helpstr="operating system")
+        parser.add_opsys_release(multiple=True, helpstr="operating system release")

--- a/src/pyfaf/actions/pull_releases.py
+++ b/src/pyfaf/actions/pull_releases.py
@@ -97,4 +97,4 @@ class PullReleases(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys()
+        parser.add_opsys(helpstr="operating system")

--- a/src/pyfaf/actions/releaseadd.py
+++ b/src/pyfaf/actions/releaseadd.py
@@ -21,7 +21,6 @@ from pyfaf.opsys import systems
 from pyfaf.queries import get_opsys_by_name, get_osrelease
 from pyfaf.storage import OpSysRelease, OpSysReleaseStatus
 
-
 class ReleaseAdd(Action):
     name = "releaseadd"
 
@@ -66,6 +65,8 @@ class ReleaseAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(helpstr="operating system")
-        parser.add_argument("--opsys-release", help="operating system release")
-        parser.add_opsys_rel_status()
+        parser.add_opsys(required=True, helpstr="operating system")
+        parser.add_argument("--opsys-release", required=True,
+                            validators=["validators.InputRequired()"],
+                            help="operating system release")
+        parser.add_opsys_rel_status(required=True)

--- a/src/pyfaf/actions/releaseadd.py
+++ b/src/pyfaf/actions/releaseadd.py
@@ -66,6 +66,6 @@ class ReleaseAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys()
+        parser.add_opsys(helpstr="operating system")
         parser.add_argument("--opsys-release", help="operating system release")
         parser.add_opsys_rel_status()

--- a/src/pyfaf/actions/releaseadd.py
+++ b/src/pyfaf/actions/releaseadd.py
@@ -67,6 +67,5 @@ class ReleaseAdd(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_opsys()
-        parser.add_opsys_release()
-        parser.add_argument("-s", "--status", default="ACTIVE",
-                            help="ACTIVE, UNDER_DEVELOPMENT or EOL")
+        parser.add_argument("--opsys-release", help="operating system release")
+        parser.add_opsys_rel_status()

--- a/src/pyfaf/actions/releasedel.py
+++ b/src/pyfaf/actions/releasedel.py
@@ -207,5 +207,5 @@ class ReleaseDelete(Action):
         self.log_info("Empty problems found: {0}".format(problems_found))
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys()
-        parser.add_opsys_release()
+        parser.add_opsys(helpstr="operating system")
+        parser.add_opsys_release(helpstr="operating system release")

--- a/src/pyfaf/actions/releasedel.py
+++ b/src/pyfaf/actions/releasedel.py
@@ -207,5 +207,5 @@ class ReleaseDelete(Action):
         self.log_info("Empty problems found: {0}".format(problems_found))
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(helpstr="operating system")
-        parser.add_opsys_release(helpstr="operating system release")
+        parser.add_opsys(required=True, helpstr="operating system")
+        parser.add_opsys_release(required=True, helpstr="operating system release")

--- a/src/pyfaf/actions/releasemod.py
+++ b/src/pyfaf/actions/releasemod.py
@@ -64,6 +64,6 @@ class ReleaseModify(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys()
-        parser.add_opsys_release()
+        parser.add_opsys(helpstr="operating system")
+        parser.add_opsys_release(helpstr="operating system release")
         parser.add_opsys_rel_status()

--- a/src/pyfaf/actions/releasemod.py
+++ b/src/pyfaf/actions/releasemod.py
@@ -66,5 +66,4 @@ class ReleaseModify(Action):
     def tweak_cmdline_parser(self, parser):
         parser.add_opsys()
         parser.add_opsys_release()
-        parser.add_argument("-s", "--status", default=None,
-                            help="ACTIVE, UNDER_DEVELOPMENT or EOL")
+        parser.add_opsys_rel_status()

--- a/src/pyfaf/actions/releasemod.py
+++ b/src/pyfaf/actions/releasemod.py
@@ -64,6 +64,6 @@ class ReleaseModify(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(helpstr="operating system")
-        parser.add_opsys_release(helpstr="operating system release")
-        parser.add_opsys_rel_status()
+        parser.add_opsys(required=True, helpstr="operating system")
+        parser.add_opsys_release(required=True, helpstr="operating system release")
+        parser.add_opsys_rel_status(required=True)

--- a/src/pyfaf/actions/repoadd.py
+++ b/src/pyfaf/actions/repoadd.py
@@ -60,8 +60,7 @@ class RepoAdd(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_argument("NAME", help="name of the new repository")
-        parser.add_argument("TYPE", choices=self.repo_types,
-                            help="type of the repository")
+        parser.add_repo_type_pos_arg(choices=self.repo_types, required=True, helpstr="type of the repository")
         parser.add_argument("URL", nargs="*",
                             help="repository/buildsystem API URL")
         parser.add_argument("--nice-name", help="human readable name")

--- a/src/pyfaf/actions/repoadd.py
+++ b/src/pyfaf/actions/repoadd.py
@@ -59,7 +59,7 @@ class RepoAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", help="name of this repository")
+        parser.add_argument("NAME", help="name of the new repository")
         parser.add_argument("TYPE", choices=self.repo_types,
                             help="type of the repository")
         parser.add_argument("URL", nargs="*",

--- a/src/pyfaf/actions/repoadd.py
+++ b/src/pyfaf/actions/repoadd.py
@@ -60,7 +60,7 @@ class RepoAdd(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_argument("NAME", help="name of the new repository")
-        parser.add_repo_type_pos_arg(choices=self.repo_types, required=True, helpstr="type of the repository")
+        parser.add_repo_type(choices=self.repo_types, required=True, positional=True, helpstr="type of the repository")
         parser.add_argument("URL", nargs="*",
                             help="repository/buildsystem API URL")
         parser.add_argument("--nice-name", help="human readable name")

--- a/src/pyfaf/actions/repoadd.py
+++ b/src/pyfaf/actions/repoadd.py
@@ -59,9 +59,12 @@ class RepoAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", help="name of the new repository")
-        parser.add_repo_type(choices=self.repo_types, required=True, positional=True, helpstr="type of the repository")
-        parser.add_argument("URL", nargs="*",
+        parser.add_argument("NAME", validators=[("InputRequired", {})],
+                            help="name of the new repository")
+        parser.add_repo_type(choices=self.repo_types, required=True, positional=True,
+                             helpstr="type of the repository")
+        #TODO: add a URL validator that works for a field with comma-separated values #pylint: disable=fixme
+        parser.add_argument("URL", nargs="+", validators=[("InputRequired", {})],
                             help="repository/buildsystem API URL")
         parser.add_argument("--nice-name", help="human readable name")
         parser.add_argument("--nogpgcheck", action="store_true",

--- a/src/pyfaf/actions/repoassign.py
+++ b/src/pyfaf/actions/repoassign.py
@@ -115,5 +115,5 @@ class RepoAssign(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_repo(helpstr="name of the repository")
-        parser.add_opsys_with_rel_pos_arg(multiple=True)
-        parser.add_arch_pos_arg()
+        parser.add_opsys_with_rel_pos_arg(multiple=True, helpstr="operating system (with release)")
+        parser.add_arch_pos_arg(multiple=True, helpstr="architecture")

--- a/src/pyfaf/actions/repoassign.py
+++ b/src/pyfaf/actions/repoassign.py
@@ -115,5 +115,6 @@ class RepoAssign(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_repo(helpstr="name of the repository")
-        parser.add_opsys_with_rel_pos_arg(multiple=True, helpstr="operating system (with release)")
-        parser.add_arch_pos_arg(multiple=True, helpstr="architecture")
+        parser.add_opsys(multiple=True, positional=True, with_rel=True,
+                         helpstr="operating system with release")
+        parser.add_arch(multiple=True, positional=True, helpstr="architecture")

--- a/src/pyfaf/actions/repoassign.py
+++ b/src/pyfaf/actions/repoassign.py
@@ -115,5 +115,5 @@ class RepoAssign(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_repo(helpstr="name of the repository")
-        parser.add_opsys_pos_arg()
+        parser.add_opsys_with_rel_pos_arg()
         parser.add_arch_pos_arg()

--- a/src/pyfaf/actions/repoassign.py
+++ b/src/pyfaf/actions/repoassign.py
@@ -27,12 +27,12 @@ class RepoAssign(Action):
 
     def run(self, cmdline, db):
         repo = (db.session.query(Repo)
-                .filter(Repo.name == cmdline.NAME)
+                .filter(Repo.name == cmdline.REPO)
                 .first())
 
         if not repo:
             self.log_error("Repository '{0}' not found"
-                           .format(cmdline.NAME))
+                           .format(cmdline.REPO))
             return 1
 
         arch_list = []
@@ -114,8 +114,6 @@ class RepoAssign(Action):
 
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", help="name of the repository")
-        parser.add_argument("OPSYS", nargs="*",
-                            help="operating system")
-        parser.add_argument("ARCH", nargs="*",
-                            help="architecture")
+        parser.add_repo(helpstr="name of the repository")
+        parser.add_opsys_pos_arg()
+        parser.add_arch_pos_arg()

--- a/src/pyfaf/actions/repoassign.py
+++ b/src/pyfaf/actions/repoassign.py
@@ -115,5 +115,5 @@ class RepoAssign(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_repo(helpstr="name of the repository")
-        parser.add_opsys_with_rel_pos_arg()
+        parser.add_opsys_with_rel_pos_arg(multiple=True)
         parser.add_arch_pos_arg()

--- a/src/pyfaf/actions/repodel.py
+++ b/src/pyfaf/actions/repodel.py
@@ -26,18 +26,18 @@ class RepoDel(Action):
 
     def run(self, cmdline, db):
         repo = (db.session.query(Repo)
-                .filter(Repo.name == cmdline.NAME)
+                .filter(Repo.name == cmdline.REPO)
                 .first())
 
         if not repo:
             self.log_error("Repository '{0}' not found"
-                           .format(cmdline.NAME))
+                           .format(cmdline.REPO))
             return 1
 
         for url in repo.url_list:
             db.session.delete(url)
 
-        self.log_info("Removing repository '{0}'".format(cmdline.NAME))
+        self.log_info("Removing repository '{0}'".format(cmdline.REPO))
 
         db.session.delete(repo)
         db.session.flush()
@@ -45,4 +45,4 @@ class RepoDel(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", help="name of the repository to delete")
+        parser.add_repo(helpstr="name of the repository to delete")

--- a/src/pyfaf/actions/repoimport.py
+++ b/src/pyfaf/actions/repoimport.py
@@ -108,6 +108,5 @@ class RepoImport(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("TYPE", choices=self.repo_types,
-                            help="type of the repository")
+        parser.add_repo_type_pos_arg(choices=self.repo_types, required=True, helpstr="type of the repository")
         parser.add_argument("FILE", help="repository file")

--- a/src/pyfaf/actions/repoimport.py
+++ b/src/pyfaf/actions/repoimport.py
@@ -108,5 +108,6 @@ class RepoImport(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_repo_type(choices=self.repo_types, required=True, positional=True, helpstr="type of the repository")
-        parser.add_argument("FILE", help="repository file")
+        parser.add_repo_type(choices=self.repo_types, required=True, positional=True,
+                             helpstr="type of the repository")
+        parser.add_file(helpstr="repository file")

--- a/src/pyfaf/actions/repoimport.py
+++ b/src/pyfaf/actions/repoimport.py
@@ -108,5 +108,5 @@ class RepoImport(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_repo_type_pos_arg(choices=self.repo_types, required=True, helpstr="type of the repository")
+        parser.add_repo_type(choices=self.repo_types, required=True, positional=True, helpstr="type of the repository")
         parser.add_argument("FILE", help="repository file")

--- a/src/pyfaf/actions/repoinfo.py
+++ b/src/pyfaf/actions/repoinfo.py
@@ -26,11 +26,11 @@ class RepoInfo(Action):
 
     def run(self, cmdline, db):
         repo = (db.session.query(Repo)
-                .filter(Repo.name == cmdline.NAME)
+                .filter(Repo.name == cmdline.REPO)
                 .first())
 
         if not repo:
-            self.log_error("Repository '{0}' not found".format(cmdline.NAME))
+            self.log_error("Repository '{0}' not found".format(cmdline.REPO))
             return 1
 
         print("Name: {0}".format(repo.name))
@@ -54,7 +54,7 @@ class RepoInfo(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", help="name of the repository")
+        parser.add_repo(helpstr="name of the repository")
         parser.add_argument("-a", "--assigned", action="store_true",
                             help="list assigned operating systems"
                                  " and architectures")

--- a/src/pyfaf/actions/repomod.py
+++ b/src/pyfaf/actions/repomod.py
@@ -90,8 +90,7 @@ class RepoMod(Action):
     def tweak_cmdline_parser(self, parser):
         parser.add_repo(helpstr="current name of the repository")
         parser.add_argument("--name", help="new name of the repository")
-        parser.add_argument("--type", choices=self.repo_types,
-                            help="new type of the repository")
+        parser.add_repo_type(choices=self.repo_types, helpstr="new type of the repository")
         parser.add_argument("--add-url", help="new repository URL")
         parser.add_argument("--remove-url", help="new repository URL")
         parser.add_argument("--nice-name", help="new human readable name")

--- a/src/pyfaf/actions/repomod.py
+++ b/src/pyfaf/actions/repomod.py
@@ -38,10 +38,6 @@ class RepoMod(Action):
                            .format(cmdline.REPO))
             return 1
 
-        if cmdline.gpgcheck and cmdline.nogpgcheck:
-            self.log_error("Argument --gpgcheck not allowed with --nogpgcheck.")
-            return 1
-
         if cmdline.name:
             dbrepo = (db.session.query(Repo)
                       .filter(Repo.name == cmdline.name)
@@ -79,10 +75,10 @@ class RepoMod(Action):
             repo.url_list.remove(url)
             db.session.delete(url)
 
-        if cmdline.gpgcheck:
+        if cmdline.gpgcheck == "enable":
             repo.nogpgcheck = False
 
-        if cmdline.nogpgcheck:
+        if cmdline.gpgcheck == "disable":
             repo.nogpgcheck = True
 
         db.session.add(repo)
@@ -98,9 +94,4 @@ class RepoMod(Action):
         parser.add_argument("--add-url", help="new repository URL")
         parser.add_argument("--remove-url", help="new repository URL")
         parser.add_argument("--nice-name", help="new human readable name")
-
-        group = parser.add_argument_group()
-        group.add_argument("--gpgcheck", action="store_true",
-                           help="enable GPG check for this repository")
-        group.add_argument("--nogpgcheck", action="store_true",
-                           help="disable GPG check for this repository")
+        parser.add_gpgcheck_toggle(helpstr="toggle GPG check requirement for this repository")

--- a/src/pyfaf/actions/repomod.py
+++ b/src/pyfaf/actions/repomod.py
@@ -30,12 +30,12 @@ class RepoMod(Action):
 
     def run(self, cmdline, db):
         repo = (db.session.query(Repo)
-                .filter(Repo.name == cmdline.NAME)
+                .filter(Repo.name == cmdline.REPO)
                 .first())
 
         if not repo:
             self.log_error("Repository '{0}' not found"
-                           .format(cmdline.NAME))
+                           .format(cmdline.REPO))
             return 1
 
         if cmdline.name:
@@ -88,7 +88,7 @@ class RepoMod(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", help="name of this repository")
+        parser.add_repo(helpstr="current name of the repository")
         parser.add_argument("--name", help="new name of the repository")
         parser.add_argument("--type", choices=self.repo_types,
                             help="new type of the repository")
@@ -98,6 +98,6 @@ class RepoMod(Action):
 
         group = parser.add_mutually_exclusive_group()
         group.add_argument("--gpgcheck", action="store_true",
-                           help="enable gpg check for this repository")
+                           help="enable GPG check for this repository")
         group.add_argument("--nogpgcheck", action="store_true",
-                           help="disable gpg check for this repository")
+                           help="disable GPG check for this repository")

--- a/src/pyfaf/actions/repomod.py
+++ b/src/pyfaf/actions/repomod.py
@@ -38,6 +38,10 @@ class RepoMod(Action):
                            .format(cmdline.REPO))
             return 1
 
+        if cmdline.gpgcheck and cmdline.nogpgcheck:
+            self.log_error("Argument --gpgcheck not allowed with --nogpgcheck.")
+            return 1
+
         if cmdline.name:
             dbrepo = (db.session.query(Repo)
                       .filter(Repo.name == cmdline.name)
@@ -95,7 +99,7 @@ class RepoMod(Action):
         parser.add_argument("--remove-url", help="new repository URL")
         parser.add_argument("--nice-name", help="new human readable name")
 
-        group = parser.add_mutually_exclusive_group()
+        group = parser.add_argument_group()
         group.add_argument("--gpgcheck", action="store_true",
                            help="enable GPG check for this repository")
         group.add_argument("--nogpgcheck", action="store_true",

--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -35,7 +35,7 @@ class RepoSync(Action):
         repo_instances = []
 
         for repo in db.session.query(Repo):
-            if cmdline.NAME and repo.name not in cmdline.NAME:
+            if cmdline.REPO and repo.name not in cmdline.REPO:
                 continue
 
             if cmdline.match_repos not in repo.name:
@@ -321,7 +321,7 @@ class RepoSync(Action):
 
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("NAME", nargs="*", help="repository to sync")
+        parser.add_repo(multiple=True, helpstr="repository to sync")
         parser.add_argument("--no-download-rpm", action="store_true",
                             help="Don't download the RPM. Cannot create "
                                  "dependencies.")
@@ -329,8 +329,8 @@ class RepoSync(Action):
                             help="Download the RPM but delete it after "
                                  "processing dependencies.")
         parser.add_argument("--name-prefix", default="",
-                            help="Process only packages whose name "
-                                 "starts with the prefix")
+                            help="Process only packages whose names "
+                                 "start with the prefix")
         parser.add_argument("--match-repos", default="",
-                            help="Process only repos which name "
+                            help="Process only repos whose names "
                                  "contain given string")

--- a/src/pyfaf/actions/save_reports.py
+++ b/src/pyfaf/actions/save_reports.py
@@ -349,6 +349,11 @@ class SaveReports(Action):
             self._move_attachment_to_saved(fname)
 
     def run(self, cmdline, db):
+
+        if cmdline.pattern and cmdline.speedup:
+            self.log_error("Argument --pattern not allowed with --speedup.")
+            return 1
+
         if not cmdline.no_reports:
             if cmdline.speedup:
                 try:
@@ -366,12 +371,14 @@ class SaveReports(Action):
         if not cmdline.no_attachments:
             self._save_attachments(db)
 
+        return 0
+
     def tweak_cmdline_parser(self, parser):
         parser.add_argument("--no-reports", action="store_true", default=False,
                             help="do not process reports")
         parser.add_argument("--no-attachments", action="store_true",
                             default=False, help="do not process attachments")
-        group = parser.add_mutually_exclusive_group()
+        group = parser.add_argument_group()
         group.add_argument("--speedup", action="store_true",
                            default=False, help="Speedup the processing. "
                            "May be less accurate.")

--- a/src/pyfaf/actions/sf_prefilter_patadd.py
+++ b/src/pyfaf/actions/sf_prefilter_patadd.py
@@ -113,7 +113,7 @@ class SfPrefilterPatAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys()
+        parser.add_opsys(helpstr="operating system")
         parser.add_argument("SOLUTION", help="Solution ID or textual cause")
         parser.add_argument("--btpath", action="append", default=[],
                             help="Regexp to match the path in stacktrace")

--- a/src/pyfaf/actions/sf_prefilter_patadd.py
+++ b/src/pyfaf/actions/sf_prefilter_patadd.py
@@ -17,6 +17,7 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
+
 from pyfaf.actions import Action
 from pyfaf.opsys import systems
 from pyfaf.queries import (get_sf_prefilter_btpath_by_pattern,
@@ -114,7 +115,8 @@ class SfPrefilterPatAdd(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_opsys(helpstr="operating system")
-        parser.add_argument("SOLUTION", help="Solution ID or textual cause")
+        parser.add_argument("SOLUTION", validators=[("InputRequired", {})],
+                            help="Solution ID or textual cause")
         parser.add_argument("--btpath", action="append", default=[],
                             help="Regexp to match the path in stacktrace")
         parser.add_argument("--pkgname", action="append", default=[],

--- a/src/pyfaf/actions/sf_prefilter_patshow.py
+++ b/src/pyfaf/actions/sf_prefilter_patshow.py
@@ -74,5 +74,5 @@ class SfPrefilterPatShow(Action):
                       .format(db_pkgname.pattern, opsys_str))
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("SOLUTION_ID", nargs="*",
+        parser.add_argument("SOLUTION_ID", nargs="+", validators=[("InputRequired", {})],
                             help="The ID of the solution or cause.")

--- a/src/pyfaf/actions/sf_prefilter_soladd.py
+++ b/src/pyfaf/actions/sf_prefilter_soladd.py
@@ -17,10 +17,10 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+
 from pyfaf.actions import Action
 from pyfaf.queries import get_sf_prefilter_sol_by_cause
 from pyfaf.storage import SfPrefilterSolution
-
 
 class SfPrefilterSolAdd(Action):
     name = "sf-prefilter-soladd"
@@ -49,10 +49,10 @@ class SfPrefilterSolAdd(Action):
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("CAUSE", help=("The cause of the problem. Will be "
-                                           "shown to end-users."))
-        parser.add_argument("NOTE", help=("Non-formatted text with additional"
-                                          " information."))
+        parser.add_argument("CAUSE", validators=[("InputRequired", {})],
+                            help=("The cause of the problem. Will be shown to end-users."))
+        parser.add_argument("NOTE", validators=[("InputRequired", {})],
+                            help=("Non-formatted text with additional information."))
         parser.add_argument("--url", help=("URL where more information about "
                                            "the issue can be found."))
         parser.add_argument("--note-html", help=("HTML-formatted text with "

--- a/src/pyfaf/actions/sf_prefilter_solshow.py
+++ b/src/pyfaf/actions/sf_prefilter_solshow.py
@@ -19,7 +19,6 @@
 from pyfaf.actions import Action
 from pyfaf.queries import get_sf_prefilter_sol, get_sf_prefilter_sols
 
-
 class SfPrefilterSolShow(Action):
     name = "sf-prefilter-solshow"
 
@@ -65,5 +64,5 @@ class SfPrefilterSolShow(Action):
                     print("HTML Note: {0}".format(db_solution.note_html))
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_argument("ID", nargs="*",
+        parser.add_argument("ID", nargs="+", validators=[("InputRequired", {})],
                             help="The ID of the solution or cause.")

--- a/src/pyfaf/actions/stats.py
+++ b/src/pyfaf/actions/stats.py
@@ -459,8 +459,8 @@ class Stats(Action):
         print(out.rstrip())
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_opsys(required=True)
-        parser.add_opsys_release(required=True)
+        parser.add_opsys(required=True, helpstr="operating system")
+        parser.add_opsys_release(required=True, helpstr="operating system release")
         parser.add_argument("--components", action="store_true", default=False,
                             help="get most crashing components")
         parser.add_argument("--trends", action="store_true", default=False,

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -144,12 +144,27 @@ class CmdlineParser(ArgumentParser):
         self._add_plugin_arg("-o", "--opsys", required=required,
                              help="operating system", multiple=multiple)
 
-    def add_opsys_with_rel_pos_arg(self, required=False): # pylint: disable=unused-argument
+    def add_opsys_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
+        """
+        Add a positional argument for operating system(s)
+        """
+
+        nargs = None
+        if multiple:
+            nargs = "*"
+
+        self.add_argument("OPSYS", nargs=nargs, help=helpstr)
+
+    def add_opsys_with_rel_pos_arg(self, multiple=False, required=False): # pylint: disable=unused-argument
         """
         Add a positional argument for operating system(s) with release
         """
 
-        self.add_argument("OPSYS", nargs="*", help="operating system (with release)")
+        nargs = None
+        if multiple:
+            nargs = "*"
+
+        self.add_argument("OPSYS", nargs=nargs, help="operating system (with release)")
 
     def add_opsys_release(self, multiple=False, required=False):
         """

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -254,3 +254,13 @@ class CmdlineParser(ArgumentParser):
         defaults.update(kwargs)
 
         self._add_plugin_arg("-s", "--solution-finder", **defaults)
+
+    def add_gpgcheck_toggle(self, required=False, helpstr=None):
+        """
+        Add an argument for changing the GPG requirement property
+        """
+
+        self.add_argument("--gpgcheck",
+                          choices=["enable", "disable"],
+                          required=required,
+                          help=helpstr)

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -136,35 +136,20 @@ class CmdlineParser(ArgumentParser):
 
         self._add_plugin_arg("-b", "--bugtracker", **defaults)
 
-    def add_opsys(self, multiple=False, required=False):
+    def add_opsys(self, multiple=False, required=False, positional=False, with_rel=False, helpstr=None): # pylint: disable=unused-argument
         """
-        Add the `-o` argument for specifying operating system.
-        """
-
-        self._add_plugin_arg("-o", "--opsys", required=required,
-                             help="operating system", multiple=multiple)
-
-    def add_opsys_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
-        """
-        Add a positional argument for operating system(s)
+        Add an argument for specifying operating system.
         """
 
-        nargs = None
-        if multiple:
-            nargs = "*"
+        if positional:
+            nargs = None
+            if multiple:
+                nargs = "*"
 
-        self.add_argument("OPSYS", nargs=nargs, help=helpstr)
-
-    def add_opsys_with_rel_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
-        """
-        Add a positional argument for operating system(s) with release
-        """
-
-        nargs = None
-        if multiple:
-            nargs = "*"
-
-        self.add_argument("OPSYS", nargs=nargs, help=helpstr)
+            self.add_argument("OPSYS", nargs=nargs, help=helpstr)
+        else:
+            self._add_plugin_arg("-o", "--opsys", multiple=multiple, required=required,
+                                 help=helpstr)
 
     def add_opsys_rel_status(self, required=False):
         """
@@ -176,33 +161,33 @@ class CmdlineParser(ArgumentParser):
                           required=required,
                           help="release status")
 
-    def add_opsys_release(self, multiple=False, required=False):
+    def add_opsys_release(self, multiple=False, required=False, positional=None, helpstr=None):
         """
-        Add the `--opsys-release` argument for specifying
-        operating system release.
+        Add the argument for specifying operating system release.
         """
 
-        self._add_plugin_arg("--opsys-release", required=required,
-                             help="operating system release", multiple=multiple)
+        if positional:
+            nargs = None
+            if multiple:
+                nargs = "*"
 
-    def add_opsys_release_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
-        """
-        Add a positional argument for architecture(s)
-        """
-        nargs = None
-        if multiple:
-            nargs = "*"
+            self.add_argument("RELEASE", nargs=nargs, help=helpstr)
+        else:
+            self._add_plugin_arg("--opsys-release", required=required,
+                                 help=helpstr, multiple=multiple)
 
-        self.add_argument("RELEASE", nargs=nargs, help=helpstr)
-
-    def add_arch_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
+    def add_arch(self, multiple=False, required=False, positional=False, helpstr=None): # pylint: disable=unused-argument
         """
-        Add a positional argument for architecture(s)
+        Add an argument for architecture(s)
         """
 
         nargs = "*" if multiple else None
 
-        self.add_argument("ARCH", nargs=nargs, help=helpstr)
+        if positional:
+            self.add_argument("ARCH", nargs=nargs, help=helpstr)
+        else:
+            self._add_plugin_arg("-a", "--arch",
+                                 help=helpstr, multiple=multiple)
 
     def add_problemtype(self, multiple=False):
         """
@@ -221,17 +206,14 @@ class CmdlineParser(ArgumentParser):
 
         self.add_argument("REPO", nargs=nargs, help=helpstr)
 
-    def add_repo_type(self, choices=None, helpstr=None):
+    def add_repo_type(self, choices=None, required=False, positional=False, helpstr=None):
         """
-        Add the `--type` argument for the type of the repository.
+        Add the argument for the type of the repository.
         """
-        self.add_argument("--type", choices=choices, help=helpstr)
-
-    def add_repo_type_pos_arg(self, choices=None, required=False, helpstr=None): # pylint: disable=unused-argument
-        """
-        Add the `TYPE` positional argument for the type of the repository.
-        """
-        self.add_argument("TYPE", choices=choices, help=helpstr)
+        if positional:
+            self.add_argument("TYPE", choices=choices, help=helpstr)
+        else:
+            self.add_argument("--type", choices=choices, required=required, help=helpstr)
 
     def add_ext_instance(self, multiple=False, helpstr=None):
         """

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -155,7 +155,7 @@ class CmdlineParser(ArgumentParser):
 
         self.add_argument("OPSYS", nargs=nargs, help=helpstr)
 
-    def add_opsys_with_rel_pos_arg(self, multiple=False, required=False): # pylint: disable=unused-argument
+    def add_opsys_with_rel_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
         """
         Add a positional argument for operating system(s) with release
         """
@@ -164,7 +164,7 @@ class CmdlineParser(ArgumentParser):
         if multiple:
             nargs = "*"
 
-        self.add_argument("OPSYS", nargs=nargs, help="operating system (with release)")
+        self.add_argument("OPSYS", nargs=nargs, help=helpstr)
 
     def add_opsys_rel_status(self, required=False):
         """
@@ -185,11 +185,24 @@ class CmdlineParser(ArgumentParser):
         self._add_plugin_arg("--opsys-release", required=required,
                              help="operating system release", multiple=multiple)
 
-    def add_arch_pos_arg(self, required=False): # pylint: disable=unused-argument
+    def add_opsys_release_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
         """
         Add a positional argument for architecture(s)
         """
-        self.add_argument("ARCH", nargs="*", help="architecture")
+        nargs = None
+        if multiple:
+            nargs = "*"
+
+        self.add_argument("RELEASE", nargs=nargs, help=helpstr)
+
+    def add_arch_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
+        """
+        Add a positional argument for architecture(s)
+        """
+
+        nargs = "*" if multiple else None
+
+        self.add_argument("ARCH", nargs=nargs, help=helpstr)
 
     def add_problemtype(self, multiple=False):
         """

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -144,12 +144,12 @@ class CmdlineParser(ArgumentParser):
         self._add_plugin_arg("-o", "--opsys", required=required,
                              help="operating system", multiple=multiple)
 
-    def add_opsys_pos_arg(self, required=False): # pylint: disable=unused-argument
+    def add_opsys_with_rel_pos_arg(self, required=False): # pylint: disable=unused-argument
         """
-        Add a positional argument for operating system(s)
+        Add a positional argument for operating system(s) with release
         """
 
-        self.add_argument("OPSYS", nargs="*", help="operating system")
+        self.add_argument("OPSYS", nargs="*", help="operating system (with release)")
 
     def add_opsys_release(self, multiple=False, required=False):
         """

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -183,6 +183,12 @@ class CmdlineParser(ArgumentParser):
 
         self.add_argument("REPO", nargs=nargs, help=helpstr)
 
+    def add_repo_type(self, choices=None, helpstr=None):
+        """
+        Add the `--type` argument for the type of the repository.
+        """
+        self.add_argument("--type", choices=choices, help=helpstr)
+
     def add_solutionfinder(self, **kwargs):
         """
         Add the `-s` argument for specifying solution finders.

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -189,6 +189,12 @@ class CmdlineParser(ArgumentParser):
         """
         self.add_argument("--type", choices=choices, help=helpstr)
 
+    def add_repo_type_pos_arg(self, choices=None, required=False, helpstr=None): # pylint: disable=unused-argument
+        """
+        Add the `TYPE` positional argument for the type of the repository.
+        """
+        self.add_argument("TYPE", choices=choices, help=helpstr)
+
     def add_ext_instance(self, multiple=False, helpstr=None):
         """
         Add the `INSTANCE_ID` positional argument for an external FAF instance.

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -144,6 +144,13 @@ class CmdlineParser(ArgumentParser):
         self._add_plugin_arg("-o", "--opsys", required=required,
                              help="operating system", multiple=multiple)
 
+    def add_opsys_pos_arg(self, required=False): # pylint: disable=unused-argument
+        """
+        Add a positional argument for operating system(s)
+        """
+
+        self.add_argument("OPSYS", nargs="*", help="operating system")
+
     def add_opsys_release(self, multiple=False, required=False):
         """
         Add the `--opsys-release` argument for specifying
@@ -153,6 +160,12 @@ class CmdlineParser(ArgumentParser):
         self._add_plugin_arg("--opsys-release", required=required,
                              help="operating system release", multiple=multiple)
 
+    def add_arch_pos_arg(self, required=False): # pylint: disable=unused-argument
+        """
+        Add a positional argument for architecture(s)
+        """
+        self.add_argument("ARCH", nargs="*", help="architecture")
+
     def add_problemtype(self, multiple=False):
         """
         Add the `-p` argument for specifying problem type.
@@ -161,13 +174,14 @@ class CmdlineParser(ArgumentParser):
         self._add_plugin_arg("-p", "--problemtype",
                              help="problem type", multiple=multiple)
 
-    def add_repo(self, multiple=False):
+    def add_repo(self, multiple=False, helpstr=None):
         """
-        Add the `-r` argument for specifying repository.
+        Add a positional argument for repository/-ies
         """
 
-        self._add_plugin_arg("-r", "--repo",
-                             help="repository", multiple=multiple)
+        nargs = "*" if multiple else None
+
+        self.add_argument("REPO", nargs=nargs, help=helpstr)
 
     def add_solutionfinder(self, **kwargs):
         """

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -153,9 +153,9 @@ class CmdlineParser(ArgumentParser):
         """
 
         if positional:
-            nargs = None
+            nargs = None if required else "?"
             if multiple:
-                nargs = "*"
+                nargs = "+" if required else "*"
 
             self.add_argument("OPSYS", nargs=nargs, help=helpstr)
         else:
@@ -178,9 +178,9 @@ class CmdlineParser(ArgumentParser):
         """
 
         if positional:
-            nargs = None
+            nargs = None if required else "?"
             if multiple:
-                nargs = "*"
+                nargs = "+" if required else "*"
 
             self.add_argument("RELEASE", nargs=nargs, help=helpstr)
         else:

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -106,6 +106,17 @@ class CmdlineParser(ArgumentParser):
                 actions[action].tweak_cmdline_parser(action_parser)
                 action_parser.set_defaults(func=actions[action].run)
 
+    def add_argument(self, *args, **kwargs):
+        """
+        Override add_argument to allow passing of validators to ActionFormArgparser
+        for use in the web UI
+        """
+
+        if "validators" in kwargs:
+            del(kwargs["validators"])
+
+        super(CmdlineParser, self).add_argument(*args, **kwargs)
+
     def parse_args(self, args=None, namespace=None):
         """
         Parse command line arguments and set loglevel accordingly.
@@ -222,6 +233,14 @@ class CmdlineParser(ArgumentParser):
         nargs = "*" if multiple else None
 
         self.add_argument("INSTANCE_ID", nargs=nargs, help=helpstr)
+
+    def add_file(self, required=False, helpstr=None):
+        """
+        Add the `FILE` positional argument for repository file.
+        """
+        nargs = 1 if required else None
+
+        self.add_argument("FILE", nargs=nargs, help=helpstr)
 
     def add_solutionfinder(self, **kwargs):
         """

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -189,6 +189,14 @@ class CmdlineParser(ArgumentParser):
         """
         self.add_argument("--type", choices=choices, help=helpstr)
 
+    def add_ext_instance(self, multiple=False, helpstr=None):
+        """
+        Add the `INSTANCE_ID` positional argument for an external FAF instance.
+        """
+        nargs = "*" if multiple else None
+
+        self.add_argument("INSTANCE_ID", nargs=nargs, help=helpstr)
+
     def add_solutionfinder(self, **kwargs):
         """
         Add the `-s` argument for specifying solution finders.

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -166,6 +166,16 @@ class CmdlineParser(ArgumentParser):
 
         self.add_argument("OPSYS", nargs=nargs, help="operating system (with release)")
 
+    def add_opsys_rel_status(self, required=False):
+        """
+        Add a positional argument for operating system(s) with release
+        """
+
+        self.add_argument("-s", "--status",
+                          choices=["ACTIVE", "UNDER_DEVELOPMENT", "EOL"],
+                          required=required,
+                          help="release status")
+
     def add_opsys_release(self, multiple=False, required=False):
         """
         Add the `--opsys-release` argument for specifying

--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -338,7 +338,7 @@ class Fedora(System):
             else:
                 branch = "f{0}".format(int_release)
         else:
-            raise FafError("{0} is not a valid Fedora version")
+            raise FafError("{0} is not a valid Fedora version".format(release))
 
         return branch
 

--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -1,6 +1,7 @@
 import re
-import concurrent.futures as futures
-from pyfaf.common import FafError, log
+from concurrent import futures
+
+from pyfaf.common import FafError, log, thread_logger
 from pyfaf.queries import get_debug_files
 from pyfaf.rpm import unpack_rpm_to_tmp
 from pyfaf.utils.proc import safe_popen

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -164,7 +164,7 @@ class ActionFormArgparser():
         setattr(self.F, "opsys", field)
         self.F.argparse_fields["opsys"] = {}
 
-    def add_opsys_pos_arg(self, required=False):
+    def add_opsys_with_rel_pos_arg(self, required=False):
         if required:
             vs = [validators.Required()]
         else:

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -246,12 +246,24 @@ class ActionFormArgparser():
         self.F.argparse_fields["REPO"] = {}
 
     def add_repo_type(self, choices=None, helpstr=None): # pylint: disable=unused-argument
-        Field = SelectField
-        field = Field(
+        field = SelectField(
             "Repository type",
             choices=[(a, a) for a in choices])
         setattr(self.F, "type", field)
         self.F.argparse_fields["type"] = {}
+
+    def add_repo_type_pos_arg(self, choices=None, required=False, helpstr=None): # pylint: disable=unused-argument
+        if required:
+            vs = [validators.Required()]
+        else:
+            vs = [validators.Optional()]
+
+        field = SelectField(
+            "Repository type",
+            vs,
+            choices=[(a, a) for a in choices])
+        setattr(self.F, "TYPE", field)
+        self.F.argparse_fields["TYPE"] = {}
 
     def add_ext_instance(self, multiple=False, helpstr=None): # pylint: disable=unused-argument
         Field = SelectField

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -153,8 +153,8 @@ class ActionFormArgparser(object):
         field = Field(
             "Operating System",
             vs,
-            choices=((osplugin.name, osplugin.nice_name)
-                     for osplugin in systems.values()))
+            choices=[(osplugin.name, osplugin.nice_name)
+                     for osplugin in systems.values()])
         setattr(self.F, "opsys", field)
         self.F.argparse_fields["opsys"] = {}
 
@@ -187,14 +187,14 @@ class ActionFormArgparser(object):
     def add_bugtracker(self, *args, **kwargs): # pylint: disable=unused-argument
         field = SelectField(
             "Bugtracker",
-            choices=((bt, bt) for bt in bugtrackers))
+            choices=[(bt, bt) for bt in bugtrackers])
         setattr(self.F, "bugtracker", field)
         self.F.argparse_fields["bugtracker"] = {}
 
     def add_solutionfinder(self, *args, **kwargs): # pylint: disable=unused-argument
         field = SelectField(
             "Solution finder",
-            choices=((sf, sf) for sf in solution_finders))
+            choices=[(sf, sf) for sf in solution_finders])
         setattr(self.F, "solution_finder", field)
         self.F.argparse_fields["solution_finder"] = {}
 

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -150,11 +150,8 @@ class ActionFormArgparser():
 
         self.F.argparse_fields[kwargs["dest"]] = kwargs
 
-    def add_argument_group(self, *args, **kwargs): # pylint: disable=unused-argument
+    def add_argument_group(self):
         return ActionFormArgGroup(self.F)
-
-    def add_mutually_exclusive_group(self, *args, **kwargs): # pylint: disable=unused-argument
-        return ActionFormArgGroup(self.F, mutually_exclusive=True)
 
     def add_opsys(self, multiple=False, required=False, positional=False, with_rel=False, helpstr=None): # pylint: disable=unused-argument
         if required:

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -162,7 +162,6 @@ class ActionFormArgparser():
         else:
             vs = [validators.Optional()]
 
-        #TODO: use either systems.values() or the DB in all cases # pylint: disable=fixme
         choice_lst = [(osplugin.name, osplugin.nice_name) for osplugin in systems.values()]
         arg_str = "opsys"
 

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -199,6 +199,19 @@ class ActionFormArgparser():
         setattr(self.F, "OPSYS", field)
         self.F.argparse_fields["OPSYS"] = {}
 
+    def add_opsys_rel_status(self, required=False):
+        if required:
+            vs = [validators.Required()]
+        else:
+            vs = [validators.Optional()]
+
+        field = SelectField(
+            "Release status",
+            vs,
+            choices=[(a, a) for a in ["ACTIVE", "UNDER_DEVELOPMENT", "EOL"]])
+        setattr(self.F, "status", field)
+        self.F.argparse_fields["status"] = {}
+
     def add_arch_pos_arg(self, required=False):
         if required:
             vs = [validators.Required()]

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -180,7 +180,7 @@ class ActionFormArgparser():
         setattr(self.F, "OPSYS", field)
         self.F.argparse_fields["OPSYS"] = {}
 
-    def add_opsys_with_rel_pos_arg(self, multiple=False, required=False):
+    def add_opsys_with_rel_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
         if required:
             vs = [validators.Required()]
         else:
@@ -212,13 +212,15 @@ class ActionFormArgparser():
         setattr(self.F, "status", field)
         self.F.argparse_fields["status"] = {}
 
-    def add_arch_pos_arg(self, required=False):
+    def add_arch_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
         if required:
             vs = [validators.Required()]
         else:
             vs = [validators.Optional()]
 
-        Field = SelectMultipleField
+        Field = SelectField
+        if multiple:
+            Field = SelectMultipleField
         field = Field(
             "Architecture",
             vs,
@@ -251,6 +253,22 @@ class ActionFormArgparser():
             choices=[(a[0], a[0]) for a in db.session.query(OpSysRelease.version).order_by(OpSysRelease.version)])
         setattr(self.F, "opsys_release", field)
         self.F.argparse_fields["opsys_release"] = {}
+
+    def add_opsys_release_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
+        if required:
+            vs = [validators.Required()]
+        else:
+            vs = [validators.Optional()]
+
+        Field = SelectField
+        if multiple:
+            Field = SelectMultipleField
+        field = Field(
+            "Operating System",
+            vs,
+            choices=[(a[0], a[0]) for a in db.session.query(OpSysRelease.version).order_by(OpSysRelease.version)])
+        setattr(self.F, "RELEASE", field)
+        self.F.argparse_fields["RELEASE"] = {}
 
     def add_bugtracker(self, *args, **kwargs): # pylint: disable=unused-argument
         field = SelectField(

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -169,8 +169,7 @@ class ActionFormArgparser():
             choice_lst = [(a[0], a[0]) for a in q]
 
             if with_rel:
-                q = q.join(OpSysRelease)
-                q = q.with_entities(OpSys.name, OpSysRelease.version)
+                q = q.join(OpSysRelease).with_entities(OpSys.name, OpSysRelease.version)
                 choice_lst = [(a[0] + " " + a[1], a[0] + " " + a[1]) for a in q]
 
         Field = SelectField
@@ -209,10 +208,13 @@ class ActionFormArgparser():
         Field = SelectField
         if multiple:
             Field = SelectMultipleField
+
+        q = db.session.query(Arch.name).order_by(Arch.name)
+
         field = Field(
             "Architecture",
             vs,
-            choices=[(a[0], a[0]) for a in db.session.query(Arch.name).order_by(Arch.name)])
+            choices=[(a[0], a[0]) for a in q])
         setattr(self.F, arg_str, field)
         self.F.argparse_fields[arg_str] = {}
 
@@ -235,10 +237,13 @@ class ActionFormArgparser():
         Field = SelectField
         if multiple:
             Field = SelectMultipleField
+
+        q = db.session.query(OpSysRelease.version).order_by(OpSysRelease.version)
+
         field = Field(
             "OS Release",
             vs,
-            choices=[(a[0], a[0]) for a in db.session.query(OpSysRelease.version).order_by(OpSysRelease.version)])
+            choices=[(a[0], a[0]) for a in q])
 
         arg_str = "opsys_release"
         if positional:
@@ -262,12 +267,16 @@ class ActionFormArgparser():
         self.F.argparse_fields["solution_finder"] = {}
 
     def add_repo(self, multiple=False, helpstr=None): # pylint: disable=unused-argument
+
         Field = SelectField
         if multiple:
             Field = SelectMultipleField
+
+        q = db.session.query(Repo.name).order_by(Repo.name)
+
         field = Field(
             "Package repository",
-            choices=[(a[0], a[0]) for a in db.session.query(Repo.name).order_by(Repo.name)])
+            choices=[(a[0], a[0]) for a in q])
         setattr(self.F, "REPO", field)
         self.F.argparse_fields["REPO"] = {}
 
@@ -290,16 +299,20 @@ class ActionFormArgparser():
         self.F.argparse_fields[arg_str] = {}
 
     def add_ext_instance(self, multiple=False, helpstr=None): # pylint: disable=unused-argument
+
         Field = SelectField
         if multiple:
             Field = SelectMultipleField
+
+        q = db.session.query(ExternalFafInstance) \
+            .with_entities(ExternalFafInstance.id, ExternalFafInstance.name) \
+            .order_by(ExternalFafInstance.id)
+
         field = Field(
             "External FAF instance",
-            choices=[(a[0], str(a[0]) + " " + a[1])
-                     for a in db.session.query(ExternalFafInstance).with_entities(
-                         ExternalFafInstance.id, ExternalFafInstance.name)
-                     .order_by(ExternalFafInstance.id)],
+            choices=[(a[0], str(a[0]) + " " + a[1]) for a in q],
             coerce=int)
+
         setattr(self.F, "INSTANCE_ID", field)
         self.F.argparse_fields["INSTANCE_ID"] = {}
 

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -60,7 +60,7 @@ def results_item(result_id):
                            task_result=tr)
 
 
-class ActionFormArgparser(object):
+class ActionFormArgparser():
     def __init__(self, F):
         self.F = F
         self.prefix_chars = "-"
@@ -141,6 +141,12 @@ class ActionFormArgparser(object):
 
         self.F.argparse_fields[kwargs["dest"]] = kwargs
 
+    def add_argument_group(self, *args, **kwargs): # pylint: disable=unused-argument
+        return ActionFormArgGroup(self.F)
+
+    def add_mutually_exclusive_group(self, *args, **kwargs): # pylint: disable=unused-argument
+        return ActionFormArgGroup(self.F, mutually_exclusive=True)
+
     def add_opsys(self, multiple=False, required=False):
         if required:
             vs = [validators.Required()]
@@ -207,6 +213,12 @@ class ActionFormArgparser(object):
             choices=[(a[0], a[0]) for a in db.session.query(Repo.name).order_by(Repo.name)])
         setattr(self.F, "NAME", field)
         self.F.argparse_fields["NAME"] = {}
+
+class ActionFormArgGroup(ActionFormArgparser):
+    def __init__(self, F, mutually_exclusive=False): # pylint: disable=super-init-not-called
+        self.F = F
+        self.mutually_exclusive = mutually_exclusive
+        self.prefix_chars = "-"
 
 
 class ActionFormBase(Form):

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -245,6 +245,14 @@ class ActionFormArgparser():
         setattr(self.F, "REPO", field)
         self.F.argparse_fields["REPO"] = {}
 
+    def add_repo_type(self, choices=None, helpstr=None): # pylint: disable=unused-argument
+        Field = SelectField
+        field = Field(
+            "Repository type",
+            choices=[(a, a) for a in choices])
+        setattr(self.F, "type", field)
+        self.F.argparse_fields["type"] = {}
+
 class ActionFormArgGroup(ActionFormArgparser):
     def __init__(self, F, mutually_exclusive=False): # pylint: disable=super-init-not-called
         self.F = F

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -10,7 +10,7 @@ from wtforms import (Form,
                      TextAreaField,
                      ValidationError)
 
-from pyfaf.storage import (PeriodicTask, TaskResult, OpSys, OpSysRelease, Repo, Arch)
+from pyfaf.storage import (ExternalFafInstance, PeriodicTask, TaskResult, OpSys, OpSysRelease, Repo, Arch)
 from pyfaf.celery_tasks import run_action, celery_app
 from pyfaf.actions import actions as actions_all
 from pyfaf.problemtypes import problemtypes
@@ -252,6 +252,20 @@ class ActionFormArgparser():
             choices=[(a, a) for a in choices])
         setattr(self.F, "type", field)
         self.F.argparse_fields["type"] = {}
+
+    def add_ext_instance(self, multiple=False, helpstr=None): # pylint: disable=unused-argument
+        Field = SelectField
+        if multiple:
+            Field = SelectMultipleField
+        field = Field(
+            "External FAF instance",
+            choices=[(a[0], str(a[0]) + " " + a[1])
+                     for a in db.session.query(ExternalFafInstance).with_entities(
+                         ExternalFafInstance.id, ExternalFafInstance.name)
+                     .order_by(ExternalFafInstance.id)],
+            coerce=int)
+        setattr(self.F, "INSTANCE_ID", field)
+        self.F.argparse_fields["INSTANCE_ID"] = {}
 
 class ActionFormArgGroup(ActionFormArgparser):
     def __init__(self, F, mutually_exclusive=False): # pylint: disable=super-init-not-called

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -164,7 +164,23 @@ class ActionFormArgparser():
         setattr(self.F, "opsys", field)
         self.F.argparse_fields["opsys"] = {}
 
-    def add_opsys_with_rel_pos_arg(self, required=False):
+    def add_opsys_pos_arg(self, multiple=False, required=False, helpstr=None): # pylint: disable=unused-argument
+        if required:
+            vs = [validators.Required()]
+        else:
+            vs = [validators.Optional()]
+
+        Field = SelectField
+        if multiple:
+            Field = SelectMultipleField
+        field = Field(
+            "Operating System",
+            vs,
+            choices=[(a[0], a[0]) for a in db.session.query(OpSys.name)])
+        setattr(self.F, "OPSYS", field)
+        self.F.argparse_fields["OPSYS"] = {}
+
+    def add_opsys_with_rel_pos_arg(self, multiple=False, required=False):
         if required:
             vs = [validators.Required()]
         else:
@@ -173,7 +189,9 @@ class ActionFormArgparser():
         q = db.session.query(OpSys).join(OpSysRelease)
         subq = q.with_entities(OpSys.name, OpSysRelease.version)
 
-        Field = SelectMultipleField
+        Field = SelectField
+        if multiple:
+            Field = SelectMultipleField
         field = Field(
             "Operating System",
             vs,

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -319,6 +319,19 @@ class ActionFormArgparser():
         setattr(self.F, "FILE", field)
         self.F.argparse_fields["FILE"] = {}
 
+    def add_gpgcheck_toggle(self, required=False, helpstr=None): # pylint: disable=unused-argument
+        if required:
+            vs = [validators.Required()]
+        else:
+            vs = [validators.Optional()]
+
+        field = SelectField(
+            "New GPG check requirement",
+            vs,
+            choices=[(a, a) for a in ["leave as is", "enable", "disable"]])
+        setattr(self.F, "gpgcheck", field)
+        self.F.argparse_fields["gpgcheck"] = {}
+
 class ActionFormArgGroup(ActionFormArgparser):
     def __init__(self, F, mutually_exclusive=False): # pylint: disable=super-init-not-called
         self.F = F

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -72,10 +72,6 @@ class ActionsTestCase(faftests.DatabaseCase):
         self.assertEqual(json_data["Contact Mail Reports"]["Reports"][0], "{}".format(num))
 
     def test_releaseadd(self):
-        self.assertEqual(self.call_action("releaseadd"), 1)
-        self.assertEqual(self.call_action("releaseadd", {
-            "opsys": "FooBarOS",
-        }), 1)
         self.assertEqual(self.call_action("releaseadd", {
             "opsys": "fedora",
             "opsys-release": "20",
@@ -658,10 +654,6 @@ class ActionsTestCase(faftests.DatabaseCase):
         }), 1)
 
     def test_releasemod(self):
-        self.assertEqual(self.call_action("releasemod"), 1)
-        self.assertEqual(self.call_action("releasemod", {
-            "opsys": "FooBarOS",
-        }), 1)
 
         # add F20 release
         self.assertEqual(self.call_action("releaseadd", {
@@ -887,10 +879,6 @@ class ActionsTestCase(faftests.DatabaseCase):
                 self.setUp()
 
     def releasedel_testing(self, repo_type):
-        self.assertEqual(self.call_action("releasedel"), 1)
-        self.assertEqual(self.call_action("releasedel", {
-            "opsys": "FooBarOS",
-        }), 1)
         self.assertEqual(self.call_action("releasedel", {
             "opsys": "fedora",
             "opsys-release": "1337",

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -663,13 +663,6 @@ class ActionsTestCase(faftests.DatabaseCase):
             "opsys": "FooBarOS",
         }), 1)
 
-        # missing release
-        self.assertEqual(self.call_action("releasemod", {
-            "opsys": "fedora",
-            "opsys-release": 20,
-            "status": "FooStatus",
-        }), 1)
-
         # add F20 release
         self.assertEqual(self.call_action("releaseadd", {
             "opsys": "fedora",

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -78,11 +78,6 @@ class ActionsTestCase(faftests.DatabaseCase):
         }), 1)
         self.assertEqual(self.call_action("releaseadd", {
             "opsys": "fedora",
-            "opsys-release": "23",
-            "status": "FooStatus",
-        }), 1)
-        self.assertEqual(self.call_action("releaseadd", {
-            "opsys": "fedora",
             "opsys-release": "20",
             "status": "ACTIVE",
         }), 0)


### PR DESCRIPTION
Resolves #724. The immediate cause was the use of generator objects instead of lists for the `choices` argument in some action form elements and the use of CmdLineParser method `add_mutually_exclusive_group` which was used by two of the actions and which wasn't implemented in the ActionFormArgparser. In the end, the mutual exclusion was ensured directly in `run` method of the respective actions for the CLI and handled ex-post based on the action's failure in case of the web UI.  
  
Many of the form elements were reworked in the process, form validation was added where practical, validation conflict was solved between the run action form and the scheduler form, methods for adding the form elements (action arguments) were refactored.