### PR TITLE
pyfaf: create_problems: Batch invalid reports

### DIFF
--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -454,7 +454,7 @@ class CreateProblems(Action):
 
             self.log_debug("Removing {0} invalid reports from problems"
                            .format(len(invalid_report_ids_to_clean)))
-            for db_report in get_reports_for_ids(db, invalid_report_ids_to_clean, 1000)
+            for db_report in get_reports_for_ids(db, invalid_report_ids_to_clean, 1000):
                 db_report.problem_id = None
                 db.session.add(db_report)
 

--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -24,7 +24,7 @@ from pyfaf.problemtypes import problemtypes
 from pyfaf.queries import (get_problems,
                            get_problem_component,
                            get_empty_problems,
-                           get_report_by_id,
+                           get_reports_for_ids,
                            get_reports_by_type,
                            remove_problem_from_low_count_reports_by_type,
                            get_reports_for_problems,
@@ -454,11 +454,9 @@ class CreateProblems(Action):
 
             self.log_debug("Removing {0} invalid reports from problems"
                            .format(len(invalid_report_ids_to_clean)))
-            for report_id in invalid_report_ids_to_clean:
-                db_report = get_report_by_id(db, report_id)
-                if db_report is not None:
-                    db_report.problem_id = None
-                    db.session.add(db_report)
+            for db_report in get_reports_for_ids(db, invalid_report_ids_to_clean, 1000)
+                db_report.problem_id = None
+                db.session.add(db_report)
 
             if report_min_count > 0:
                 self.log_debug("Removing problems from low count reports")

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -804,6 +804,16 @@ def get_report_by_id(db, report_id):
             .first())
 
 
+def get_reports_for_ids(db, ids, yield_num=0):
+    query = (db.session.query(st.Report)
+             .filter(st.Report.id.in_(ids)))
+
+    if yield_num > 0:
+        return query.yield_per(yield_num)
+
+    return query.all()
+
+
 def get_report(db, report_hash, os_name=None, os_version=None, os_arch=None):
     '''
     Return pyfaf.storage.Report object or None if not found


### PR DESCRIPTION
Seems that the create_problems action that’s been running on retrace01
for a couple of days now is spending a lot of time querying for reports.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>