### PR TITLE
Whitelist C extensions in pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -21,6 +21,8 @@ persistent=yes
 # usually to register additional checkers.
 load-plugins=
 
+# A comma-separated list of package or module names from where C extensions may be loaded. Extensions are loading into the active Python interpreter and may run arbitrary code.
+extension-pkg-whitelist=satyr,rpm,pycurl
 
 [MESSAGES CONTROL]
 


### PR DESCRIPTION
Add a `pylintrc` directive to avoid pyilnt `E1101: Module '%s' has no '%s' member (no-member)` in Fedora 31 builds.

Signed-off-by: Michal Fabik <mfabik@redhat.com>