### PR TITLE
Streamline setup of FAF w/ Celery and Redis in containers

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -108,7 +108,33 @@ otherwise an official image can be run with
 
     $ make run
 
+Connection to the database container is already set up in the FAF container in the `PGHOST`, `PGUSER`, `PGPASSWORD`, `PGPORT` and `PGDATABASE` environment variables. Alternatively, it can be set up by editing `/etc/faf/faf.conf` in the FAF container. The database container's IP address can be found by running
+
+    $ docker inspect -f='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' db
+
 FAF should be available at ```http://localhost:8080/faf/```
+
+You can log in to the FAF container by running
+
+    $ make sh
+
+#### Web UI with Celery
+
+Download redis docker image
+
+    $ docker pull redis:latest
+
+Start redis container with hostname and opened port 6379:
+
+    $ docker run --name faf-redis --hostname faf-redis -dit -p 6379:6379 redis
+
+Create faf-network and connect faf and faf-redis containers to it:
+
+    $ docker network create faf-network
+    $ docker network connect faf-network faf
+    $ docker network connect faf-network faf-redis
+
+The message broker and backend used by Celery (Redis, in our case) are already set up in the FAF container in the `RDSBROKER` and `RDSBACKEND` environment variables. Alternatively, they can be set up by editing `/etc/faf/plugins/celery_tasks.conf` in the FAF container, followed by container restart.
 
 ### Reporting into FAF
 1. Set a `URL` to your server in `/etc/libreport/plugins/ureport.conf`

--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -34,6 +34,7 @@ USER 0
 # Update FAF
 RUN rpm -Uvh noarch/faf-* && \
     sed -i -e"s/everyone_is_admin\s*=\s*false/everyone_is_admin = true/i" /etc/faf/plugins/web.conf && \
+    echo 'Defaults    env_keep = "PGHOST PGUSER PGPASSWORD PGPORT PGDATABASE RDSBROKER RDSBACKEND"' >> /etc/sudoers.d/faf && \
     /usr/libexec/fix-permissions /faf && \
     /usr/libexec/fix-permissions /run/faf-celery && \
     /usr/libexec/fix-permissions /var/log/faf && \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -13,10 +13,10 @@ build_db:
 	docker tag postgres-semver abrt/postgres-semver
 
 run:
-	docker run --name faf -dit -e PGHOST=$(DB_IP) -e PGUSER=faf -e PGPASSWORD=scrt -e PGPORT=5432 -e PGDATABASE=faf -p 8080:8080 abrt/faf-image
+	docker run --name faf -dit -e PGHOST=$(DB_IP) -e PGUSER=faf -e PGPASSWORD=scrt -e PGPORT=5432 -e PGDATABASE=faf -e RDSBROKER=redis://faf-redis:6379/0 -e RDSBACKEND=redis://faf-redis:6379/0 -p 8080:8080 abrt/faf-image
 
 run_local:
-	docker run --name faf -dit -e PGHOST=$(DB_IP) -e PGUSER=faf -e PGPASSWORD=scrt -e PGPORT=5432 -e PGDATABASE=faf -p 8080:8080 faf-image-local
+	docker run --name faf -dit -e PGHOST=$(DB_IP) -e PGUSER=faf -e PGPASSWORD=scrt -e PGPORT=5432 -e PGDATABASE=faf -e RDSBROKER=redis://faf-redis:6379/0 -e RDSBACKEND=redis://faf-redis:6379/0 -p 8080:8080 faf-image-local
 
 # When running as docker containers and need persistent storage, do this for the first time
 # mkdir /var/tmp/data

--- a/docker/files/usr/bin/faf-celery-beat
+++ b/docker/files/usr/bin/faf-celery-beat
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+source /etc/faf/celery-beat-env.conf
+
+case $1 in
+start)
+        /usr/bin/python3 -m celery multi start $CELERYD_NODES \
+        -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
+        --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+        $CELERYD_OPTS &
+        ;;
+stop)
+        /usr/bin/python3 -m celery multi stopwait $CELERYD_NODES \
+        --pidfile=${CELERYD_PID_FILE} &
+        ;;
+reload)
+        /usr/bin/python3 -m celery multi restart $CELERYD_NODES \
+        -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
+        --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+        $CELERYD_OPTS &
+        ;;
+esac

--- a/docker/files/usr/bin/faf-celery-worker
+++ b/docker/files/usr/bin/faf-celery-worker
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+source /etc/faf/celery-worker-env.conf
+
+case $1 in
+start)
+        /usr/bin/python3 -m celery multi start $CELERYD_NODES \
+        -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
+        --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+        $CELERYD_OPTS &
+        ;;
+stop)
+        /usr/bin/python3 -m celery multi stopwait $CELERYD_NODES \
+        --pidfile=${CELERYD_PID_FILE} &
+        ;;
+reload)
+        /usr/bin/python3 -m celery multi restart $CELERYD_NODES \
+        -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
+        --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+        $CELERYD_OPTS &
+        ;;
+esac

--- a/docker/files/usr/bin/run_faf
+++ b/docker/files/usr/bin/run_faf
@@ -34,5 +34,8 @@ else
     faf-migrate-db
 fi
 
