### PR TITLE
pyfaf: Remove version_info checks

### DIFF
--- a/src/pyfaf/checker.py
+++ b/src/pyfaf/checker.py
@@ -17,7 +17,6 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import sys
 from numbers import Integral
 from pyfaf.common import FafError
 
@@ -104,10 +103,7 @@ class StringChecker(Checker):
     """
 
     def __init__(self, pattern=None, maxlen=0, **kwargs):
-        if sys.version_info >= (3, 0):
-            super(StringChecker, self).__init__(str, **kwargs)
-        else:
-            super(StringChecker, self).__init__(basestring, **kwargs) # pylint: disable=undefined-variable
+        super(StringChecker, self).__init__(str, **kwargs)
 
         if pattern is not None:
             self.re = re.compile(pattern)

--- a/src/pyfaf/storage/custom_types.py
+++ b/src/pyfaf/storage/custom_types.py
@@ -17,7 +17,6 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import sys
 from sqlalchemy import func, types
 
 
@@ -55,10 +54,7 @@ class Semver(types.UserDefinedType):
         return func.to_semver(bindvalue, type_=self)
 
     def python_type(self):
-        if sys.version_info >= (3, 0):
-            return str
-        return basestring # pylint: disable=undefined-variable
-
+        return str
 
 # Semver 1.0.0
 semver_valid = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"


### PR DESCRIPTION
No need to check for this. We removed Python2 support in the past.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>