### PR TITLE
faf_rpm: Use Popen instead of safe_popen

### DIFF
--- a/src/pyfaf/faf_rpm.py
+++ b/src/pyfaf/faf_rpm.py
@@ -148,7 +148,7 @@ def unpack_rpm_to_tmp(path, prefix="faf"):
         os.makedirs(os.path.join(result, "usr", dirname))
         os.symlink(os.path.join("usr", dirname), os.path.join(result, dirname))
 
-    rpm2cpio = safe_popen("rpm2cpio", path)
+    rpm2cpio = Popen(["rpm2cpio", path], stdout=PIPE, stderr=PIPE)
     cpio = Popen(["cpio", "-id", "--quiet"], stdin=rpm2cpio.stdout, stderr=PIPE, cwd=result)
 
     rpm2cpio.stdout.close()


### PR DESCRIPTION
safe_popen uses popen function that returns result of communicate() (which is bytes/str) instead of
stdout stream.

close() call then fails because bytes/str has no `close` member.

Introduced in 490c147

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>