### PR TITLE
save-reports: Defer reports on PermissionError

### DIFF
--- a/src/pyfaf/actions/save_reports.py
+++ b/src/pyfaf/actions/save_reports.py
@@ -184,7 +184,7 @@ class SaveReports(Action):
             try:
                 save(db, ureport, create_component=self.create_components,
                      timestamp=timestamp)
-            except FafError as ex:
+            except (FafError, PermissionError) as ex:
                 self.log_warn("Failed to save uReport: {0}".format(str(ex)))
                 self._move_report_to_deferred(fname)
                 continue
@@ -293,7 +293,7 @@ class SaveReports(Action):
             try:
                 save(db, ureport, create_component=self.create_components,
                      timestamp=timestamp, count=len(unique["filenames"]))
-            except FafError as ex:
+            except (FafError, PermissionError) as ex:
                 self.log_warn("Failed to save uReport: {0}".format(str(ex)))
                 self._move_reports_to_deferred(unique["filenames"])
                 continue


### PR DESCRIPTION
It might happen that the user running the action may not have permission to write LOB, for instance, in which case Python throws an exception. This shouldn't crash the process but rather defer the report for later processing.