### PR TITLE
Remove try-except ImportError of Python modules

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -37,7 +37,6 @@ BuildRequires: python3
 BuildRequires: python3-devel
 BuildRequires: python3-alembic
 BuildRequires: python3-setuptools
-BuildRequires: python3-unittest2
 BuildRequires: python3-bugzilla >= 2.0
 BuildRequires: python3-psycopg2
 BuildRequires: python3-testing.postgresql < 1.2

--- a/src/pyfaf/actions/shell.py
+++ b/src/pyfaf/actions/shell.py
@@ -26,11 +26,7 @@
 # Wildcard import
 # pylint: disable-msg=W0401
 
-try:
-    from collections import Iterable
-except ImportError:
-    from collections.abc import Iterable
-
+from collections.abc import Iterable
 from sqlalchemy.sql.expression import func
 
 import pyfaf

--- a/src/pyfaf/solutionfinders/__init__.py
+++ b/src/pyfaf/solutionfinders/__init__.py
@@ -17,10 +17,7 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-try:
-    from html import escape
-except ImportError:
-    from cgi import escape # Python2 does not have html
+from html import escape
 from pyfaf.common import FafError, Plugin, import_dir, load_plugins
 from pyfaf.storage import Report, getDatabase
 from pyfaf.ureport import ureport2, validate

--- a/tests/faftests/__init__.py
+++ b/tests/faftests/__init__.py
@@ -3,10 +3,7 @@ import sys
 import json
 import shutil
 import datetime
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import psycopg2
 import testing.postgresql

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 import json
 from datetime import datetime, timedelta

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 
 import faftests

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 import datetime
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 
 import faftests

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 
 import faftests

--- a/tests/test_create_problems.py
+++ b/tests/test_create_problems.py
@@ -1,10 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
+import unittest
 import logging
 import datetime
 import random

--- a/tests/test_dnf.py
+++ b/tests/test_dnf.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import os
 import glob
 import shutil

--- a/tests/test_find_report_solution.py
+++ b/tests/test_find_report_solution.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 
 import faftests

--- a/tests/test_mark_probably_fixed.py
+++ b/tests/test_mark_probably_fixed.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 import faftests
 import json

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 
 import faftests

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 
 import faftests

--- a/tests/test_retrace.py
+++ b/tests/test_retrace.py
@@ -2,10 +2,7 @@
 # -*- encoding: utf-8 -*-
 import os
 import logging
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import faftests
 from pyfaf.common import FafError

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import glob
 import logging
 

--- a/tests/test_rpm_metadata.py
+++ b/tests/test_rpm_metadata.py
@@ -2,10 +2,7 @@
 # -*- encoding: utf-8 -*-
 # vim: set makeprg=python3-flake8\ %
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import os
 import glob
 import time

--- a/tests/test_save_reports.py
+++ b/tests/test_save_reports.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 import json
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -3,10 +3,7 @@
 from __future__ import unicode_literals
 
 import logging
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import faftests
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,10 +1,7 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
 import os
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 import datetime
 

--- a/tests/test_ureport.py
+++ b/tests/test_ureport.py
@@ -3,10 +3,7 @@
 import json
 import datetime
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 import logging
 
 import faftests

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,10 +2,7 @@
 # -*- encoding: utf-8 -*-
 import logging
 import datetime
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import faftests
 

--- a/tests/test_webfaf/test_problems.py
+++ b/tests/test_webfaf/test_problems.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 from webfaftests import WebfafTestCase
 
 from pyfaf.storage.opsys import Build, Package

--- a/tests/test_webfaf/test_reports.py
+++ b/tests/test_webfaf/test_reports.py
@@ -2,10 +2,7 @@
 # -*- encoding: utf-8 -*-
 import os
 import json
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import sys
 from io import BytesIO as StringIO

--- a/tests/test_webfaf/test_summary.py
+++ b/tests/test_webfaf/test_summary.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 from webfaftests import WebfafTestCase
 
 

--- a/tests/test_webfaf/test_user.py
+++ b/tests/test_webfaf/test_user.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 # -*- encoding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from flask import json
 from webfaftests import WebfafTestCase


### PR DESCRIPTION
- unittest2 is backport of features from Python2.7/Python3.3 to Python2.4+/Python3.0+.
- In Python3.3 Iterable was moved to collections.abc.
- html is new in Python since 3.2.