### PR TITLE
assign-r-t-builds: Modify the sql like search statement

### DIFF
--- a/src/pyfaf/actions/assign_release_to_builds.py
+++ b/src/pyfaf/actions/assign_release_to_builds.py
@@ -89,7 +89,7 @@ class AssignReleaseToBuilds(Action):
             self.log_info("Selecting builds by expression: '{0}'"
                           .format(cmdline.expression))
             found_builds = (db.session.query(Build)
-                            .filter(Build.release.like("%{0}"
+                            .filter(Build.release.like("%{0}%"
                                                        .format(cmdline.expression)))
                             .all())
             for build in found_builds:


### PR DESCRIPTION
This should help to find packages like `lxpolkit-0.5.3-2.fc30.6` where release is `fc30.6`.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>