### PR TITLE
docker: Do not fail local Docker build if pylint fails

### DIFF
--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -23,7 +23,8 @@ USER faf
 ENV HOME /faf
 
 # Build faf
-RUN ./autogen.sh && \
+RUN sed -i '/^pylint/s/$/ ||:/' faf.spec.in && \
+    ./autogen.sh && \
     ./configure && \
     make rpm
 


### PR DESCRIPTION
It takes a lot of time to build the Docker image. It is annoying when
the whole build fails at the end because of an issue found by pylint
and you have to rerun the build.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>