### PR TITLE
retrace: Fix enumerate unpacking

### DIFF
--- a/src/pyfaf/actions/retrace.py
+++ b/src/pyfaf/actions/retrace.py
@@ -104,7 +104,7 @@ class Retrace(Action):
 
             tasks = collections.deque()
 
-            for i, db_debug_pkg, (db_src_pkg, binpkgmap) in enumerate(pkgmap.items(), start=1):
+            for i, (db_debug_pkg, (db_src_pkg, binpkgmap)) in enumerate(pkgmap.items(), start=1):
                 self.log_debug("[%d / %d] Creating task for '%s'", i, len(pkgmap), db_debug_pkg.nvra())
 
                 try:


### PR DESCRIPTION
Introduced in 90f92ce0524da472405a7eb19e8bbefe7b4133f9

Caused a "ValueError: need more than 2 values to unpack"

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>