### PR TITLE
Improvements to logging system

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -4,7 +4,8 @@
 
 SUBDIRS = plugins templates
 
-config_DATA = faf.conf
+config_DATA = faf.conf \
+              faf-logging.conf
 
 if HAVE_SYSTEMD
   config_DATA += celery-beat-env.conf
@@ -29,5 +30,6 @@ logrotatedir = ${sysconfdir}/logrotate.d
 EXTRA_DIST = celery-beat-env.conf \
              celery-worker-env.conf \
              faf.conf.in \
+             faf-logging.conf \
              faf-web.conf.in \
              faf

--- a/config/faf-logging.conf
+++ b/config/faf-logging.conf
@@ -1,0 +1,45 @@
+[loggers]
+keys=root,main,thread
+
+[handlers]
+keys=main,thread
+
+[formatters]
+keys=main,thread
+
+# Used only if no other loggers are specified
+[logger_root]
+level=DEBUG
+handlers=main
+
+[logger_main]
+level=INFO
+handlers=main
+qualname=faf
+propagate=0
+
+[logger_thread]
+level=INFO
+handlers=thread
+qualname=faf.thread
+propagate=0
+
+[handler_main]
+level=DEBUG
+formatter=main
+class=StreamHandler
+args=[]
+
+[handler_thread]
+level=DEBUG
+formatter=thread
+class=StreamHandler
+args=[]
+
+[formatter_main]
+format=[%(asctime)s] %(levelname)s:%(name)s: %(message)s
+datefmt=%Y-%m-%d %H:%M:%S
+
+[formatter_thread]
+format=[%(asctime)s] %(levelname)s:%(name)s(%(threadName)s): %(message)s
+datefmt=%Y-%m-%d %H:%M:%S

--- a/faf.spec.in
+++ b/faf.spec.in
@@ -624,6 +624,7 @@ fi
 %dir %{_sysconfdir}/faf/plugins
 %dir %{_sysconfdir}/faf/templates
 %config(noreplace) %{_sysconfdir}/faf/faf.conf
+%config(noreplace) %{_sysconfdir}/faf/faf-logging.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/faf
 
 # /var/spool

--- a/src/bin/faf
+++ b/src/bin/faf
@@ -103,7 +103,7 @@ def main():
     if str2bool(config["main.autoenableplugins"]):
         plugins = set()
         for cls in Plugin.__subclasses__():
-            plugins |= set(load_plugins(cls, init=False).values())
+            plugins |= set(load_plugins(cls, init=False, debug=cmdline.debug).values())
 
         for plugin in plugins:
             try:

--- a/src/bin/faf
+++ b/src/bin/faf
@@ -109,7 +109,7 @@ def main():
             try:
                 if not plugin.installed(db):
                     log.debug("Automatically installing plugin %s", plugin.__name__)
