### PR TITLE
pyfaf: problemtypes: Drop unused code

### DIFF
--- a/src/pyfaf/problemtypes/__init__.py
+++ b/src/pyfaf/problemtypes/__init__.py
@@ -151,16 +151,6 @@ class ProblemType(Plugin):
         raise NotImplementedError("compare is not implemented for {0}"
                                   .format(self.__class__.__name__))
 
-    def compare_many(self, db_reports):
-        """
-        Some libraries (btparser, satyr) provide a way to compare
-        many reports at the same time returning a report list
-        and distances object. This may be a significant speedup.
-        """
-
-        raise NotImplementedError("compare_many is not implemented for {0}"
-                                  .format(self.__class__.__name__))
-
     def check_btpath_match(self, ureport, parser):
         """
         Check whether a path in stacktrace matches to a knowledgebase rule.

--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -433,31 +433,6 @@ class CoredumpProblem(ProblemType):
         satyr_report2 = self.db_report_to_satyr(db_report2)
         return satyr_report1.distance(satyr_report2)
 
-    def compare_many(self, db_reports):
-        self.log_info("Loading reports")
-        reports = []
-        ret_db_reports = []
-
-        i = 0
-        for db_report in db_reports:
-            i += 1
-
-            self.log_debug("[{0} / {1}] Loading report #{2}"
-                           .format(i, len(db_reports), db_report.id))
-
-            report = self.db_report_to_satyr(db_report)
-            if report is None:
-                self.log_debug("Unable to build satyr.GdbStacktrace")
-                continue
-
-            reports.append(report)
-            ret_db_reports.append(db_report)
-
-        self.log_info("Calculating distances")
-        distances = satyr.Distances(reports, len(reports))
-
-        return ret_db_reports, distances
-
     def check_btpath_match(self, ureport, parser):
         crash_thread = None
         for thread in ureport["stacktrace"]:

--- a/src/pyfaf/problemtypes/java.py
+++ b/src/pyfaf/problemtypes/java.py
@@ -348,31 +348,6 @@ class JavaProblem(ProblemType):
         satyr_report2 = self.db_report_to_satyr(db_report2)
         return satyr_report1.distance(satyr_report2)
 
-    def compare_many(self, db_reports):
-        self.log_info("Loading reports")
-        reports = []
-        ret_db_reports = []
-
-        i = 0
-        for db_report in db_reports:
-            i += 1
-
-            self.log_debug("[{0} / {1}] Loading report #{2}"
-                           .format(i, len(db_reports), db_report.id))
-
-            report = self.db_report_to_satyr(db_report)
-            if report is None:
-                self.log_debug("Unable to build satyr.JavaStacktrace")
-                continue
-
-            reports.append(report)
-            ret_db_reports.append(db_report)
-
-        self.log_info("Calculating distances")
-        distances = satyr.Distances(reports, len(reports))
-
-        return ret_db_reports, distances
-
     def check_btpath_match(self, ureport, parser):
         for thread in ureport["threads"]:
             for frame in thread["frames"]:

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -508,32 +508,6 @@ class KerneloopsProblem(ProblemType):
         satyr_report2 = self.db_report_to_satyr(db_report2)
         return satyr_report1.distance(satyr_report2)
 
-    def compare_many(self, db_reports):
-        self.log_info("Loading reports")
-
-        reports = []
-        ret_db_reports = []
-
-        i = 0
-        for db_report in db_reports:
-            i += 1
-
-            self.log_debug("[{0} / {1}] Loading report #{2}"
-                           .format(i, len(db_reports), db_report.id))
-            report = self.db_report_to_satyr(db_report)
-
-            if report is None:
-                self.log_debug("Unable to build satyr.Kerneloops")
-                continue
-
-            reports.append(report)
-            ret_db_reports.append(db_report)
-
-        self.log_info("Calculating distances")
-        distances = satyr.Distances(reports, len(reports))
-
-        return ret_db_reports, distances
-
     def _get_ssources_for_retrace_query(self, db):
         koops_syms = (db.session.query(SymbolSource.id)
                       .join(ReportBtFrame)

--- a/src/pyfaf/problemtypes/python.py
+++ b/src/pyfaf/problemtypes/python.py
@@ -307,31 +307,6 @@ class PythonProblem(ProblemType):
         satyr_report2 = self.db_report_to_satyr(db_report2)
         return satyr_report1.distance(satyr_report2)
 
-    def compare_many(self, db_reports):
-        self.log_info("Loading reports")
-        reports = []
-        ret_db_reports = []
-
-        i = 0
-        for db_report in db_reports:
-            i += 1
-
-            self.log_debug("[{0} / {1}] Loading report #{2}"
-                           .format(i, len(db_reports), db_report.id))
-
-            report = self.db_report_to_satyr(db_report)
-            if report is None:
-                self.log_debug("Unable to build satyr.PythonStacktrace")
-                continue
-
-            reports.append(report)
-            ret_db_reports.append(db_report)
-
-        self.log_info("Calculating distances")
-        distances = satyr.Distances(reports, len(reports))
-
-        return ret_db_reports, distances
-
     def check_btpath_match(self, ureport, parser):
         for frame in ureport["stacktrace"]:
             if "special_file" in frame:

--- a/src/pyfaf/problemtypes/ruby.py
+++ b/src/pyfaf/problemtypes/ruby.py
@@ -299,31 +299,6 @@ class RubyProblem(ProblemType):
         satyr_report2 = self.db_report_to_satyr(db_report2)
         return satyr_report1.distance(satyr_report2)
 
-    def compare_many(self, db_reports):
-        self.log_info("Loading reports")
-        reports = []
-        ret_db_reports = []
-
-        i = 0
-        for db_report in db_reports:
-            i += 1
-
-            self.log_debug("[{0} / {1}] Loading report #{2}"
-                           .format(i, len(db_reports), db_report.id))
-
-            report = self.db_report_to_satyr(db_report)
-            if report is None:
-                self.log_debug("Unable to build satyr.RubyStacktrace")
-                continue
-
-            reports.append(report)
-            ret_db_reports.append(db_report)
-
-        self.log_info("Calculating distances")
-        distances = satyr.Distances(reports, len(reports))
-
-        return ret_db_reports, distances
-
     def check_btpath_match(self, ureport, parser):
         for frame in ureport["stacktrace"]:
             if "special_file" in frame:


### PR DESCRIPTION
Seems that 2f135c7adbce687d2394b91e653fd9f83ebd9b55 ripped out the
common implementation and uses it directly in create_problems.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>