### PR TITLE
webfaf: Fix division by zero in problem detail page

### DIFF
--- a/src/webfaf/problems.py
+++ b/src/webfaf/problems.py
@@ -1,6 +1,8 @@
 import datetime
 from collections import defaultdict
+import logging
 from operator import itemgetter
+import random
 from flask import (Blueprint, render_template, request, abort, url_for,
                    redirect, jsonify, g, flash)
 
@@ -47,6 +49,7 @@ from webfaf.utils import (Pagination, request_wants_json, metric,
                           is_problem_maintainer)
 
 problems = Blueprint("problems", __name__)
+logger = logging.getLogger("webfaf.problems")
 
 
 # pylint: disable=too-many-arguments,dangerous-default-value
@@ -617,28 +620,28 @@ def item(problem_id, component_names=None):
                  .join(Problem)
                  .filter(Problem.id == problem_id)
                  .distinct(ReportHash.hash).all())
-    # Limit to 10 bt_hashes (otherwise the URL can get too long)
-    # Select the 10 hashes uniformly from the entire list to make sure it is a
-    # good representation. (Slicing the 10 first could mean the 10 oldest
-    # are selected which is not a good representation.)
-    k = min(len(bt_hashes), 10)
-    a = 0
-    d = len(bt_hashes)/float(k)
-    bt_hashes_limited = []
-    for _ in range(k):
-        bt_hashes_limited.append("bth=" + bt_hashes[int(a)][0])
-        a += d
-    bt_hash_qs = "&".join(bt_hashes_limited)
 
     forward = {"problem": problem,
                "osreleases": metric(osreleases),
                "arches": metric(arches),
                "exes": metric(exes),
                "package_counts": package_counts,
-               "bt_hash_qs": bt_hash_qs,
                "solutions": solutions,
                "components_form": components_form
               }
+
+    if not bt_hashes:
+        logger.warning("No backtrace hashes found for problem #%d", problem_id)
+    else:
+        # Generate a permalink for this problem. We do this by uniformly picking
+        # (at most) 10 hashes from the list. This ensures the selected hashes are
+        # more or less representative of the problem.
+        k = min(len(bt_hashes), 10)
+        # A hint of determinism in this uncertain world.
+        r = random.Random(problem_id)
+        hashes_sampled = r.sample(bt_hashes, k)
+        permalink_query = "&".join("bth={}".format(bth) for (bth,) in hashes_sampled)
+        forward["permalink_query"] = permalink_query
 
     if request_wants_json():
         return jsonify(forward)

--- a/src/webfaf/templates/problems/item.html
+++ b/src/webfaf/templates/problems/item.html
@@ -19,13 +19,15 @@ Problem #{{ problem.id }} -
 <script src="{{ url_for('static', filename='js/jquery.flot.pie.js')}}"></script>
 <script src="{{ url_for('static', filename='js/jquery.flot.tickrotor.js')}}"></script>
 <script src="{{ url_for('static', filename='js/jquery.flot.time.js')}}"></script>
+{% if permalink_query %}
 <script type="text/javascript">
   $(document).ready(function() {
     try {
-      history.replaceState(null, "", "{{url_for('problems.bthash_permalink')}}?{{ bt_hash_qs|safe }}")
+      history.replaceState(null, "", "{{url_for('problems.bthash_permalink')}}?{{ permalink_query|safe }}")
     } catch(err) {};
   });
 </script>
+{% endif %}
 {% endblock js %}
 
 {% block body %}
@@ -34,15 +36,17 @@ Problem #{{ problem.id }} -
     <div class='col-md-6'>
       <h3>Info</h3>
       <dl class='info dl-horizontal'>
-        <dt><a href="{{url_for('problems.bthash_permalink')}}?{{ bt_hash_qs|safe }}"><span class="glyphicon glyphicon-link"></span> Permalink</a></dt>
-        <dd></dd>
-        {% if extfafs %}
-          <dt>Ext. instances</dt>
-          <dd>
-            {% for extfaf in extfafs %}
-              <a href="{{extfaf.baseurl}}/problems/bthash/?{{ bt_hash_qs|safe }}">{{extfaf.name}}</a>{% if not loop.last %}, {% endif %}
-            {% endfor %}
-          </dd>  
+        {% if permalink_query %}
+          <dt><a href="{{url_for('problems.bthash_permalink')}}?{{ permalink_query|safe }}"><span class="glyphicon glyphicon-link"></span> Permalink</a></dt>
+          <dd></dd>
+          {% if extfafs %}
+            <dt>Ext. instances</dt>
+            <dd>
+              {% for extfaf in extfafs %}
+                <a href="{{extfaf.baseurl}}/problems/bthash/?{{ permalink_query|safe }}">{{extfaf.name}}</a>{% if not loop.last %}, {% endif %}
+              {% endfor %}
+            </dd>
+          {% endif %}
         {% endif %}
         <dt>Function</dt>
         <dd>


### PR DESCRIPTION
* Refactor the algorithm for choosing backtrace hashes for problem permalink to use the standard library.
* Warn if no hashes are found.

Fixes #815