+/usr/bin/faf-celery-worker start
+/usr/bin/faf-celery-beat start
+
 /usr/sbin/uwsgi --ini /etc/uwsgi.ini --logto /var/log/faf/uwsgi_logs &
 /usr/sbin/httpd -DFOREGROUND

--- a/docker/openshift/faf-template.yml
+++ b/docker/openshift/faf-template.yml
@@ -161,7 +161,7 @@ parameters:
   value: faf-database
 
 - displayName: 'Database Port'
-  description: 'Database port on which the database is running on.'
+  description: 'Port on which the database communicates.'
   name: PG_FAF_PORT
   required: true
   value: '5432'
@@ -171,3 +171,15 @@ parameters:
   name: FAF_VOLUME_CAPACITY
   required: true
   value: '1Gi'
+
+- displayName: 'Redis broker'
+  description: 'Address of the Redis message broker machine, with redis scheme, port number and db number'
+  name: RDS_BROKER
+  required: false
+  value: 'redis://faf-redis:6379/0'
+
+- displayName: 'Redis backend'
+  description: 'Address of the Redis backend, with redis scheme and port number and db number'
+  name: RDS_BACKEND
+  required: false
+  value: 'redis://faf-redis:6379/0'

--- a/docker/openshift/faf-template.yml
+++ b/docker/openshift/faf-template.yml
@@ -105,6 +105,10 @@ objects:
             value: ${PG_FAF_HOST}
           - name: PGPORT
             value: ${PG_FAF_PORT}
+          - name: RDSBROKER
+            value: ${RDS_BROKER}
+          - name: RDSBACKEND
+            value: ${RDS_BACKEND}
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 8080
@@ -161,7 +165,7 @@ parameters:
   value: faf-database
 
 - displayName: 'Database Port'
-  description: 'Port on which the database communicates.'
+  description: 'Database port on which the database is running on.'
   name: PG_FAF_PORT
   required: true
   value: '5432'

--- a/src/pyfaf/celery_tasks/__init__.py
+++ b/src/pyfaf/celery_tasks/__init__.py
@@ -1,18 +1,20 @@
 import datetime
 import logging
+import os
 import munch
 
 from celery import Celery
 from celery.signals import task_postrun
 from pyfaf.actions import actions
 from pyfaf.config import config
+from pyfaf.common import get_env_or_config
 from pyfaf.storage import DatabaseFactory, TaskResult
 from pyfaf.utils.contextmanager import captured_output_combined
 
 
 celery_app = Celery("pyfaf_tasks",
-                    broker=config.get("celery_tasks.broker", ""),
-                    backend=config.get("celery_tasks.backend", ""))
+                    broker=get_env_or_config("celery_tasks.broker", "RDSBROKER", ""),
+                    backend=get_env_or_config("celery_tasks.backend", "RDSBACKEND", ""))
 
 db_factory = DatabaseFactory(autocommit=True)
 

--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -176,7 +176,7 @@ def get_temp_dir(subdir=None):
     return os.path.join(basetmp, userdir, subdir)
 
 
-def _get_env_or_config(conf_s, env_s, default):
+def get_env_or_config(conf_s, env_s, default):
     found = os.environ.get(env_s, None)
     if not found:
         found = config.get(conf_s, None)
@@ -188,8 +188,8 @@ def _get_env_or_config(conf_s, env_s, default):
 def get_connect_string():
     """Create connection string for database from config file."""
     login = ""
-    user = _get_env_or_config("storage.dbuser", "PGUSER", "")
-    passwd = _get_env_or_config("storage.dbpasswd", "PGPASSWORD", "")
+    user = get_env_or_config("storage.dbuser", "PGUSER", "")
+    passwd = get_env_or_config("storage.dbpasswd", "PGPASSWORD", "")
     # password without user does not make sense
     if user:
         if passwd:
@@ -197,8 +197,8 @@ def get_connect_string():
         else:
             login = user
 
-    host = _get_env_or_config("storage.dbhost", "PGHOST", "")
-    port = _get_env_or_config("storage.dbport", "PGPORT", "")
+    host = get_env_or_config("storage.dbhost", "PGHOST", "")
+    port = get_env_or_config("storage.dbport", "PGPORT", "")
     # port without host does not make sense
     if host:
         if port:
@@ -206,7 +206,7 @@ def get_connect_string():
         else:
             login = login + "@" + host
 
-    return "postgresql://" + login + "/" + _get_env_or_config("storage.dbname", "PGDATABASE", "")
+    return "postgresql://" + login + "/" + get_env_or_config("storage.dbname", "PGDATABASE", "")
 
 
 class FafError(Exception):


### PR DESCRIPTION
This PR introduces several changes to reduce the number of steps necessary to set up FAF, with the web UI using Celery and Redis, with three docker containers - for FAF itself, the database with the repo, package and report data, and for Redis which acts as a message broker and backend for Celery. Instructions in HACKING.md are expanded accordingly.
  
Signed-off-by: Michal Fabik <mfabik@redhat.com>