### PR TITLE
actions: create_problems: Bypass ORM when unassigning reports

### DIFF
--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -24,7 +24,7 @@ from pyfaf.problemtypes import problemtypes
 from pyfaf.queries import (get_problems,
                            get_problem_component,
                            get_empty_problems,
-                           get_reports_for_ids,
+                           unassign_reports,
                            get_reports_by_type,
                            remove_problem_from_low_count_reports_by_type,
                            get_reports_for_problems,
@@ -454,9 +454,7 @@ class CreateProblems(Action):
 
             self.log_debug("Removing {0} invalid reports from problems"
                            .format(len(invalid_report_ids_to_clean)))
-            for db_report in get_reports_for_ids(db, invalid_report_ids_to_clean, 1000):
-                db_report.problem_id = None
-                db.session.add(db_report)
+            unassign_reports(db, invalid_report_ids_to_clean)
 
             if report_min_count > 0:
                 self.log_debug("Removing problems from low count reports")

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -1027,6 +1027,16 @@ def get_unassigned_reports(db, report_type, min_count=0):
         query = query.filter(st.Report.count >= min_count)
     return query.all()
 
+def unassign_reports(db, report_ids):
+    """
+    Unset problem ID for reports that are matched by report_ids
+    and return the number of reports changed.
+    """
+    return (db.session.query(st.Report)
+            .filter(st.Report.id.in_(report_ids))
+            .update({st.Report.problem_id: None},
+                    synchronize_session=False))
+
 def remove_problem_from_low_count_reports_by_type(db, report_type, min_count):
     """
     Set problem_id = NULL for reports of given `report_type` where count is


### PR DESCRIPTION
For more SPEED.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>