-                    logger = log.getChildLogger(plugin.__name__)
+                    logger = log.getChild(plugin.__name__)
                     plugin.install(db, logger=logger)
             except Exception as ex:
                 log.critical("Unable to enable plugin %s: %s: %s", plugin.__name__,

--- a/src/pyfaf/actions/addcompathashes.py
+++ b/src/pyfaf/actions/addcompathashes.py
@@ -115,16 +115,15 @@ class AddCompatHashes(Action):
                 for db_backtrace in db_report.backtraces:
                     k += 1
 
-                    self.log_debug("    [{0} / {1}] Processing backtrace #{2}"
-                                   .format(k, len(db_report.backtraces),
-                                           db_backtrace.id))
+                    self.log_debug("    [%d / %d] Processing backtrace #%d",
+                                   k, len(db_report.backtraces), db_backtrace.id)
                     try:
                         component = db_report.component.name
                         include_offset = ptype.lower() == "python"
                         bthash = self._hash_backtrace(db_backtrace,
                                                       hashbase=[component],
                                                       offset=include_offset)
-                        self.log_debug("    {0}".format(bthash))
+                        self.log_debug("    %s", bthash)
                         db_dup = get_report(db, bthash)
                         if db_dup is None:
                             self.log_info("    Adding hash '{0}'"
@@ -136,8 +135,7 @@ class AddCompatHashes(Action):
                                 db.session.add(db_reporthash)
                                 hashes.add(bthash)
                         elif db_dup == db_report:
-                            self.log_debug("    Hash '{0}' already assigned"
-                                           .format(bthash))
+                            self.log_debug("    Hash '%s' already assigned", bthash)
                         else:
                             self.log_warn(("    Conflict! Skipping hash '{0}'"
                                            " (report #{1})").format(bthash,

--- a/src/pyfaf/actions/addcompathashes.py
+++ b/src/pyfaf/actions/addcompathashes.py
@@ -115,7 +115,7 @@ class AddCompatHashes(Action):
                 for db_backtrace in db_report.backtraces:
                     k += 1
 
-                    self.log_debug("    [%d / %d] Processing backtrace #%d",
+                    self.log_debug("\t[%d / %d] Processing backtrace #%d",
                                    k, len(db_report.backtraces), db_backtrace.id)
                     try:
                         component = db_report.component.name
@@ -123,7 +123,7 @@ class AddCompatHashes(Action):
                         bthash = self._hash_backtrace(db_backtrace,
                                                       hashbase=[component],
                                                       offset=include_offset)
-                        self.log_debug("    %s", bthash)
+                        self.log_debug("\t%s", bthash)
                         db_dup = get_report(db, bthash)
                         if db_dup is None:
                             self.log_info("    Adding hash '{0}'"
@@ -135,7 +135,7 @@ class AddCompatHashes(Action):
                                 db.session.add(db_reporthash)
                                 hashes.add(bthash)
                         elif db_dup == db_report:
-                            self.log_debug("    Hash '%s' already assigned", bthash)
+                            self.log_debug("\tHash '%s' already assigned", bthash)
                         else:
                             self.log_warn(("    Conflict! Skipping hash '{0}'"
                                            " (report #{1})").format(bthash,

--- a/src/pyfaf/actions/addcompathashes.py
+++ b/src/pyfaf/actions/addcompathashes.py
@@ -93,27 +93,20 @@ class AddCompatHashes(Action):
             self.log_info("Nothing to do")
             return 0
 
-        i = 0
-        for ptype in ptypes:
-            i += 1
-
+        for i, ptype in enumerate(ptypes, start=1):
             problemtype = problemtypes[ptype]
 
             self.log_info("[{0} / {1}] Processing problem type '{2}'"
                           .format(i, len(ptypes), problemtype.nice_name))
             db_reports = get_reports_by_type(db, ptype)
 
-            j = 0
-            for db_report in db_reports:
-                j += 1
+            for j, db_report in enumerate(db_reports, start=1):
 
                 self.log_info("  [{0} / {1}] Processing report #{2}"
                               .format(j, len(db_reports), db_report.id))
 
                 hashes = set()
-                k = 0
-                for db_backtrace in db_report.backtraces:
-                    k += 1
+                for k, db_backtrace in enumerate(db_report.backtraces, start=1):
 
                     self.log_debug("\t[%d / %d] Processing backtrace #%d",
                                    k, len(db_report.backtraces), db_backtrace.id)

--- a/src/pyfaf/actions/archive_reports.py
+++ b/src/pyfaf/actions/archive_reports.py
@@ -110,7 +110,7 @@ class ArchiveReports(Action):
             linkpath = os.path.join(tmpsubdir, os.path.basename(filepath))
             # merge - do not overwrite already archived data
             try:
-                self.log_debug("{0} ~> {1}".format(filepath, linkpath))
+                self.log_debug("%s ~> %s", filepath, linkpath)
                 os.symlink(filepath, linkpath)
             except OSError as ex:
                 if ex.errno != errno.EEXIST:

--- a/src/pyfaf/actions/archive_reports.py
+++ b/src/pyfaf/actions/archive_reports.py
@@ -164,9 +164,7 @@ class ArchiveReports(Action):
         if dates is None:
             dates = list(archive_map.keys())
 
-        i = 0
-        for date in sorted(dates):
-            i += 1
+        for i, date in enumerate(sorted(dates), start=1):
             self.log_info("[{0} / {1}] Archiving reports from {2}"
                           .format(i, len(dates), date))
 
@@ -189,9 +187,7 @@ class ArchiveReports(Action):
         if dates is None:
             dates = list(archive_map.keys())
 
-        i = 0
-        for date in sorted(dates):
-            i += 1
+        for i, date in enumerate(sorted(dates), start=1):
             self.log_info("[{0} / {1}] Archiving reports from {2}"
                           .format(i, len(dates), date))
 

--- a/src/pyfaf/actions/c2p.py
+++ b/src/pyfaf/actions/c2p.py
@@ -85,7 +85,7 @@ class Coredump2Packages(Action):
                 elif match.group(5) != "-":
                     # vDSO
                     if match.group(7):
-                        self.log_debug("Skipping vDSO {}".format(match.group(8)))
+                        self.log_debug("Skipping vDSO %s", match.group(8))
                         continue
                     # Deleted
                     elif match.group(9):
@@ -118,9 +118,8 @@ class Coredump2Packages(Action):
                               .format(build_id, soname))
                 continue
             else:
-                self.log_debug("Found {0} debuginfo packages for '{1}' ({2}): "
-                               "{3}".format(len(db_packages), build_id, soname,
-                                            [p.nvra() for p in db_packages]))
+                self.log_debug("Found %d debuginfo packages for '%d' (%s): %s",
+                               len(db_packages), build_id, soname, [p.nvra() for p in db_packages])
 
             if build_id not in build_id_maps:
                 build_id_maps[build_id] = set()
@@ -159,13 +158,11 @@ class Coredump2Packages(Action):
             if best["package"]:
                 basename = best["package"].build.base_package_name
                 if basename in Coredump2Packages.SKIP_PACKAGES:
-                    self.log_debug("Skipping '{0}'".format(basename))
+                    self.log_debug("Skipping '%s'", basename)
                     continue
 
-                self.log_debug("Picking '{0}' for '{1}' with {2} build_id "
-                               "matches".format(best["package"].nvra(),
-                                                best["package"].name,
-                                                best["count"]))
+                self.log_debug("Picking '%s' for '%s' with %d build_id matches",
+                               best["package"].nvra(), best["package"].name, best["count"])
 
                 debuginfo_packages.append(best["package"])
                 debuginfo_maps[best["package"].name] = best["package"]
@@ -195,7 +192,7 @@ class Coredump2Packages(Action):
             else:
                 debuginfo_name = build_id_maps[build_id]
                 if debuginfo_name in Coredump2Packages.SKIP_PACKAGES:
-                    self.log_debug("Skipping {0}".format(debuginfo_name))
+                    self.log_debug("Skipping %s", debuginfo_name)
                     continue
 
                 db_arch = debuginfo_maps[debuginfo_name].arch
@@ -245,8 +242,7 @@ class Coredump2Packages(Action):
 
                 for db_package in db_build.packages:
                     if db_package.arch.name == arch:
-                        self.log_debug("Picking {0} for {1}"
-                                       .format(db_package.nvra(), basename))
+                        self.log_debug("Picking %s for %s", db_package.nvra(), basename)
                         result.add(db_package)
 
         link = None

--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -53,8 +53,7 @@ class CreateProblems(Action):
         empty_problems = get_empty_problems(db)
         self.log_info("Found {0} empty problems".format(len(empty_problems)))
         for db_problem in empty_problems:
-            self.log_debug("Removing empty problem #{0}"
-                           .format(db_problem.id))
+            self.log_debug("Removing empty problem #%d", db_problem.id)
             db.session.delete(db_problem)
         db.session.flush()
 
@@ -170,8 +169,7 @@ class CreateProblems(Action):
             if match > 0:
                 # Ratio of problems matched
                 match_metric = float(match)/len(db_reports)
-                self.log_debug("Found possible match #{0} ({1:.2f})"
-                               .format(db_problem.id, match_metric))
+                self.log_debug("Found possible match #%d (%.2f)", db_problem.id, match_metric)
                 matches.append((match_metric, db_reports, db_problem))
 
         return matches
@@ -199,8 +197,7 @@ class CreateProblems(Action):
         for problem in problems:
             i += 1
 
-            self.log_debug("[{0} / {1}] Processing cluster"
-                           .format(i, len(problems)))
+            self.log_debug("[%d / %d] Processing cluster", i, len(problems))
 
             reports_changed = True
             problem_id = reuse_problems.get(
@@ -209,8 +206,7 @@ class CreateProblems(Action):
                 db_problem = problems_dict.get(problem_id, None)
                 reports_changed = False
                 lookedup_count += 1
-                self.log_debug("Looked up existing problem #{0}"
-                               .format(db_problem.id))
+                self.log_debug("Looked up existing problem #%d", db_problem.id)
             else:
                 matches = self._find_problem_matches(db_problems, problem)
                 if not matches:
@@ -229,7 +225,7 @@ class CreateProblems(Action):
 
         # Phase two: yield problems in order of best match
         self.log_debug("Matching existing problems")
-        self.log_debug("{0} possible matches".format(len(match_list)))
+        self.log_debug("%d possible matches", len(match_list))
         for match_metric, problem, db_problem in sorted(match_list,
                                                         key=itemgetter(0),
                                                         reverse=True):
@@ -247,8 +243,7 @@ class CreateProblems(Action):
             yield (problem, db_problem, True)
 
         # Phase three: create new problems if no match was found above
-        self.log_debug("Processing {0} leftover problems"
-                       .format(len(second_pass)))
+        self.log_debug("Processing %d leftover problems", len(second_pass))
         for problem in second_pass:
             self.log_debug("Creating problem")
             db_problem = Problem()
@@ -256,8 +251,8 @@ class CreateProblems(Action):
             created_count += 1
             yield (problem, db_problem, True)
 
-        self.log_debug("Total: {0}  Looked up: {1}  Found: {2}  Created: {3}"
-                       .format(i, lookedup_count, found_count, created_count))
+        self.log_debug("Total: %d  Looked up: %d  Found: %d  Created: %d",
+                       i, lookedup_count, found_count, created_count)
 
     def _create_problems(self, db, problemplugin, #pylint: disable=too-many-statements
                          report_min_count=0, speedup=False):
@@ -299,8 +294,7 @@ class CreateProblems(Action):
             i = 0
             for db_report in db_reports:
                 i += 1
-                self.log_debug("[{0} / {1}] Loading report #{2}"
-                               .format(i, len(db_reports), db_report.id))
+                self.log_debug("[%d / %d] Loading report #%d", i, len(db_reports), db_report.id)
 
                 _satyr_report = problemplugin.db_report_to_satyr(db_report)
                 if _satyr_report is None:
@@ -322,8 +316,7 @@ class CreateProblems(Action):
             i = 0
             for cluster in clusters:
                 i += 1
-                self.log_debug("[{0} / {1}] Computing distances"
-                               .format(i, len(clusters)))
+                self.log_debug("[%d / %d] Computing distances", i, len(clusters))
                 distances = satyr.Distances(cluster, len(cluster))
 
                 self.log_debug("Getting dendrogram")
@@ -452,8 +445,8 @@ class CreateProblems(Action):
                 if reports_changed:
                     self.update_comps(db, comps, db_problem)
 
-            self.log_debug("Removing {0} invalid reports from problems"
-                           .format(len(invalid_report_ids_to_clean)))
+            self.log_debug("Removing %d invalid reports from problems",
+                           len(invalid_report_ids_to_clean))
             unassign_reports(db, invalid_report_ids_to_clean)
 
             if report_min_count > 0:

--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -180,6 +180,7 @@ class CreateProblems(Action):
         Yields (problem, db_problem, reports_changed) tuples.
         """
         # Three phases, see below
+        problems_total = len(problems)
 
         # Counts for statistics
         lookedup_count = 0
@@ -195,7 +196,7 @@ class CreateProblems(Action):
         # Phase one: try to look up precise matches
         for i, problem in enumerate(problems, start=1):
 
-            self.log_debug("[%d / %d] Processing cluster", i, len(problems))
+            self.log_debug("[%d / %d] Processing cluster", i, problems_total)
 
             reports_changed = True
             problem_id = reuse_problems.get(
@@ -250,7 +251,7 @@ class CreateProblems(Action):
             yield (problem, db_problem, True)
 
         self.log_debug("Total: %d  Looked up: %d  Found: %d  Created: %d",
-                       i, lookedup_count, found_count, created_count)
+                       problems_total, lookedup_count, found_count, created_count)
 
     def _create_problems(self, db, problemplugin, #pylint: disable=too-many-statements
                          report_min_count=0, speedup=False):
@@ -292,8 +293,9 @@ class CreateProblems(Action):
         else:
             report_map = {}
             _satyr_reports = []
+            db_reports_len = len(db_reports)
             for i, db_report in enumerate(db_reports, start=1):
-                self.log_debug("[%d / %d] Loading report #%d", i, len(db_reports), db_report.id)
+                self.log_debug("[%d / %d] Loading report #%d", i, db_reports_len, db_report.id)
 
                 _satyr_report = problemplugin.db_report_to_satyr(db_report)
                 if _satyr_report is None:
@@ -312,8 +314,9 @@ class CreateProblems(Action):
             unique_func_threads = set(_satyr_reports) - set().union(*clusters)
 
             dendrograms = []
+            clusters_len = len(clusters)
             for i, cluster in enumerate(clusters, start=1):
-                self.log_debug("[%d / %d] Computing distances", i, len(clusters))
+                self.log_debug("[%d / %d] Computing distances", i, clusters_len)
                 distances = satyr.Distances(cluster, len(cluster))
 
                 self.log_debug("Getting dendrogram")
@@ -478,10 +481,11 @@ class CreateProblems(Action):
         else:
             ptypes = cmdline.problemtype
 
+        ptypes_len = len(ptypes)
         for i, ptype in enumerate(ptypes, start=1):
             problemplugin = problemtypes[ptype]
             self.log_info("[{0} / {1}] Processing problem type: {2}"
-                          .format(i, len(ptypes), problemplugin.nice_name))
+                          .format(i, ptypes_len, problemplugin.nice_name))
 
             self._create_problems(db,
                                   problemplugin,

--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -182,7 +182,6 @@ class CreateProblems(Action):
         # Three phases, see below
 
         # Counts for statistics
-        i = 0
         lookedup_count = 0
         found_count = 0
         created_count = 0
@@ -194,8 +193,7 @@ class CreateProblems(Action):
         # must be yielded at most once.
         db_problems_used = set()
         # Phase one: try to look up precise matches
-        for problem in problems:
-            i += 1
+        for i, problem in enumerate(problems, start=1):
 
             self.log_debug("[%d / %d] Processing cluster", i, len(problems))
 
@@ -291,9 +289,7 @@ class CreateProblems(Action):
         else:
             report_map = {}
             _satyr_reports = []
-            i = 0
-            for db_report in db_reports:
-                i += 1
+            for i, db_report in enumerate(db_reports, start=1):
                 self.log_debug("[%d / %d] Loading report #%d", i, len(db_reports), db_report.id)
 
                 _satyr_report = problemplugin.db_report_to_satyr(db_report)
@@ -313,9 +309,7 @@ class CreateProblems(Action):
             unique_func_threads = set(_satyr_reports) - set().union(*clusters)
 
             dendrograms = []
-            i = 0
-            for cluster in clusters:
-                i += 1
+            for i, cluster in enumerate(clusters, start=1):
                 self.log_debug("[%d / %d] Computing distances", i, len(clusters))
                 distances = satyr.Distances(cluster, len(cluster))
 
@@ -481,9 +475,7 @@ class CreateProblems(Action):
         else:
             ptypes = cmdline.problemtype
 
-        i = 0
-        for ptype in ptypes:
-            i += 1
+        for i, ptype in enumerate(ptypes, start=1):
             problemplugin = problemtypes[ptype]
             self.log_info("[{0} / {1}] Processing problem type: {2}"
                           .format(i, len(ptypes), problemplugin.nice_name))

--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -255,7 +255,10 @@ class CreateProblems(Action):
     def _create_problems(self, db, problemplugin, #pylint: disable=too-many-statements
                          report_min_count=0, speedup=False):
         if speedup:
+            self.log_debug("[%s] Getting reports for problems", problemplugin.name)
             db_reports = get_reports_for_problems(db, problemplugin.name)
+
+            self.log_debug("[%s] Getting unassigned reports", problemplugin.name)
             db_reports += get_unassigned_reports(db, problemplugin.name,
                                                  min_count=report_min_count)
         else:

--- a/src/pyfaf/actions/extfafclonebz.py
+++ b/src/pyfaf/actions/extfafclonebz.py
@@ -95,9 +95,7 @@ class ExternalFafCloneBZ(Action):
 
         db_external_reports = db.session.query(ReportExternalFaf).all()
 
-        i = 0
-        for db_external_report in db_external_reports:
-            i += 1
+        for i, db_external_report in enumerate(db_external_reports, start=1):
 
             db_instance = db_external_report.faf_instance
 

--- a/src/pyfaf/actions/extfafclonebz.py
+++ b/src/pyfaf/actions/extfafclonebz.py
@@ -38,11 +38,11 @@ class ExternalFafCloneBZ(Action):
     def _get_bugs(self, url, bz):
         result = set()
 
-        self.log_debug("Opening URL {0}".format(url))
+        self.log_debug("Opening URL %s", url)
         url = urllib.request.urlopen(url)
         code = url.getcode()
         if code != 200:
-            self.log_debug("Unexpected HTTP code: {0}".format(code))
+            self.log_debug("Unexpected HTTP code: %d", code)
             return []
 
         body = url.read()
@@ -58,11 +58,10 @@ class ExternalFafCloneBZ(Action):
                 bug = bz.bz.getbug(bug_id)
                 while (bug.status == "CLOSED" and
                        bug.resolution == "DUPLICATE"):
-                    self.log_debug("Bug {0} is a duplicate of {1}"
-                                   .format(bug.id, bug.dupe_of))
+                    self.log_debug("Bug %d is a duplicate of %d", bug.id, bug.dupe_of)
                     bug = bz.bz.getbug(bug.dupe_of)
             except Exception as ex: # pylint: disable=broad-except
-                self.log_debug("Unable to fetch bug: {0}".format(str(ex)))
+                self.log_debug("Unable to fetch bug: %s", str(ex))
                 continue
 
             result.add(bug)
@@ -108,15 +107,13 @@ class ExternalFafCloneBZ(Action):
                                   db_external_report.external_id))
 
             if db_external_report.report.bz_bugs:
-                self.log_debug("Report #{0} has already a BZ assigned"
-                               .format(db_external_report.report_id))
+                self.log_debug("Report #%d has already a BZ assigned", db_external_report.report_id)
                 continue
 
             now = datetime.datetime.utcnow()
             two_weeks = datetime.timedelta(days=140)
             if now - db_external_report.report.last_occurrence >= two_weeks:
-                self.log_debug("Report #{0} is older than 14 days, skipping"
-                               .format(db_external_report.report_id))
+                self.log_debug("Report #%d is older than 14 days, skipping", db_external_report.report_id)
                 continue
 
             url = "{0}/reports/{1}".format(db_instance.baseurl,
@@ -127,12 +124,11 @@ class ExternalFafCloneBZ(Action):
                 continue
 
             for bug in bugs:
-                self.log_debug("Processing bug #{0}".format(bug.id))
+                self.log_debug("Processing bug #%d", bug.id)
 
                 if bug.component in skip_components:
-                    self.log_debug("Bug #{0} is reported against "
-                                   "an unsupported component {1}"
-                                   .format(bug.id, bug.component))
+                    self.log_debug("Bug #%d is reported against an unsupported component %s",
+                                   bug.id, bug.component)
                     continue
 
                 if bug.status == "CLOSED":

--- a/src/pyfaf/actions/extfafdelete.py
+++ b/src/pyfaf/actions/extfafdelete.py
@@ -32,7 +32,7 @@ class ExternalFafDelete(Action):
                               "in storage".format(instance_id))
                 continue
 
-            self.log_debug("Processing instance '{0}'".format(db_instance.name))
+            self.log_debug("Processing instance '%s'", db_instance.name)
 
             if db_instance.reports:
                 if not cmdline.cascade:
@@ -42,8 +42,7 @@ class ExternalFafDelete(Action):
                     continue
 
                 for db_external_report in db_instance.reports:
-                    self.log_debug("Deleting assigned report #{0}"
-                                   .format(db_external_report.external_id))
+                    self.log_debug("Deleting assigned report #%d", db_external_report.external_id)
                     db.session.delete(db_external_report)
 
             db.session.delete(db_instance)

--- a/src/pyfaf/actions/extfaflink.py
+++ b/src/pyfaf/actions/extfaflink.py
@@ -68,9 +68,7 @@ class ExternalFafLink(Action):
         db_reports = self._get_reports_query(db)
         cnt = db_reports.count()
 
-        i = 0
-        for db_report in db_reports:
-            i += 1
+        for i, db_report in enumerate(db_reports, start=1):
 
             hashes = set()
             self.log_info("[{0} / {1}] Processing report #{2}"
@@ -85,9 +83,7 @@ class ExternalFafLink(Action):
                     self.log_debug("Adding backtrace hash '%s'", db_bthash.hash)
                     hashes.add(db_bthash.hash)
 
-            j = 0
-            for hashvalue in hashes:
-                j += 1
+            for j, hashvalue in enumerate(hashes, start=1):
 
                 self.log_debug("[%d / %d] Processing hash '%s'", j, len(hashes), hashvalue)
                 external_id = self._find_hash(hashvalue,

--- a/src/pyfaf/actions/extfaflink.py
+++ b/src/pyfaf/actions/extfaflink.py
@@ -83,9 +83,10 @@ class ExternalFafLink(Action):
                     self.log_debug("Adding backtrace hash '%s'", db_bthash.hash)
                     hashes.add(db_bthash.hash)
 
+            hashes_len = len(hashes)
             for j, hashvalue in enumerate(hashes, start=1):
 
-                self.log_debug("[%d / %d] Processing hash '%s'", j, len(hashes), hashvalue)
+                self.log_debug("[%d / %d] Processing hash '%s'", j, hashes_len, hashvalue)
                 external_id = self._find_hash(hashvalue,
                                               db_external_faf.baseurl,
                                               parser)

--- a/src/pyfaf/actions/extfaflink.py
+++ b/src/pyfaf/actions/extfaflink.py
@@ -77,22 +77,19 @@ class ExternalFafLink(Action):
                           .format(i, cnt, db_report.id))
 
             for db_reporthash in db_report.hashes:
-                self.log_debug("Adding report hash '{0}'"
-                               .format(db_reporthash.hash))
+                self.log_debug("Adding report hash '%s'", db_reporthash.hash)
                 hashes.add(db_reporthash.hash)
 
             for db_backtrace in db_report.backtraces:
                 for db_bthash in db_backtrace.hashes:
-                    self.log_debug("Adding backtrace hash '{0}'"
-                                   .format(db_bthash.hash))
+                    self.log_debug("Adding backtrace hash '%s'", db_bthash.hash)
                     hashes.add(db_bthash.hash)
 
             j = 0
             for hashvalue in hashes:
                 j += 1
 
-                self.log_debug("[{0} / {1}] Processing hash '{2}'"
-                               .format(j, len(hashes), hashvalue))
+                self.log_debug("[%d / %d] Processing hash '%s'", j, len(hashes), hashvalue)
                 external_id = self._find_hash(hashvalue,
                                               db_external_faf.baseurl,
                                               parser)
@@ -100,8 +97,7 @@ class ExternalFafLink(Action):
                     continue
 
                 if self._has_external_report(db_report, external_id):
-                    self.log_debug("Skipping existing external report #{0}"
-                                   .format(external_id))
+                    self.log_debug("Skipping existing external report #%d", external_id)
                     continue
 
                 self.log_info("Adding external report #{0}"

--- a/src/pyfaf/actions/find_components.py
+++ b/src/pyfaf/actions/find_components.py
@@ -70,9 +70,8 @@ class FindComponents(Action):
 
                 comp_name = db_build.base_package_name
                 if comp_name not in components:
-                    self.log_debug("Component '{0}' not found in operating "
-                                   "system '{1}'".format(comp_name,
-                                                         osplugin.nice_name))
+                    self.log_debug("Component '%s' not found in operating system '%s'",
+                                   comp_name, osplugin.nice_name)
                     continue
 
                 db_component = components[comp_name]

--- a/src/pyfaf/actions/find_components.py
+++ b/src/pyfaf/actions/find_components.py
@@ -60,10 +60,8 @@ class FindComponents(Action):
             for db_component in db_components:
                 components[db_component.name] = db_component
 
-            i = 0
             db_builds = osplugin.get_build_candidates(db)
-            for db_build in db_builds:
-                i += 1
+            for i, db_build in enumerate(db_builds, start=1):
 
                 self.log_info("[{0} / {1}] Processing '{2}'"
                               .format(i, len(db_builds), db_build.nevr()))

--- a/src/pyfaf/actions/find_crash_function.py
+++ b/src/pyfaf/actions/find_crash_function.py
@@ -31,9 +31,7 @@ class FindCrashFunction(Action):
         db_backtraces = get_backtraces_by_type(db, problemplugin.name,
                                                query_all=query_all)
         db_backtraces_count = db_backtraces.count()
-        i = 0
-        for db_backtrace in db_backtraces.yield_per(100):
-            i += 1
+        for i, db_backtrace in enumerate(db_backtraces.yield_per(100), start=1):
             try:
                 crashfn = (demangle(problemplugin.find_crash_function(
                     db_backtrace))[:column_len(ReportBacktrace, "crashfn")])
@@ -63,9 +61,7 @@ class FindCrashFunction(Action):
         else:
             ptypes = cmdline.problemtype
 
-        i = 0
-        for ptype in ptypes:
-            i += 1
+        for i, ptype in enumerate(ptypes, start=1):
             problemplugin = problemtypes[ptype]
             self.log_info("[{0} / {1}] Processing problem type: {2}"
                           .format(i, len(ptypes), problemplugin.nice_name))

--- a/src/pyfaf/actions/init.py
+++ b/src/pyfaf/actions/init.py
@@ -49,7 +49,7 @@ class Init(Action):
 
         for plugin in plugins:
             if not plugin.installed(db):
-                plugin.install(db, logger=log.getChildLogger(plugin.__name__))
+                plugin.install(db, logger=log.getChild(plugin.__name__))
 
         db.session.flush()
 

--- a/src/pyfaf/actions/mark_probably_fixed.py
+++ b/src/pyfaf/actions/mark_probably_fixed.py
@@ -173,8 +173,8 @@ class MarkProbablyFixed(Action):
             problem_counter = 0
             for problem in problems:
                 problem_counter += 1
-                self.log_debug("Processing problem ID:{0} {1}/{2}:"
-                               .format(problem.id, problem_counter, len(problems)))
+                self.log_debug("Processing problem ID:%d %d/%d:",
+                               problem.id, problem_counter, len(problems))
                 affected_newest = {}
                 affected_not_found = False
 
@@ -277,8 +277,8 @@ class MarkProbablyFixed(Action):
                     self._save_probable_fix(db, problem, db_release,
                                             pkg["probable_fix"],
                                             probably_fixed_since)
-                    self.log_debug("  Probably fixed for {0} days.".format(
-                        (datetime.now() - probably_fixed_since).days))
+                    self.log_debug("  Probably fixed for %d days.",
+                                   (datetime.now() - probably_fixed_since).days)
                     probably_fixed_total += 1
                 else:
                     self._save_probable_fix(db, problem, db_release, None)

--- a/src/pyfaf/actions/mark_probably_fixed.py
+++ b/src/pyfaf/actions/mark_probably_fixed.py
@@ -186,7 +186,7 @@ class MarkProbablyFixed(Action):
                 if reports_for_release:
                     problems_in_release += 1
                 else:
-                    self.log_debug(" This problem doesn't appear in this release.")
+                    self.log_debug("\tThis problem doesn't appear in this release.")
                     self._save_probable_fix(db, problem, db_release, None)
                     # Next problem
                     continue
@@ -233,7 +233,7 @@ class MarkProbablyFixed(Action):
                 if affected_not_found or not affected_newest:
                     # Affected package of one of the reports was not found.
                     # We can't make any conclusions.
-                    self.log_debug(" Affected package not found.")
+                    self.log_debug("\tAffected package not found.")
                     self._save_probable_fix(db, problem, db_release, None)
                     # Next problem
                     continue
@@ -241,7 +241,7 @@ class MarkProbablyFixed(Action):
                 if len(affected_newest) > 1:
                     # Multiple different affected packages => cannot be fixed
                     # by a single package update
-                    self.log_debug(" Multiple affected packages. No simple fix.")
+                    self.log_debug("\tMultiple affected packages. No simple fix.")
                     self._save_probable_fix(db, problem, db_release, None)
                     # Next problem
                     continue
@@ -277,12 +277,12 @@ class MarkProbablyFixed(Action):
                     self._save_probable_fix(db, problem, db_release,
                                             pkg["probable_fix"],
                                             probably_fixed_since)
-                    self.log_debug("  Probably fixed for %d days.",
+                    self.log_debug("\tProbably fixed for %d days.",
                                    (datetime.now() - probably_fixed_since).days)
                     probably_fixed_total += 1
                 else:
                     self._save_probable_fix(db, problem, db_release, None)
-                    self.log_debug("  Not fixed.")
+                    self.log_debug("\tNot fixed.")
 
             db.session.flush()
             if problems_in_release > 0:

--- a/src/pyfaf/actions/mark_probably_fixed.py
+++ b/src/pyfaf/actions/mark_probably_fixed.py
@@ -140,9 +140,7 @@ class MarkProbablyFixed(Action):
 
         problems = get_problems(db)
 
-        task_i = 0
-        for osplugin, db_release in tasks:
-            task_i += 1
+        for task_i, (osplugin, db_release) in enumerate(tasks, start=1):
 
             self.log_info("[{0} / {1}] Processing '{2} {3}'"
                           .format(task_i, len(tasks), osplugin.nice_name,
@@ -170,11 +168,9 @@ class MarkProbablyFixed(Action):
 
             probably_fixed_total = 0
             problems_in_release = 0
-            problem_counter = 0
-            for problem in problems:
-                problem_counter += 1
+            for j, problem in enumerate(problems, start=1):
                 self.log_debug("Processing problem ID:%d %d/%d:",
-                               problem.id, problem_counter, len(problems))
+                               problem.id, j, len(problems))
                 affected_newest = {}
                 affected_not_found = False
 

--- a/src/pyfaf/actions/pull_associates.py
+++ b/src/pyfaf/actions/pull_associates.py
@@ -63,7 +63,7 @@ class PullAssociates(Action):
                 j += 1
 
                 name = db_component.name
-                self.log_debug("  [%d / %d] Processing component '%s'", j, len(components), name)
+                self.log_debug("\t[%d / %d] Processing component '%s'", j, len(components), name)
                 try:
                     acls = opsys.get_component_acls(name)
                 except TypeError:
@@ -84,7 +84,7 @@ class PullAssociates(Action):
                     k = 0
                     for associate in acl_lists[permission]:
                         k += 1
-                        self.log_debug("    [%d / %d] Processing associate '%s' permission %s",
+                        self.log_debug("\t[%d / %d] Processing associate '%s' permission %s",
                                        k, len(acl_lists[permission]), associate, permission)
 
                         db_associate = get_associate_by_name(db, associate)

--- a/src/pyfaf/actions/pull_associates.py
+++ b/src/pyfaf/actions/pull_associates.py
@@ -50,18 +50,12 @@ class PullAssociates(Action):
             opsyss.append((opsys, db_opsys))
 
         new_associates = {}
-        i = 0
-        for (opsys, db_opsys) in opsyss:
-            i += 1
-
+        for i, (opsys, db_opsys) in enumerate(opsyss, start=1):
             self.log_info("[{0} / {1}] Processing {2}"
                           .format(i, len(opsyss), opsys.nice_name))
 
-            j = 0
             components = get_components_by_opsys(db, db_opsys).all()
-            for db_component in components:
-                j += 1
-
+            for j, db_component in enumerate(components, start=1):
                 name = db_component.name
                 self.log_debug("\t[%d / %d] Processing component '%s'", j, len(components), name)
                 try:
@@ -81,9 +75,7 @@ class PullAssociates(Action):
                             acl_lists[permission].append(associate)
 
                 for permission in acl_lists:
-                    k = 0
-                    for associate in acl_lists[permission]:
-                        k += 1
+                    for k, associate in enumerate(acl_lists[permission], start=1):
                         self.log_debug("\t[%d / %d] Processing associate '%s' permission %s",
                                        k, len(acl_lists[permission]), associate, permission)
 

--- a/src/pyfaf/actions/pull_associates.py
+++ b/src/pyfaf/actions/pull_associates.py
@@ -63,8 +63,7 @@ class PullAssociates(Action):
                 j += 1
 
                 name = db_component.name
-                self.log_debug("  [{0} / {1}] Processing component '{2}'"
-                               .format(j, len(components), name))
+                self.log_debug("  [%d / %d] Processing component '%s'", j, len(components), name)
                 try:
                     acls = opsys.get_component_acls(name)
                 except TypeError:
@@ -85,10 +84,8 @@ class PullAssociates(Action):
                     k = 0
                     for associate in acl_lists[permission]:
                         k += 1
-                        self.log_debug("    [{0} / {1}] Processing associate '{2}' "
-                                       "permission {3}"
-                                       .format(k, len(acl_lists[permission]),
-                                               associate, permission))
+                        self.log_debug("    [%d / %d] Processing associate '%s' permission %s",
+                                       k, len(acl_lists[permission]), associate, permission)
 
                         db_associate = get_associate_by_name(db, associate)
                         if db_associate is None:

--- a/src/pyfaf/actions/pull_associates.py
+++ b/src/pyfaf/actions/pull_associates.py
@@ -50,14 +50,16 @@ class PullAssociates(Action):
             opsyss.append((opsys, db_opsys))
 
         new_associates = {}
+        opsyss_len = len(opsyss)
         for i, (opsys, db_opsys) in enumerate(opsyss, start=1):
             self.log_info("[{0} / {1}] Processing {2}"
-                          .format(i, len(opsyss), opsys.nice_name))
+                          .format(i, opsyss_len, opsys.nice_name))
 
             components = get_components_by_opsys(db, db_opsys).all()
+            components_len = len(components)
             for j, db_component in enumerate(components, start=1):
                 name = db_component.name
-                self.log_debug("\t[%d / %d] Processing component '%s'", j, len(components), name)
+                self.log_debug("\t[%d / %d] Processing component '%s'", j, components_len, name)
                 try:
                     acls = opsys.get_component_acls(name)
                 except TypeError:
@@ -75,9 +77,10 @@ class PullAssociates(Action):
                             acl_lists[permission].append(associate)
 
                 for permission in acl_lists:
+                    acl_list_perm_len = len(acl_lists[permission])
                     for k, associate in enumerate(acl_lists[permission], start=1):
                         self.log_debug("\t[%d / %d] Processing associate '%s' permission %s",
-                                       k, len(acl_lists[permission]), associate, permission)
+                                       k, acl_list_perm_len, associate, permission)
 
                         db_associate = get_associate_by_name(db, associate)
                         if db_associate is None:

--- a/src/pyfaf/actions/pull_components.py
+++ b/src/pyfaf/actions/pull_components.py
@@ -101,10 +101,7 @@ class PullComponents(Action):
 
         new_components = {}
 
-        i = 0
-        for osplugin, db_release in tasks:
-            i += 1
-
+        for i, (osplugin, db_release) in enumerate(tasks, start=1):
             self.log_info("[{0} / {1}] Processing '{2} {3}'"
                           .format(i, len(tasks), osplugin.nice_name,
                                   db_release.version))

--- a/src/pyfaf/actions/pull_releases.py
+++ b/src/pyfaf/actions/pull_releases.py
@@ -51,7 +51,7 @@ class PullReleases(Action):
         self.log_info("Loading releases from local storage")
         db_releases = {}
         for db_release in opsys.releases:
-            self.log_debug("Loading release '{0}'".format(db_release.version))
+            self.log_debug("Loading release '%s'", db_release.version)
             db_releases[db_release.version] = db_release
 
         self.log_info("Downloading releases from remote database")
@@ -70,8 +70,7 @@ class PullReleases(Action):
                 db_release = db_releases[release]
 
                 if remote_status == db_release.status:
-                    self.log_debug("Release '{0}' is up to date"
-                                   .format(release))
+                    self.log_debug("Release '%s' is up to date", release)
                     continue
 
                 self.log_info("Updating status for release '{0}': '{1}' "

--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -146,8 +146,7 @@ class PullReports(Action):
         pulled = 0
         try:
             for i, report in enumerate(sorted(new_reports)):
-                self.log_debug("[{0} / {1}] Pulling #{2}..."
-                               .format(i + 1, len(new_reports), report))
+                self.log_debug("[%d / %d] Pulling #%d...", i + 1, len(new_reports), report)
                 # Fetch the uReport from the server
                 ureport = self._get_report(report)
                 if ureport is None:
@@ -165,7 +164,7 @@ class PullReports(Action):
                 with open(filename, "wb") as f:
                     f.write(ureport)
 
-                self.log_debug("Saved to {0}".format(filename))
+                self.log_debug("Saved to %s", filename)
                 self.known.add(report)
                 pulled += 1
         finally:

--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -145,8 +145,9 @@ class PullReports(Action):
 
         pulled = 0
         try:
+            new_reports_len = len(new_reports)
             for i, report in enumerate(sorted(new_reports), start=1):
-                self.log_debug("[%d / %d] Pulling #%d...", i, len(new_reports), report)
+                self.log_debug("[%d / %d] Pulling #%d...", i, new_reports_len, report)
                 # Fetch the uReport from the server
                 ureport = self._get_report(report)
                 if ureport is None:

--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -145,8 +145,8 @@ class PullReports(Action):
 
         pulled = 0
         try:
-            for i, report in enumerate(sorted(new_reports)):
-                self.log_debug("[%d / %d] Pulling #%d...", i + 1, len(new_reports), report)
+            for i, report in enumerate(sorted(new_reports), start=1):
+                self.log_debug("[%d / %d] Pulling #%d...", i, len(new_reports), report)
                 # Fetch the uReport from the server
                 ureport = self._get_report(report)
                 if ureport is None:

--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -111,8 +111,8 @@ class RepoSync(Action):
 
             self.log_info("Repository has '{0}' packages".format(total))
 
-            for num, pkg in enumerate(pkglist):
-                self.log_debug("[%d / %d] Processing package %s", num + 1, total, pkg["name"])
+            for num, pkg in enumerate(pkglist, start=1):
+                self.log_debug("[%d / %d] Processing package %s", num, total, pkg["name"])
 
                 if not pkg["name"].lower().startswith(cmdline.name_prefix):
                     self.log_debug("Skipped package %s", pkg["name"])

--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -112,12 +112,10 @@ class RepoSync(Action):
             self.log_info("Repository has '{0}' packages".format(total))
 
             for num, pkg in enumerate(pkglist):
-                self.log_debug("[{0} / {1}] Processing package {2}"
-                               .format(num + 1, total, pkg["name"]))
+                self.log_debug("[%d / %d] Processing package %s", num + 1, total, pkg["name"])
 
                 if not pkg["name"].lower().startswith(cmdline.name_prefix):
-                    self.log_debug("Skipped package {0}"
-                                   .format(pkg["name"]))
+                    self.log_debug("Skipped package %s", pkg["name"])
                     continue
                 arch = architectures.get(pkg["arch"], None)
                 if not arch:
@@ -142,8 +140,7 @@ class RepoSync(Action):
                          .first())
 
                 if not build:
-                    self.log_debug("Adding build {0}-{1}".format(
-                        pkg["base_package_name"], pkg["version"]))
+                    self.log_debug("Adding build %s-%d", pkg["base_package_name"], pkg["version"])
 
                     build = Build()
                     build.base_package_name = pkg["base_package_name"]
@@ -254,7 +251,7 @@ class RepoSync(Action):
                             self.log_error("Error deleting the RPM file.")
 
                 else:
-                    self.log_debug("Known package {0}".format(pkg["filename"]))
+                    self.log_debug("Known package %s", pkg["filename"])
 
     @retry(3, delay=5, backoff=3, verbose=True)
     def _download(self, obj, lob, url):

--- a/src/pyfaf/actions/retrace.py
+++ b/src/pyfaf/actions/retrace.py
@@ -45,10 +45,9 @@ class Retrace(Action):
         i = 0
         for db_ssource in db_ssources:
             i += 1
-            self.log_debug(u"[{0} / {1}] Processing '{2}' @ '{3}'"
-                           .format(i, len(db_ssources),
-                                   ssource2funcname(db_ssource),
-                                   db_ssource.path))
+            self.log_debug("[%d / %d] Processing '%s' @ '%s'",
+                           i, len(db_ssources), ssource2funcname(db_ssource),
+                           db_ssource.path)
 
             try:
                 pkgs = problemplugin.find_packages_for_ssource(db, db_ssource)
@@ -111,8 +110,7 @@ class Retrace(Action):
             for db_debug_pkg, (db_src_pkg, binpkgmap) in pkgmap.items():
                 i += 1
 
-                self.log_debug("[{0} / {1}] Creating task for '{2}'"
-                               .format(i, len(pkgmap), db_debug_pkg.nvra()))
+                self.log_debug("[%d / %d] Creating task for '%s'", i, len(pkgmap), db_debug_pkg.nvra())
 
                 try:
                     tasks.append(RetraceTask(db_debug_pkg, db_src_pkg,

--- a/src/pyfaf/actions/retrace.py
+++ b/src/pyfaf/actions/retrace.py
@@ -42,9 +42,7 @@ class Retrace(Action):
 
         result = {}
 
-        i = 0
-        for db_ssource in db_ssources:
-            i += 1
+        for i, db_ssource in enumerate(db_ssources, start=1):
             self.log_debug("[%d / %d] Processing '%s' @ '%s'",
                            i, len(db_ssources), ssource2funcname(db_ssource),
                            db_ssource.path)
@@ -106,10 +104,7 @@ class Retrace(Action):
 
             tasks = collections.deque()
 
-            i = 0
-            for db_debug_pkg, (db_src_pkg, binpkgmap) in pkgmap.items():
-                i += 1
-
+            for i, db_debug_pkg, (db_src_pkg, binpkgmap) in enumerate(pkgmap.items(), start=1):
                 self.log_debug("[%d / %d] Creating task for '%s'", i, len(pkgmap), db_debug_pkg.nvra())
 
                 try:

--- a/src/pyfaf/actions/retrace_remote.py
+++ b/src/pyfaf/actions/retrace_remote.py
@@ -58,11 +58,9 @@ class RetraceRemote(Action):
             if not db_ssources:
                 continue
 
-            i = 0
             batch = []
             db_batch = []
-            for db_ssource in db_ssources:
-                i += 1
+            for i, db_ssource in enumerate(db_ssources, start=1):
                 self.log_info("Processing symbol {0}/{1}"
                               .format(i, len(db_ssources)))
                 req_data = {

--- a/src/pyfaf/actions/save_reports.py
+++ b/src/pyfaf/actions/save_reports.py
@@ -151,10 +151,7 @@ class SaveReports(Action):
 
         report_filenames = glob.glob(os.path.join(self.dir_report_incoming, pattern))
 
-        i = 0
-        for filename in sorted(report_filenames):
-            i += 1
-
+        for i, filename in enumerate(sorted(report_filenames), start=1):
             fname = os.path.basename(filename)
             self.log_info("[{0} / {1}] Processing file '{2}'"
                           .format(i, len(report_filenames), filename))
@@ -240,10 +237,7 @@ class SaveReports(Action):
         # with appropriate count.
 
         reports = {}
-        i = 0
-        for fname in sorted(report_filenames):
-            i += 1
-
+        for i, fname in enumerate(sorted(report_filenames), start=1):
             filename = os.path.join(self.dir_report_incoming, fname)
             self.log_info("[{0} / {1}] Loading file '{2}'"
                           .format(i, len(report_filenames), filename))
@@ -275,9 +269,7 @@ class SaveReports(Action):
                 self._move_report_to_deferred(fname)
                 continue
 
-        i = 0
-        for unique in reports.values():
-            i += 1
+        for i, unique in enumerate(reports.values(), start=1):
             self.log_info("[{0} / {1}] Processing unique file '{2}'"
                           .format(i, len(reports), unique["filenames"][0]))
             ureport = unique["ureport"]
@@ -316,10 +308,7 @@ class SaveReports(Action):
 
         attachment_filenames = os.listdir(self.dir_attach_incoming)
 
-        i = 0
-        for fname in sorted(attachment_filenames):
-            i += 1
-
+        for i, fname in enumerate(sorted(attachment_filenames), start=1):
             filename = os.path.join(self.dir_attach_incoming, fname)
             self.log_info("[{0} / {1}] Processing file '{2}'"
                           .format(i, len(attachment_filenames), filename))

--- a/src/pyfaf/actions/save_reports.py
+++ b/src/pyfaf/actions/save_reports.py
@@ -76,7 +76,7 @@ class SaveReports(Action):
         path_from = os.path.join(self.dir_report_incoming, filename)
         path_to = os.path.join(self.dir_report_saved, filename)
 
-        self.log_debug("Moving file '{0}' to saved".format(path_from))
+        self.log_debug("Moving file '%s' to saved", path_from)
 
         try:
             os.rename(path_from, path_to)
@@ -92,7 +92,7 @@ class SaveReports(Action):
         path_from = os.path.join(self.dir_report_incoming, filename)
         path_to = os.path.join(self.dir_report_deferred, filename)
 
-        self.log_debug("Moving file '{0}' to deferred".format(path_from))
+        self.log_debug("Moving file '%s' to deferred", path_from)
 
         try:
             os.rename(path_from, path_to)
@@ -108,7 +108,7 @@ class SaveReports(Action):
         path_from = os.path.join(self.dir_attach_incoming, filename)
         path_to = os.path.join(self.dir_attach_saved, filename)
 
-        self.log_debug("Moving file '{0}' to saved".format(path_from))
+        self.log_debug("Moving file '%s' to saved", path_from)
 
         try:
             os.rename(path_from, path_to)
@@ -120,7 +120,7 @@ class SaveReports(Action):
         path_from = os.path.join(self.dir_attach_incoming, filename)
         path_to = os.path.join(self.dir_attach_deferred, filename)
 
-        self.log_debug("Moving file '{0}' to deferred".format(path_from))
+        self.log_debug("Moving file '%s' to deferred", path_from)
 
         try:
             os.rename(path_from, path_to)
@@ -208,11 +208,11 @@ class SaveReports(Action):
         self.lock_filename = os.path.join(self.dir_report_incoming, lock_name)
         open(self.lock_filename, "w").close()
         os.utime(self.lock_filename, (int(now), int(now)))
-        self.log_debug("Created lock {0}".format(self.lock_filename))
+        self.log_debug("Created lock %s", self.lock_filename)
 
         # Remove lock on SIGTERM and Ctrl-C
         def handle_term(_, __):
-            self.log_debug("Signal caught, removing lock {0}".format(self.lock_filename))
+            self.log_debug("Signal caught, removing lock %s", self.lock_filename)
             os.remove(self.lock_filename)
             sys.exit(0)
         signal.signal(signal.SIGTERM, handle_term)
@@ -308,7 +308,7 @@ class SaveReports(Action):
 
             self._move_reports_to_saved(unique["filenames"])
 
-        self.log_debug("Removing lock {0}".format(self.lock_filename))
+        self.log_debug("Removing lock %s", self.lock_filename)
         os.remove(self.lock_filename)
 
     def _save_attachments(self, db):
@@ -354,8 +354,7 @@ class SaveReports(Action):
                 try:
                     self._save_reports_speedup(db)
                 except:
-                    self.log_debug("Uncaught exception. Removing lock {0}"
-                                   .format(self.lock_filename))
+                    self.log_debug("Uncaught exception. Removing lock %s", self.lock_filename)
                     os.remove(self.lock_filename)
                     raise
             elif cmdline.pattern:

--- a/src/pyfaf/actions/sf_prefilter_patadd.py
+++ b/src/pyfaf/actions/sf_prefilter_patadd.py
@@ -60,12 +60,10 @@ class SfPrefilterPatAdd(Action):
                           .format(db_opsys.name))
 
         for btpath in cmdline.btpath:
-            self.log_debug("Processing stacktrace path pattern: {0}"
-                           .format(btpath))
+            self.log_debug("Processing stacktrace path pattern: %s", btpath)
             db_btpath = get_sf_prefilter_btpath_by_pattern(db, btpath)
             if db_btpath is not None:
-                self.log_debug("Stacktrace path pattern {0} already exists"
-                               .format(btpath))
+                self.log_debug("Stacktrace path pattern %s already exists", btpath)
                 continue
 
             try:
@@ -85,12 +83,10 @@ class SfPrefilterPatAdd(Action):
             db.session.add(db_btpath)
 
         for pkgname in cmdline.pkgname:
-            self.log_debug("Processing package name pattern: {0}"
-                           .format(pkgname))
+            self.log_debug("Processing package name pattern: %s", pkgname)
             db_btpath = get_sf_prefilter_pkgname_by_pattern(db, pkgname)
             if db_btpath is not None:
-                self.log_debug("Package name pattern {0} already exists"
-                               .format(pkgname))
+                self.log_debug("Package name pattern %s already exists", pkgname)
                 continue
 
             try:

--- a/src/pyfaf/actions/stats.py
+++ b/src/pyfaf/actions/stats.py
@@ -118,10 +118,10 @@ class Stats(Action):
 
         out = "Components:\n\n"
 
-        for num, (comp, count, reports) in enumerate(results):
+        for num, (comp, count, reports) in enumerate(results, start=1):
             if reports:
                 out += ("{0}. {1} seen {2} times ({3:.0%} of all reports)\n"
-                        .format(num + 1, comp, count, count / float(total_num)))
+                        .format(num, comp, count, count / float(total_num)))
 
                 for problem_url, bugs in reports:
                     if problem_url or bugs:

--- a/src/pyfaf/actions/update_bugs.py
+++ b/src/pyfaf/actions/update_bugs.py
@@ -55,8 +55,7 @@ class UpdateBugs(Action):
             if hasattr(bug, "external_id") and bug.external_id:
                 bug_id = bug.external_id
 
-            self.log_debug("[{0} / {1}] Updating bug {2}"
-                           .format(num + 1, total, bug_id))
+            self.log_debug("[%d / %d] Updating bug %d", num + 1, total, bug_id)
 
             try:
                 tracker.download_bug_to_storage(db, bug_id)

--- a/src/pyfaf/actions/update_bugs.py
+++ b/src/pyfaf/actions/update_bugs.py
@@ -49,13 +49,13 @@ class UpdateBugs(Action):
             self.log_info("Found no bugs associated with this bugtracker")
 
         total = len(buglist)
-        for num, bug in enumerate(buglist):
+        for num, bug in enumerate(buglist, start=1):
             bug_id = bug.id
             # Mantis bugs IDs are stored in external_id
             if hasattr(bug, "external_id") and bug.external_id:
                 bug_id = bug.external_id
 
-            self.log_debug("[%d / %d] Updating bug %d", num + 1, total, bug_id)
+            self.log_debug("[%d / %d] Updating bug %d", num, total, bug_id)
 
             try:
                 tracker.download_bug_to_storage(db, bug_id)

--- a/src/pyfaf/bugtrackers/__init__.py
+++ b/src/pyfaf/bugtrackers/__init__.py
@@ -42,7 +42,7 @@ class BugTracker(Plugin):
     @classmethod
     def install(cls, db, logger=None):
         if logger is None:
-            logger = log.getChildLogger(cls.__name__)
+            logger = log.getChild(cls.__name__)
 
         logger.info("Adding bugtracker '{0}'".format(cls.name))
         new = Bugtracker()

--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -416,8 +416,8 @@ class Bugzilla(BugTracker):
         """
 
         total = len(ccs)
-        for num, user_email in enumerate(ccs):
-            self.log_debug("Processing CC: %d/%d", num + 1, total)
+        for num, user_email in enumerate(ccs, start=1):
+            self.log_debug("Processing CC: %d/%d", num, total)
             cc = (
                 db.session.query(BzBugCc)
                 .join(BzUser)
@@ -454,8 +454,8 @@ class Bugzilla(BugTracker):
         """
 
         total = len(events)
-        for num, event in enumerate(events):
-            self.log_debug("Processing history event %d/%d", num + 1, total)
+        for num, event in enumerate(events, start=1):
+            self.log_debug("Processing history event %d/%d", num, total)
 
             user_email = event["who"]
             user = queries.get_bz_user(db, user_email)
@@ -505,8 +505,8 @@ class Bugzilla(BugTracker):
         """
 
         total = len(attachments)
-        for num, attachment in enumerate(attachments):
-            self.log_debug("Processing attachment %d/%d", num + 1, total)
+        for num, attachment in enumerate(attachments, start=1):
+            self.log_debug("Processing attachment %d/%d", num, total)
 
             if queries.get_bz_attachment(db, attachment["id"]):
                 self.log_debug("Skipping existing attachment #%d", attachment["id"])
@@ -559,8 +559,8 @@ class Bugzilla(BugTracker):
         """
 
         total = len(comments)
-        for num, comment in enumerate(comments):
-            self.log_debug("Processing comment %d/%d", num + 1, total)
+        for num, comment in enumerate(comments, start=1):
+            self.log_debug("Processing comment %d/%d", num, total)
 
             if queries.get_bz_comment(db, comment["id"]):
                 self.log_debug("Skipping existing comment #%d", comment["id"])

--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -95,15 +95,13 @@ class Bugzilla(BugTracker):
                 "No api_url specified for '{0}' bugzilla instance"
                 .format(self.name))
 
-        self.log_debug("Opening bugzilla connection for '{0}'"
-                       .format(self.name))
+        self.log_debug("Opening bugzilla connection for '%s'", self.name)
 
         self.bz = bugzilla.Bugzilla(url=str(self.api_url), cookiefile=None,
                                     tokenfile=None)
 
         if self.user and self.password:
-            self.log_debug("Logging into bugzilla '{0}' as '{1}'"
-                           .format(self.name, self.user))
+            self.log_debug("Logging into bugzilla '%s' as '%s'", self.name, self.user)
 
             self.bz.login(self.user, self.password)
         else:
@@ -117,7 +115,7 @@ class Bugzilla(BugTracker):
         Download and save single bug identified by `bug_id`.
         """
 
-        self.log_debug(u"Downloading bug #{0}".format(bug_id))
+        self.log_debug(u"Downloading bug #%d", bug_id)
         self.connect()
         try:
             if self.save_attachments:
@@ -185,7 +183,7 @@ class Bugzilla(BugTracker):
 
                 count = len(result)
                 fetched_per_date_range += count
-                self.log_debug("Got {0} bugs".format(count))
+                self.log_debug("Got %d bugs", count)
                 for bug in result:
                     yield bug.bug_id
 
@@ -219,9 +217,8 @@ class Bugzilla(BugTracker):
         if "chfield" in custom_fields:
             target = "bugs created"
 
-        self.log_debug("Fetching {0} between "
-                       "{1} and {2}, offset is: {3}".format(target, from_date,
-                                                            to_date, offset))
+        self.log_debug("Fetching %s between %s and %s, offset is: %s",
+                       target, from_date, to_date, offset)
 
         queue = dict(
             chfieldto=to_date.strftime("%Y-%m-%d"),
@@ -305,8 +302,7 @@ class Bugzilla(BugTracker):
             self.log_error("Bug pre-processing failed")
             raise FafError("Bug pre-processing failed")
 
-        self.log_debug("Saving bug #{0}: {1}".format(bug_dict["bug_id"],
-                                                     bug_dict["summary"]))
+        self.log_debug("Saving bug #%d: %s", bug_dict["bug_id"], bug_dict["summary"])
 
         bug_id = bug_dict["bug_id"]
 
@@ -352,8 +348,7 @@ class Bugzilla(BugTracker):
 
         reporter = queries.get_bz_user(db, bug_dict["reporter"])
         if not reporter:
-            self.log_debug("Creator {0} not found".format(
-                bug_dict["reporter"]))
+            self.log_debug("Creator %s not found", bug_dict["reporter"])
 
             downloaded = self._download_user(bug_dict["reporter"])
             if not downloaded:
@@ -374,8 +369,7 @@ class Bugzilla(BugTracker):
             new_bug.resolution = bug_dict["resolution"]
             if bug_dict["resolution"] == "DUPLICATE":
                 if not queries.get_bz_bug(db, bug_dict["dupe_id"]):
-                    self.log_debug("Duplicate #{0} not found".format(
-                        bug_dict["dupe_id"]))
+                    self.log_debug("Duplicate #%d not found", bug_dict["dupe_id"])
 
                     dup = self.download_bug_to_storage(db, bug_dict["dupe_id"])
                     if dup:
@@ -390,8 +384,7 @@ class Bugzilla(BugTracker):
         # the bug itself might be downloaded during duplicate processing
         # exit in this case - it would cause duplicate database entry
         if queries.get_bz_bug(db, bug_dict["bug_id"]):
-            self.log_debug("Bug #{0} already exists in storage,"
-                           " updating".format(bug_dict["bug_id"]))
+            self.log_debug("Bug #%d already exists in storage, updating", bug_dict["bug_id"])
 
             bugdict = {}
             for col in new_bug.__table__._columns: #pylint: disable=protected-access
@@ -424,7 +417,7 @@ class Bugzilla(BugTracker):
 
         total = len(ccs)
         for num, user_email in enumerate(ccs):
-            self.log_debug("Processing CC: {0}/{1}".format(num + 1, total))
+            self.log_debug("Processing CC: %d/%d", num + 1, total)
             cc = (
                 db.session.query(BzBugCc)
                 .join(BzUser)
@@ -432,14 +425,12 @@ class Bugzilla(BugTracker):
                         (BzBugCc.bug_id == new_bug_id)).first())
 
             if cc:
-                self.log_debug("CC'ed user {0} already"
-                               " exists".format(user_email))
+                self.log_debug("CC'ed user %s already exists", user_email)
                 continue
 
             cced = queries.get_bz_user(db, user_email)
             if not cced:
-                self.log_debug("CC'ed user {0} not found,"
-                               " adding.".format(user_email))
+                self.log_debug("CC'ed user %s not found, adding.", user_email)
 
                 downloaded = self._download_user(user_email)
                 if not downloaded:
@@ -464,15 +455,13 @@ class Bugzilla(BugTracker):
 
         total = len(events)
         for num, event in enumerate(events):
-            self.log_debug("Processing history event {0}/{1}".format(num + 1,
-                                                                     total))
+            self.log_debug("Processing history event %d/%d", num + 1, total)
 
             user_email = event["who"]
             user = queries.get_bz_user(db, user_email)
 
             if not user:
-                self.log_debug("History changed by unknown user #{0}".format(
-                    user_email))
+                self.log_debug("History changed by unknown user # %s", user_email)
 
                 downloaded = self._download_user(user_email)
                 if not downloaded:
@@ -493,8 +482,7 @@ class Bugzilla(BugTracker):
                     .first())
 
                 if ch:
-                    self.log_debug("Skipping existing history event "
-                                   "#{0}".format(ch.id))
+                    self.log_debug("Skipping existing history event #%d", ch.id)
                     continue
 
                 new = BzBugHistory()
@@ -518,20 +506,17 @@ class Bugzilla(BugTracker):
 
         total = len(attachments)
         for num, attachment in enumerate(attachments):
-            self.log_debug("Processing attachment {0}/{1}".format(num + 1,
-                                                                  total))
+            self.log_debug("Processing attachment %d/%d", num + 1, total)
 
             if queries.get_bz_attachment(db, attachment["id"]):
-                self.log_debug("Skipping existing attachment #{0}".format(
-                    attachment["id"]))
+                self.log_debug("Skipping existing attachment #%d", attachment["id"])
                 continue
 
             user_email = attachment["attacher"]
             user = queries.get_bz_user(db, user_email)
 
             if not user:
-                self.log_debug("Attachment from unknown user {0}".format(
-                    user_email))
+                self.log_debug("Attachment from unknown user %s", user_email)
 
                 downloaded = self._download_user(user_email)
                 if not downloaded:
@@ -575,22 +560,19 @@ class Bugzilla(BugTracker):
 
         total = len(comments)
         for num, comment in enumerate(comments):
-            self.log_debug("Processing comment {0}/{1}".format(num + 1,
-                                                               total))
+            self.log_debug("Processing comment %d/%d", num + 1, total)
 
             if queries.get_bz_comment(db, comment["id"]):
-                self.log_debug("Skipping existing comment #{0}".format(
-                    comment["id"]))
+                self.log_debug("Skipping existing comment #%d", comment["id"])
                 continue
 
-            self.log_debug("Downloading comment #{0}".format(comment["id"]))
+            self.log_debug("Downloading comment #%d", comment["id"])
 
             user_email = comment["creator"]
             user = queries.get_bz_user(db, user_email)
 
             if not user:
-                self.log_debug("History changed by unknown user #{0}".format(
-                    user_email))
+                self.log_debug("History changed by unknown user # %s", user_email)
 
                 downloaded = self._download_user(user_email)
                 if not downloaded:
@@ -642,7 +624,7 @@ class Bugzilla(BugTracker):
 
             return None
 
-        self.log_debug("Downloading user {0}".format(user_email))
+        self.log_debug("Downloading user %s", user_email)
         self.connect()
         user = self.bz.getuser(user_email)
         return user

--- a/src/pyfaf/bugtrackers/mantisbt.py
+++ b/src/pyfaf/bugtrackers/mantisbt.py
@@ -95,8 +95,7 @@ class Mantis(BugTracker):
                 "No username or password specified for '{0}'"
                 " mantisbt instance".format(self.name))
 
-        self.log_debug("Opening mantisbt connection for '{0}'"
-                       .format(self.name))
+        self.log_debug("Opening mantisbt connection for '%s'", self.name)
 
         client = Client(self.api_url)
         self.mantis_client = client
@@ -110,7 +109,7 @@ class Mantis(BugTracker):
         Download and save single bug identified by `bug_id`.
         """
 
-        self.log_debug(u"Downloading bug #{0}".format(bug_id))
+        self.log_debug("Downloading bug #%d", bug_id)
         self.connect()
         bug = self.mc.mc_issue_get(self.user, self.password, bug_id)
         return self._save_bug(db, bug)
@@ -162,8 +161,7 @@ class Mantis(BugTracker):
             self.log_error("Bug pre-processing failed")
             return None
 
-        self.log_debug("Saving bug #{0}: {1}".format(bug_dict["bug_id"],
-                                                     bug_dict["summary"]))
+        self.log_debug("Saving bug #%d: %s", bug_dict["bug_id"], bug_dict["summary"])
 
         bug_id = bug_dict["bug_id"]
 
@@ -215,8 +213,7 @@ class Mantis(BugTracker):
             new_bug.resolution = bug_dict["resolution"]
             if bug_dict["resolution"] == "DUPLICATE":
                 if not queries.get_mantis_bug(db, bug_dict["dupe_id"], tracker.id):
-                    self.log_debug("Duplicate #{0} not found".format(
-                        bug_dict["dupe_id"]))
+                    self.log_debug("Duplicate #%d not found", bug_dict["dupe_id"])
 
                     dup = self.download_bug_to_storage(db, bug_dict["dupe_id"])
                     if dup:
@@ -229,8 +226,7 @@ class Mantis(BugTracker):
         # the bug itself might be downloaded during duplicate processing
         # exit in this case - it would cause duplicate database entry
         if queries.get_mantis_bug(db, bug_dict["bug_id"], tracker.id):
-            self.log_debug("Bug #{0} already exists in storage,"
-                           " updating".format(bug_dict["bug_id"]))
+            self.log_debug("Bug #%d already exists in storage, updating", bug_dict["bug_id"])
 
             bugdict = {}
             for col in new_bug.__table__._columns: #pylint: disable=protected-access

--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -22,7 +22,7 @@ import os
 import pwd
 import re
 import tempfile
-from pyfaf.config import config
+from pyfaf.config import config, load_log_config
 
 __all__ = ["FafError",
            "Plugin",
@@ -31,17 +31,25 @@ __all__ = ["FafError",
            "load_plugins",
            "load_plugin_types",
            "log",
+           "thread_logger",
            "get_connect_string",
           ]
 
 RE_PLUGIN_NAME = re.compile(r"^[a-zA-Z0-9\-]+$")
 
 # Initialize common logging
-logging.basicConfig()
+LOG_CONFIG = load_log_config()
+if LOG_CONFIG:
+    logging.config.fileConfig(LOG_CONFIG)
+else:
+    LOGFMT = "[%(asctime)s] %(levelname)s:%(name)s: %(message)s"
+    DATEFMT = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=LOGFMT, datefmt=DATEFMT)
 
 # Invalid name "log" for type constant
 # pylint: disable-msg=C0103
-log = logging.getLogger(name="faf")
+log = logging.getLogger("faf")
+thread_logger = logging.getLogger("faf.thread")
 # pylint: enable-msg=C0103
 
 

--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -37,53 +37,6 @@ __all__ = ["FafError",
 RE_PLUGIN_NAME = re.compile(r"^[a-zA-Z0-9\-]+$")
 
 # Initialize common logging
-
-
-class FafLogger(logging.Logger, object):
-    """
-    Custom logger class with explicitly defined getChildLogger method.
-    We need this because Python 2.6 does not support getChild.
-    """
-
-    def __init__(self, name, level="NOTSET"):
-        super(FafLogger, self).__init__(name, level=level)
-
-        self._children = set()
-
-    def getChildLogger(self, suffix): #pylint: disable=invalid-name
-        """
-        Get a logger which is a descendant to this one.
-
-        This is a convenience method, such that
-
-        logging.getLogger('abc').getChild('def.ghi')
-
-        is the same as
-
-        logging.getLogger('abc.def.ghi')
-
-        It's useful, for example, when the parent logger is named using
-        __name__ rather than a literal string.
-        """
-
-        if self.root is not self:
-            suffix = '.'.join((self.name, suffix))
-
-        result = self.manager.getLogger(suffix)
-        self._children.add(result)
-
-        return result
-
-    def setLevel(self, level):
-        """
-        Sets the level of the current logger and all of its children loggers.
-        """
-
-        self.level = level
-        for child in self._children:
-            child.setLevel(level)
-
-logging.setLoggerClass(FafLogger)
 logging.basicConfig()
 
 # Invalid name "log" for type constant
@@ -297,7 +250,7 @@ class Plugin(object):
                            "in order to implement a plugin.".format(subcls))
 
         # initialize logging by classname
-        self._logger = log.getChildLogger(self.__class__.__name__)
+        self._logger = log.getChild(self.__class__.__name__)
         self.log_debug = self._logger.debug
         self.log_info = self._logger.info
         self.log_warn = self._logger.warn

--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -115,7 +115,7 @@ def import_dir(module, dirname, prefix=None):
             continue
 
 
-def load_plugins(cls, result=None, regexp=RE_PLUGIN_NAME, init=True):
+def load_plugins(cls, result=None, regexp=RE_PLUGIN_NAME, init=True, debug=False):
     """
     Loads plugins (subclasses of `cls`) into `result` dictionary.
     Each plugin must contain a `name` attribute unique among other plugins
@@ -151,7 +151,8 @@ def load_plugins(cls, result=None, regexp=RE_PLUGIN_NAME, init=True):
                       "name.", cls.__name__, plugin.name, classname)
 
         else:
-            log.debug("Registering %s plugin '%s': %s", cls.__name__, plugin.name, classname)
+            if debug:
+                log.debug("Registering %s plugin '%s': %s", cls.__name__, plugin.name, classname)
 
             if init:
                 result[plugin.name] = plugin()

--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -22,7 +22,7 @@ import os
 import pwd
 import re
 import tempfile
-from pyfaf.config import config, load_log_config
+from pyfaf.config import config, configure_logging
 
 __all__ = ["FafError",
            "Plugin",
@@ -38,13 +38,7 @@ __all__ = ["FafError",
 RE_PLUGIN_NAME = re.compile(r"^[a-zA-Z0-9\-]+$")
 
 # Initialize common logging
-LOG_CONFIG = load_log_config()
-if LOG_CONFIG:
-    logging.config.fileConfig(LOG_CONFIG)
-else:
-    LOGFMT = "[%(asctime)s] %(levelname)s:%(name)s: %(message)s"
-    DATEFMT = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=LOGFMT, datefmt=DATEFMT)
+configure_logging()
 
 # Invalid name "log" for type constant
 # pylint: disable-msg=C0103

--- a/src/pyfaf/config.py
+++ b/src/pyfaf/config.py
@@ -19,15 +19,18 @@
 import configparser
 import os
 import logging
+import logging.config
 
 from pyfaf.local import etc, var
 
-__all__ = ["config"]
+__all__ = ["config", "load_log_config"]
 
 MAIN_CONFIG_DIR = os.path.join(etc, "faf")
 MAIN_CONFIG_FILE = "faf.conf"
+MAIN_LOG_CONFIG_FILE = "faf-logging.conf"
 CONFIG_FILE_SUFFIX = ".conf"
 CONFIG_FILE_ENV_VAR = "FAF_CONFIG_FILE"
+CONFIG_LOG_FILE_ENV_VAR = "FAF_LOG_CONFIG_FILE"
 CONFIG_CHILD_SECTIONS = ["main.pluginsdir"]
 
 
@@ -86,6 +89,24 @@ def load_config():
     result = load_config_files(plugin_config_files + main_config_files)
 
     return result
+
+def load_log_config():
+    """
+    Load main config file for logging.
+    """
+    main_log_config_file = None
+    fpath = os.path.join(MAIN_CONFIG_DIR, MAIN_LOG_CONFIG_FILE)
+
+    if CONFIG_LOG_FILE_ENV_VAR in os.environ:
+        fpath = os.environ[CONFIG_LOG_FILE_ENV_VAR]
+
+    if os.access(fpath, os.R_OK):
+        main_log_config_file = fpath
+    else:
+        logging.error("Config file specified by %s environment variable"
+                      " (%s) not found or unreadable", CONFIG_LOG_FILE_ENV_VAR, fpath)
+
+    return main_log_config_file
 
 
 def load_paths(conf):

--- a/src/pyfaf/opsys/centos.py
+++ b/src/pyfaf/opsys/centos.py
@@ -75,7 +75,7 @@ class CentOS(System):
     @classmethod
     def install(cls, db, logger=None):
         if logger is None:
-            logger = log.getChildLogger(cls.__name__)
+            logger = log.getChild(cls.__name__)
 
         logger.info("Adding CentOS")
         new = OpSys()

--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -87,7 +87,7 @@ class Fedora(System):
     @classmethod
     def install(cls, db, logger=None):
         if logger is None:
-            logger = log.getChildLogger(cls.__name__)
+            logger = log.getChild(cls.__name__)
 
         logger.info("Adding Fedora operating system")
         new = OpSys()

--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -466,16 +466,16 @@ class CoredumpProblem(ProblemType):
         return q
 
     def find_packages_for_ssource(self, db, db_ssource):
-        self.log_debug("Build-id: {0}".format(db_ssource.build_id))
+        self.log_debug("Build-id: %d", db_ssource.build_id)
         filename = self._get_file_name_from_build_id(db_ssource.build_id)
-        self.log_debug("File name: {0}".format(filename))
+        self.log_debug("File name: %s", filename)
         db_debug_package = get_package_by_file(db, filename)
         if db_debug_package is None:
             debug_nvra = "Not found"
         else:
             debug_nvra = db_debug_package.nvra()
 
-        self.log_debug("Debug Package: {0}".format(debug_nvra))
+        self.log_debug("Debug Package: %s", debug_nvra)
 
         db_bin_package = None
 
@@ -517,7 +517,7 @@ class CoredumpProblem(ProblemType):
         else:
             bin_nvra = db_bin_package.nvra()
 
-        self.log_debug("Binary Package: {0}".format(bin_nvra))
+        self.log_debug("Binary Package: %s", bin_nvra)
 
         db_src_package = None
 
@@ -530,7 +530,7 @@ class CoredumpProblem(ProblemType):
         else:
             src_nvra = db_src_package.nvra()
 
-        self.log_debug("Source Package: {0}".format(src_nvra))
+        self.log_debug("Source Package: %s", src_nvra)
 
         # indicate incomplete result
         if db_bin_package is None:
@@ -550,10 +550,9 @@ class CoredumpProblem(ProblemType):
             for db_ssource in db_ssources:
                 i += 1
 
-                self.log_debug("[{0} / {1}] Processing '{2}' @ '{3}'"
-                               .format(i, len(db_ssources),
-                                       ssource2funcname(db_ssource),
-                                       db_ssource.path))
+                self.log_debug("[%d / %d] Processing '%s' @ '%s'",
+                               i, len(db_ssources), ssource2funcname(db_ssource),
+                               db_ssource.path)
 
                 norm_path = get_libname(db_ssource.path)
 
@@ -567,8 +566,7 @@ class CoredumpProblem(ProblemType):
                 try:
                     address = get_base_address(binary) + db_ssource.offset
                 except FafError as ex:
-                    self.log_debug("get_base_address failed: {0}"
-                                   .format(str(ex)))
+                    self.log_debug("get_base_address failed: %s", str(ex))
                     db_ssource.retrace_fail_count += 1
                     continue
 
@@ -578,7 +576,7 @@ class CoredumpProblem(ProblemType):
                     results = addr2line(binary, address, debug_path)
                     results.reverse()
                 except Exception as ex: # pylint: disable=broad-except
-                    self.log_debug("addr2line failed: {0}".format(str(ex)))
+                    self.log_debug("addr2line failed: %s", str(ex))
                     db_ssource.retrace_fail_count += 1
                     continue
 
@@ -587,8 +585,7 @@ class CoredumpProblem(ProblemType):
                     inl_id += 1
 
                     funcname, srcfile, srcline = results.pop()
-                    self.log_debug("Unwinding inlined function '{0}'"
-                                   .format(funcname))
+                    self.log_debug("Unwinding inlined function '%s'", funcname)
                     # hack - we have no offset for inlined symbols
                     # let's use minus source line to avoid collisions
                     offset = -srcline
@@ -643,15 +640,14 @@ class CoredumpProblem(ProblemType):
                         db.session.add(db_newframe)
 
                 funcname, srcfile, srcline = results.pop()
-                self.log_debug("Result: {0}".format(funcname))
+                self.log_debug("Result: %s", funcname)
                 db_symbol = get_symbol_by_name_path(db, funcname, norm_path)
                 if db_symbol is None:
                     key = (funcname, norm_path)
                     if key in new_symbols:
                         db_symbol = new_symbols[key]
                     else:
-                        self.log_debug("Creating new symbol '{0}' @ '{1}'"
-                                       .format(funcname, db_ssource.path))
+                        self.log_debug("Creating new symbol '%s' @ '%s'", funcname, db_ssource.path)
                         db_symbol = Symbol()
                         db_symbol.name = funcname
                         db_symbol.normalized_path = norm_path
@@ -667,16 +663,16 @@ class CoredumpProblem(ProblemType):
                 db_ssource.line_number = srcline
 
         if task.debuginfo.unpacked_path is not None:
-            self.log_debug("Removing {0}".format(task.debuginfo.unpacked_path))
+            self.log_debug("Removing %s", task.debuginfo.unpacked_path)
             shutil.rmtree(task.debuginfo.unpacked_path, ignore_errors=True)
 
         if task.source is not None and task.source.unpacked_path is not None:
-            self.log_debug("Removing {0}".format(task.source.unpacked_path))
+            self.log_debug("Removing %s", task.source.unpacked_path)
             shutil.rmtree(task.source.unpacked_path, ignore_errors=True)
 
         for bin_pkg in task.binary_packages.keys():
             if bin_pkg.unpacked_path is not None:
-                self.log_debug("Removing {0}".format(bin_pkg.unpacked_path))
+                self.log_debug("Removing %s", bin_pkg.unpacked_path)
                 shutil.rmtree(bin_pkg.unpacked_path, ignore_errors=True)
 
     def find_crash_function(self, db_backtrace):

--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -169,6 +169,8 @@ class CoredumpProblem(ProblemType):
         return result
 
     def _db_thread_to_satyr(self, db_thread):
+        self.log_debug("Creating threads using satyr")
+
         thread = satyr.GdbThread()
         thread.number = db_thread.number
 

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -121,7 +121,7 @@ class KerneloopsProblem(ProblemType):
     @classmethod
     def install(cls, db, logger=None):
         if logger is None:
-            logger = log.getChildLogger(cls.__name__)
+            logger = log.getChild(cls.__name__)
 
         for flag, (char, nice_name) in cls.tainted_flags.items():
             if get_taint_flag_by_ureport_name(db, flag) is None:

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -310,8 +310,7 @@ class KerneloopsProblem(ProblemType):
 
 
         if dep is None:
-            self.log_debug("Unable to find debuginfo for module '{0}'"
-                           .format(module))
+            self.log_debug("Unable to find debuginfo for module '%s'", module)
             return None
 
         return dep.name
@@ -526,8 +525,8 @@ class KerneloopsProblem(ProblemType):
 
     def find_packages_for_ssource(self, db, db_ssource):
         if db_ssource.build_id is None:
-            self.log_debug("No kernel information for '{0}' @ '{1}'"
-                           .format(db_ssource.symbol.name, db_ssource.path))
+            self.log_debug("No kernel information for '%s' @ '%s'",
+                           db_ssource.symbol.name, db_ssource.path)
             return db_ssource, (None, None, None)
 
         if db_ssource.build_id in self._kernel_pkg_map:
@@ -551,7 +550,7 @@ class KerneloopsProblem(ProblemType):
 
         db_src_pkg = None
         if db_debug_pkg is None:
-            self.log_debug("Package {0} not found in storage".format(nvra))
+            self.log_debug("Package %s not found in storage", nvra)
         elif not self.skipsrc:
             srcname = "kernel-debuginfo-common-{0}".format(arch)
             db_src_pkg = get_package_by_name_build_arch(db, srcname,
@@ -559,8 +558,8 @@ class KerneloopsProblem(ProblemType):
                                                         db_debug_pkg.arch)
 
             if db_src_pkg is None:
-                self.log_debug("Package {0}-{1}-{2}.{3} not found in storage"
-                               .format(srcname, version, release, arch))
+                self.log_debug("Package %s-%s-%s.%s not found in storage",
+                               srcname, version, release, arch)
 
         result = db_debug_pkg, db_debug_pkg, db_src_pkg
         self._kernel_pkg_map[db_ssource.build_id] = result
@@ -599,8 +598,8 @@ class KerneloopsProblem(ProblemType):
                         address += (1 << 64)
                 else:
                     if module not in offset_map:
-                        self.log_debug("Module '{0}' not found in package '{1}'"
-                                       .format(module, task.debuginfo.nvra))
+                        self.log_debug("Module '%s' not found in package '%s'",
+                                       module, task.debuginfo.nvra)
                         db_ssource.retrace_fail_count += 1
                         continue
 
@@ -611,9 +610,8 @@ class KerneloopsProblem(ProblemType):
                         symbol_name = symbol_name.lstrip("_")
 
                     if symbol_name not in module_map:
-                        self.log_debug("Function '{0}' not found in module "
-                                       "'{1}'".format(db_ssource.symbol.name,
-                                                      module))
+                        self.log_debug("Function '%s' not found in module '%s'",
+                                       db_ssource.symbol.name, module)
                         db_ssource.retrace_fail_count += 1
                         continue
 
@@ -633,7 +631,7 @@ class KerneloopsProblem(ProblemType):
                     results = addr2line(abspath, address, debug_dir)
                     results.reverse()
                 except FafError as ex:
-                    self.log_debug("addr2line failed: {0}".format(str(ex)))
+                    self.log_debug("addr2line failed: %s", str(ex))
                     db_ssource.retrace_fail_count += 1
                     continue
 
@@ -642,8 +640,7 @@ class KerneloopsProblem(ProblemType):
                     inl_id += 1
 
                     funcname, srcfile, srcline = results.pop()
-                    self.log_debug("Unwinding inlined function '{0}'"
-                                   .format(funcname))
+                    self.log_debug("Unwinding inlined function '%s'", funcname)
                     # hack - we have no offset for inlined symbols
                     # let's use minus source line to avoid collisions
                     offset = -srcline
@@ -698,15 +695,14 @@ class KerneloopsProblem(ProblemType):
                         db.session.add(db_newframe)
 
                 funcname, srcfile, srcline = results.pop()
-                self.log_debug("Result: {0}".format(funcname))
+                self.log_debug("Result: %s", funcname)
                 db_symbol = get_symbol_by_name_path(db, funcname, module)
                 if db_symbol is None:
                     key = (funcname, module)
                     if key in new_symbols:
                         db_symbol = new_symbols[key]
                     else:
-                        self.log_debug("Creating new symbol '{0}' @ '{1}'"
-                                       .format(funcname, module))
+                        self.log_debug("Creating new symbol '%s' @ '%s'", funcname, module)
                         db_symbol = Symbol()
                         db_symbol.name = funcname
                         db_symbol.normalized_path = module
@@ -722,11 +718,11 @@ class KerneloopsProblem(ProblemType):
                 db_ssource.line_number = srcline
 
         if task.debuginfo is not None:
-            self.log_debug("Removing {0}".format(task.debuginfo.unpacked_path))
+            self.log_debug("Removing %s", task.debuginfo.unpacked_path)
             shutil.rmtree(task.debuginfo.unpacked_path, ignore_errors=True)
 
         if task.source is not None and task.source.unpacked_path is not None:
-            self.log_debug("Removing {0}".format(task.source.unpacked_path))
+            self.log_debug("Removing %s", task.source.unpacked_path)
             shutil.rmtree(task.source.unpacked_path, ignore_errors=True)
 
     def check_btpath_match(self, ureport, parser):

--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -1,6 +1,7 @@
 import re
 import concurrent.futures as futures
-from pyfaf.common import FafError, log
+
+from pyfaf.common import FafError, log, thread_logger
 from pyfaf.queries import get_debug_files
 from pyfaf.rpm import unpack_rpm_to_tmp
 from pyfaf.utils.proc import safe_popen
@@ -107,7 +108,7 @@ class RetracePool:
     def __init__(self, db, tasks, problemplugin, workers):
 
         self.name = "RetracePool"
-        self.log = log.getChild(self.name)
+        self.log = thread_logger.getChild(self.name)
         self.db = db
         self.plugin = problemplugin
         self.tasks = tasks

--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -5,10 +5,10 @@ from pyfaf.queries import get_debug_files
 from pyfaf.rpm import unpack_rpm_to_tmp
 from pyfaf.utils.proc import safe_popen
 
-# Instance of 'RootLogger' has no 'getChildLogger' member
+# Instance of 'RootLogger' has no 'getChild' member
 # Invalid name "log" for type constant
 # pylint: disable-msg=C0103,E1103
-log = log.getChildLogger(__name__)
+log = log.getChild(__name__)
 # pylint: enable-msg=C0103
 
 RE_ADDR2LINE_LINE1 = re.compile(r"^([_0-9a-zA-Z\.~<>@:\*&,\)"
@@ -107,10 +107,7 @@ class RetracePool:
     def __init__(self, db, tasks, problemplugin, workers):
 
         self.name = "RetracePool"
-        # pylint: disable-msg=E1103
-        self.log = log.getChildLogger(self.name)
-        # pylint: enable-msg=E1103
-
+        self.log = log.getChild(self.name)
         self.db = db
         self.plugin = problemplugin
         self.tasks = tasks

--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -122,8 +122,9 @@ class RetracePool:
         Starts the executors job and schedules tasks for workers when they are available.
         """
         taskid = 0
+        name = "Worker"
 
-        with futures.ThreadPoolExecutor(max_workers=self.workers, thread_name_prefix=self.name) as executor:
+        with futures.ThreadPoolExecutor(max_workers=self.workers, thread_name_prefix=name) as executor:
             while self.tasks:
                 taskid += 1
                 task = self.tasks.popleft()

--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -160,19 +160,19 @@ class RetracePool:
         Helper for unpacking a set of packages (debuginfo, source, binary)
         """
 
-        self.log.debug("Unpacking '{0}'".format(task.debuginfo.nvra))
+        self.log.debug("Unpacking '%s'", task.debuginfo.nvra)
         task.debuginfo.unpacked_path = \
             task.debuginfo.unpack_to_tmp(task.debuginfo.path,
                                          prefix=task.debuginfo.nvra)
 
         if task.source is not None:
-            self.log.debug("Unpacking '{0}'".format(task.source.nvra))
+            self.log.debug("Unpacking '%s'", task.source.nvra)
             task.source.unpacked_path = \
                 task.source.unpack_to_tmp(task.source.path,
                                           prefix=task.source.nvra)
 
         for bin_pkg in task.binary_packages.keys():
-            self.log.debug("Unpacking '{0}'".format(bin_pkg.nvra))
+            self.log.debug("Unpacking '%s'", bin_pkg.nvra)
             if bin_pkg.path == task.debuginfo.path:
                 self.log.debug("Already unpacked")
                 continue
@@ -282,7 +282,7 @@ def demangle(mangled):
 
     result = child.stdout.strip()
     if result != mangled:
-        log.debug("Demangled: '{0}' ~> '{1}'".format(mangled, result))
+        log.debug("Demangled: '%s' ~> '%s'", mangled, result)
 
     return result
 

--- a/src/pyfaf/rpm.py
+++ b/src/pyfaf/rpm.py
@@ -27,7 +27,7 @@ from pyfaf.common import FafError, log
 from pyfaf.config import config
 from pyfaf.storage.opsys import PackageDependency
 
-log = log.getChildLogger(__name__)
+log = log.getChild(__name__)
 
 __all__ = ["store_rpm_deps", "unpack_rpm_to_tmp"]
 

--- a/src/pyfaf/rpm.py
+++ b/src/pyfaf/rpm.py
@@ -82,8 +82,7 @@ def store_rpm_deps(db, package, nogpgcheck=False):
         return False
 
     files = header.fiFromHeader()
-    log.debug("{0} contains {1} files".format(package.nvra(),
-                                              len(files)))
+    log.debug("%s contains %d files", package.nvra(), len(files))
 
     # Invalid name for type variable
     # pylint: disable-msg=C0103

--- a/src/pyfaf/storage/events_fedmsg.py
+++ b/src/pyfaf/storage/events_fedmsg.py
@@ -31,7 +31,7 @@ if notify_reports or notify_problems:
     from faf_schema.schema import FafReportMessage, FafProblemMessage
     from pyfaf.utils import web
     from pyfaf.common import log
-    logger = log.getChildLogger(__name__)
+    logger = log.getChild(__name__)
 
     levels = tuple(10**n for n in range(7))
 

--- a/src/pyfaf/ureport.py
+++ b/src/pyfaf/ureport.py
@@ -66,7 +66,7 @@ from pyfaf.storage import (Arch,
                            column_len)
 from pyfaf.ureport_compat import ureport1to2
 
-log = log.getChildLogger(__name__)
+log = log.getChild(__name__)
 
 __all__ = ["get_version", "save", "ureport2",
            "validate", "validate_attachment"]

--- a/src/pyfaf/utils/proc.py
+++ b/src/pyfaf/utils/proc.py
@@ -19,7 +19,7 @@
 import subprocess
 from pyfaf.common import log
 
-log = log.getChildLogger(__name__)
+log = log.getChild(__name__)
 
 __all__ = ["popen", "safe_popen"]
 


### PR DESCRIPTION
I did this mainly because it was not possible to make any changes to format of logging messages without editing the code.
 
___
**Changes**
- Logging configuration from a file (`/etc/faf/faf-logging.conf`)
- Added DATETIME to logging messages:
```
[DATE TIME] LEVEL:NAME: MESSAGE
```
- Added THREADNAME for logging from threads:
```
[DATE TIME] LEVEL:NAME(THREADNAME): MESSAGE
```
- Lazy formatting of debugging logs
- Removed custom logger for Python 2.6
- Get indexes using enumerate in for loops
- Added some debugging messages 
- Compute len of arrays outside of for loops


The old format:
```
LEVEL:NAME: MESSAGE
```


Also see: https://docs.python.org/3/library/logging.html
Related to #806 