### PR TITLE
assign-r-t-builds: Consider arch when searching for builds

### DIFF
--- a/src/pyfaf/actions/assign_release_to_builds.py
+++ b/src/pyfaf/actions/assign_release_to_builds.py
@@ -17,8 +17,8 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 from pyfaf.actions import Action
-from pyfaf.storage.opsys import (Build, BuildOpSysReleaseArch, OpSys,
-                                 OpSysRelease, Arch)
+from pyfaf.storage.opsys import (Arch, Build, BuildArch, BuildOpSysReleaseArch,
+                                 OpSys, OpSysRelease)
 from pyfaf.opsys import systems
 from pyfaf.queries import get_opsys_by_name, get_osrelease, get_arch_by_name
 
@@ -89,6 +89,8 @@ class AssignReleaseToBuilds(Action):
             self.log_info("Selecting builds by expression: '{0}'"
                           .format(cmdline.expression))
             found_builds = (db.session.query(Build)
+                            .filter(BuildArch.arch_id == arch.id)
+                            .filter(Build.id == BuildArch.build_id)
                             .filter(Build.release.like("%{0}"
                                                        .format(cmdline.expression)))
                             .all())

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -26,6 +26,7 @@ from pyfaf.storage.opsys import (Arch,
                                  OpSysReleaseRepo,
                                  BuildOpSysReleaseArch,
                                  Build,
+                                 BuildArch,
                                  Package,
                                  )
 from pyfaf.storage.debug import InvalidUReport
@@ -451,6 +452,12 @@ class ActionsTestCase(faftests.DatabaseCase):
         build.version = "1.2.3"
         build.release = "20.fc24"
         self.db.session.add(build)
+        self.db.session.flush()
+
+        build_arch = BuildArch(arch_id=self.arch_x86_64.id,
+                               build_id=build.id)
+        self.db.session.add(build_arch)
+        self.db.session.flush()
 
         build = Build()
         build.base_package_name = "build1"
@@ -458,7 +465,12 @@ class ActionsTestCase(faftests.DatabaseCase):
         build.version = "1.2.3"
         build.release = "20.fc23"
         self.db.session.add(build)
+        self.db.session.flush()
 
+        build_arch = BuildArch(arch_id=self.arch_x86_64.id,
+                               build_id=build.id)
+
+        self.db.session.add(build_arch)
         self.db.session.flush()
 
         systems['fedora'].get_released_builds = get_released_builds_mock


### PR DESCRIPTION
Right now the action searches for all builds matching the expression and
assigns those builds to release and arch the user chose.

With this patch the action should search only for builds that are assigned to the
same arch as the one chosen by user.

Little bit more info:
https://github.com/abrt/faf/pull/528

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>