### PR TITLE
pyfaf: Don't crash when no action is specified

### DIFF
--- a/src/bin/faf
+++ b/src/bin/faf
@@ -84,6 +84,11 @@ def main():
         print("ABRT Analytics v{}".format(pyfaf.__version__))
         sys.exit(0)
 
+    if not hasattr(cmdline, "func"):
+        log.error("No command specified")
+        cmdline_parser.print_help()
+        sys.exit(1)
+
     # Catching too general exception Exception
     # pylint: disable-msg=W0703
 


### PR DESCRIPTION
Don't crash on a runtime error in case the user calls `faf` with no actions. Instead, output an error and print the help message.