### PR TITLE
Rename the pyfaf.rpm module

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -653,7 +653,7 @@ fi
 %{python3_sitelib}/pyfaf/config.py
 %{python3_sitelib}/pyfaf/local.py
 %{python3_sitelib}/pyfaf/retrace.py
-%{python3_sitelib}/pyfaf/rpm.py
+%{python3_sitelib}/pyfaf/faf_rpm.py
 %{python3_sitelib}/pyfaf/queries.py
 %{python3_sitelib}/pyfaf/ureport.py
 %{python3_sitelib}/pyfaf/ureport_compat.py
@@ -664,7 +664,7 @@ fi
 %{python3_sitelib}/pyfaf/__pycache__/config.*.pyc
 %{python3_sitelib}/pyfaf/__pycache__/local.*.pyc
 %{python3_sitelib}/pyfaf/__pycache__/retrace.*.pyc
-%{python3_sitelib}/pyfaf/__pycache__/rpm.*.pyc
+%{python3_sitelib}/pyfaf/__pycache__/faf_rpm.*.pyc
 %{python3_sitelib}/pyfaf/__pycache__/queries.*.pyc
 %{python3_sitelib}/pyfaf/__pycache__/ureport.*.pyc
 %{python3_sitelib}/pyfaf/__pycache__/ureport_compat.*.pyc

--- a/src/pyfaf/Makefile.am
+++ b/src/pyfaf/Makefile.am
@@ -17,7 +17,7 @@ pyfaf_PYTHON = \
     config.py \
     local.py \
     retrace.py \
-    rpm.py \
+    faf_rpm.py \
     queries.py \
     ureport.py \
     ureport_compat.py

--- a/src/pyfaf/__init__.py.in
+++ b/src/pyfaf/__init__.py.in
@@ -17,7 +17,7 @@
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
 __all__ = ["checker", "cmdline", "common", "config", "local",
-           "queries", "retrace", "rpm", "ureport", "utils", "actions",
+           "queries", "retrace", "faf_rpm", "ureport", "utils", "actions",
            "bugtrackers", "opsys", "problemtypes", "repos"]
 __version__ = "@fafversion@"
 
@@ -38,7 +38,7 @@ except:
     retrace = None
     # pylint: enable-msg=C0103
 # pylint: enable-msg=W0702
-from . import rpm
+from . import faf_rpm
 from . import ureport
 from . import utils
 

--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -19,7 +19,7 @@
 import itertools
 import urllib
 
-from pyfaf.rpm import store_rpm_deps
+from pyfaf.faf_rpm import store_rpm_deps
 from pyfaf.repos import repo_types
 from pyfaf.actions import Action
 from pyfaf.storage.opsys import (Repo, Build, BuildArch, Package, OpSys,

--- a/src/pyfaf/faf_rpm.py
+++ b/src/pyfaf/faf_rpm.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-
 import os
 import shutil
 import tempfile

--- a/src/pyfaf/retrace.py
+++ b/src/pyfaf/retrace.py
@@ -3,7 +3,7 @@ from concurrent import futures
 
 from pyfaf.common import FafError, log, thread_logger
 from pyfaf.queries import get_debug_files
-from pyfaf.rpm import unpack_rpm_to_tmp
+from pyfaf.faf_rpm import unpack_rpm_to_tmp
 from pyfaf.utils.proc import safe_popen
 
 # Instance of 'RootLogger' has no 'getChild' member

--- a/src/pyfaf/storage/fixtures/__init__.py
+++ b/src/pyfaf/storage/fixtures/__init__.py
@@ -28,7 +28,7 @@ from datetime import datetime, timedelta
 
 import pyfaf
 from pyfaf.config import config
-from pyfaf.rpm import store_rpm_deps
+from pyfaf.faf_rpm import store_rpm_deps
 
 from pyfaf.storage.opsys import (Arch,
                                  OpSys,

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -7,7 +7,7 @@ import logging
 import faftests
 
 from pyfaf.storage.opsys import Arch, Build, Package, PackageDependency
-from pyfaf.rpm import store_rpm_deps
+from pyfaf.faf_rpm import store_rpm_deps
 
 
 class RpmTestCase(faftests.DatabaseCase):


### PR DESCRIPTION
There was a name ambiguity between the `pyfaf.rpm` module and the python3 built-in `rpm` causing pylint `W0406: Module import itself (import-self)`.

Signed-off-by: Michal Fabik <mfabik@redhat.com>