### PR TITLE
Web UI cosmetic tweaks

### DIFF
--- a/src/webfaf/static/css/style.css
+++ b/src/webfaf/static/css/style.css
@@ -1440,7 +1440,7 @@ td > div.progress {
   margin-bottom: 0;
 }
 
-tr.stripe {
+tr.odd, tr.stripe {
   background-color: #f5f5f5;
 }
 

--- a/src/webfaf/static/js/custom.js
+++ b/src/webfaf/static/js/custom.js
@@ -82,13 +82,24 @@ $(document).ready(function() {
     $('.btn-more').click(function() {
       $(this).parents('table').find('tr.package.hide').removeClass('hide');
       $(this).parents('tr').remove();
+      return false;
     });
 
-    $('.btn-show-versions').click(function() {
-      $(this).parents('table').find('.btn-more').click();
-      $(this).parents('table').find('tr.version.hide').removeClass('hide');
-      $(this).parents('table').find('tr.package').addClass('stripe');
-      $(this).parents('table').data('showVersions', 1);
+    $('.btn-toggle-versions').click(function() {
+      const $parentTable = $(this).parents('table').first();
+
+      if ($parentTable.data('versionsShown')) {
+        $parentTable.find('tr.version').addClass('hide');
+        $parentTable.find('tr.package').removeClass('stripe');
+        $(this).text('Show versions');
+        $parentTable.data('versionsShown', 0);
+      } else {
+        $parentTable.find('.btn-more').click();
+        $parentTable.find('tr.version').removeClass('hide');
+        $parentTable.find('tr.package').addClass('stripe');
+        $(this).text('Hide versions');
+        $parentTable.data('versionsShown', 1);
+      }
     });
 
     function sort_table($table, col) {

--- a/src/webfaf/templates/_helpers.html
+++ b/src/webfaf/templates/_helpers.html
@@ -75,8 +75,8 @@
         </tr>
         {% for version, cnt in versions %}
           <tr class="version hide">
-            <td>&nbsp;&nbsp;{{version}}</td>
-            <td>{{ cnt|readable_int }}</td>
+            <td>&ensp;{{version}}</td>
+            <td class="cell-count">{{ cnt|readable_int }}</td>
           </tr>
         {% endfor %}
         {% if data|length > row_limit+1 and loop.index == row_limit %}

--- a/src/webfaf/templates/_helpers.html
+++ b/src/webfaf/templates/_helpers.html
@@ -8,16 +8,21 @@
       </tr>
     </thead>
     {% for row, cnt in data %}
-      <tr class="package {%- if loop.index > row_limit and data|length > row_limit+1 %} hide {%- endif %}">
+      {% set row_class = "package" %}
+      {% if loop.index is odd %}
+        {% set row_class = row_class + " odd" %}
+      {% endif %}
+      {% if loop.index > row_limit and data|length > row_limit + 1 %}
+        {% set row_class = row_class + " hide" %}
+      {% endif %}
+      <tr class="{{ row_class }}">
         <td>{{ row }}</td>
         <td class="cell-count">{{ cnt|readable_int }}</td>
       </tr>
       {% if data|length > row_limit+1 and loop.index == row_limit %}
         <tr>
-          <td colspan='2'>
-            <button class="btn btn-default btn-xs btn-more" type="button">
-              + {{ data|length-row_limit }} more
-            </button>
+          <td colspan="2" class="text-center">
+            <a href="#" class="btn-more">Show more… ({{ data|length - row_limit }})</a>
           </td>
         </tr>
       {% endif %}
@@ -43,10 +48,8 @@
       </tr>
       {% if data|length > row_limit+1 and loop.index == row_limit %}
         <tr>
-          <td colspan='2'>
-            <button class="btn btn-default btn-xs btn-more" type="button">
-              + {{ data|length-row_limit }} more
-            </button>
+          <td colspan="2" class="text-center">
+            <a href="#" class="btn-more">Show more… ({{ data|length - row_limit }})</a>
           </td>
         </tr>
       {% endif %}
@@ -57,10 +60,10 @@
 
 {% macro package_counts_table(data, row_limit=3) -%}
 {% if data %}
-  <table class="table table-bordered counts-table table-condensed" data-sort-col="2" data-sort-order="desc" data-show-versions="0">
+  <table class="table table-bordered counts-table table-condensed" data-sort-col="2" data-sort-order="desc" data-versions-shown="0">
     <thead>
       <tr class="stripe">
-        <th colspan="2" class="text-right"><button class="btn btn-default btn-xs btn-show-versions">Show versions</button></th>
+        <th colspan="2" class="text-right"><button class="btn btn-default btn-xs btn-toggle-versions">Show versions</button></th>
       </tr>
       <tr class="stripe">
         <th><a href="#" class="btn-sort-packages">Related packages</a> <i class="sort-indicator sort-1-desc hide fa fa-sort-alpha-desc"></i><i class="sort-indicator sort-1-asc hide fa fa-sort-alpha-asc"></i></th>
@@ -69,7 +72,14 @@
     </thead>
     <tbody>
       {% for name, cnt, versions in data %}
-        <tr class="package {%- if loop.index > row_limit and data|length > row_limit+1 %} hide {%- endif %} {%- if loop.index % 2 == 0 %} stripe {%- endif %}">
+        {% set row_class = "package" %}
+        {% if loop.index is odd %}
+          {% set row_class = row_class + " odd" %}
+        {% endif %}
+        {% if loop.index > row_limit and data|length > row_limit + 1 %}
+          {% set row_class = row_class + " hide" %}
+        {% endif %}
+        <tr class="{{ row_class }}">
           <td>{{ name }}</td>
           <td class="cell-count">{{ cnt|readable_int }}</td>
         </tr>
@@ -81,10 +91,8 @@
         {% endfor %}
         {% if data|length > row_limit+1 and loop.index == row_limit %}
           <tr>
-            <td colspan='2'>
-              <button class="btn btn-default btn-xs btn-more" type="button">
-                + {{ data|length-row_limit }} more
-              </button>
+            <td colspan="2" class="text-center">
+              <a href="#" class="btn-more">Show more… ({{ data|length - row_limit }})</a>
             </td>
           </tr>
         {% endif %}

--- a/src/webfaf/templates/stats/by_date.html
+++ b/src/webfaf/templates/stats/by_date.html
@@ -24,7 +24,11 @@
         <dt>To date:</dt>
         <dd> {{ to }} </dd>
         <dt>Reports:</dt>
-        <dd> {{ total|default("No reports", boolean=True) }} </dd>
+        {% if total %}
+          <dd>{{ total|readable_int }}</dd>
+        {% else %}
+          <dd>No reports</dd>
+        {% endif %}
       </dl>
     </p>
 
@@ -35,9 +39,9 @@
           <h3>{{ release.release }}</h3>
           <dl class='dl-horizontal'>
             <dt>Reports:</dt>
-            <dd>{{ release.sum }} ({{ release.percentage }}%)</dd>
+            <dd>{{ release.sum|readable_int }} ({{ release.percentage }}%)</dd>
             <dt>Components:</dt>
-            <dd>{{ release.comps|length }}</dd>
+            <dd>{{ release.comps|length|readable_int }}</dd>
           </dl>
         </div>
         <div class='col-md-5'>
@@ -52,7 +56,7 @@
             {% for comp, count, percentage in release.comps %}
               <tr>
                 <td>{{ comp }}</td>
-                <td>{{ count }}</td>
+                <td class="cell-count">{{ count|readable_int }}</td>
                 <td>
                 <div class="progress progress-info progress-striped">
                   <div class="progress-bar" role="progressbar"

--- a/src/webfaf/templates/stats/by_date.html
+++ b/src/webfaf/templates/stats/by_date.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set row_limit = 10 %}
 
 {% block title %}Statistics{% endblock %}
 
@@ -54,7 +55,11 @@
               </tr>
             </thead>
             {% for comp, count, percentage in release.comps %}
-              <tr>
+              {% if loop.index > row_limit and release.comps|length > row_limit + 1 %}
+                <tr class="package hide">
+              {% else %}
+                <tr class="package">
+              {% endif %}
                 <td>{{ comp }}</td>
                 <td class="cell-count">{{ count|readable_int }}</td>
                 <td>
@@ -65,6 +70,13 @@
                 </div>
                 </td>
               </tr>
+              {% if loop.index == row_limit and release.comps|length > row_limit + 1 %}
+                <tr>
+                  <td colspan="3" class="text-center">
+                    <a href="#" class="btn-more">Show more… ({{ release.comps|length - row_limit }})</a>
+                  </td>
+                </tr>
+              {% endif %}
             {% endfor %}
           </table>
         </div>


### PR DESCRIPTION
Summary of changes:

* Change _Show more_ button into a link to reduce visual clutter.
* Allow toggling between shown and hidden component versions in report and problem pages. (It was only possible to show them but not hide them again before.)
* Only show the top ten crashing components of a given opsys release in the stats page with the option to show the rest on request.

Stats page before:
![Screenshot_2019-11-27 ABRT Analytics - Statistics(2)](https://user-images.githubusercontent.com/134321/69728592-03985b00-1125-11ea-87f0-772996ed3f6d.png)

Stats page after:
![Screenshot_2019-11-27 ABRT Analytics - Statistics](https://user-images.githubusercontent.com/134321/69728167-3f7ef080-1124-11ea-9a07-9ad55d2c9844.png)

