### PR TITLE
Add bash autocompletion for faf

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -22,6 +22,7 @@ Requires: python3-psycopg2
 Requires: python3-sqlalchemy
 Requires: python3-rpm
 Requires: python3-pycurl
+Requires: python3-argcomplete
 
 BuildRequires: autoconf
 BuildRequires: intltool
@@ -48,8 +49,8 @@ BuildRequires: python3-fedora-messaging
 BuildRequires: python3-pycurl
 BuildRequires: python3-celery >= 3.1
 BuildRequires: python3-dnf
-
 BuildRequires: python3-zeep
+BuildRequires: python3-argcomplete
 
 %if 0%{?fedora}
 BuildRequires: python3-pylint
@@ -621,6 +622,7 @@ fi
 %config(noreplace) %{_sysconfdir}/faf/faf.conf
 %config(noreplace) %{_sysconfdir}/faf/faf-logging.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/faf
+%config(noreplace) %{_sysconfdir}/bash_completion.d/faf.bash_completion
 
 # /var/spool
 %dir %attr(0775, faf, faf) %{_localstatedir}/spool/faf
@@ -1158,6 +1160,7 @@ fi
 %{python3_sitelib}/webfaf/templates/celery_tasks/schedule_item.html
 
 %files migrations
+%config(noreplace) %{_sysconfdir}/bash_completion.d/faf-migrate-db.bash_completion
 %dir %{python3_sitelib}/pyfaf/storage/migrations
 %dir %{python3_sitelib}/pyfaf/storage/migrations/__pycache__
 %dir %{python3_sitelib}/pyfaf/storage/migrations/versions

--- a/src/bin/Makefile.am
+++ b/src/bin/Makefile.am
@@ -1,3 +1,9 @@
 bin_SCRIPTS = faf faf-migrate-db
 
+bashcompdir = $(sysconfdir)/bash_completion.d
+
+dist_bashcomp_DATA = \
+    faf.bash_completion \
+    faf-migrate-db.bash_completion
+
 EXTRA_DIST = $(bin_SCRIPTS)

--- a/src/bin/faf
+++ b/src/bin/faf
@@ -21,6 +21,7 @@
 import os
 import re
 import sys
+from argcomplete import autocomplete
 
 
 # Re-execute self with LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$FAF_LD_LIBRARY_PATH
@@ -77,6 +78,7 @@ def main():
                                    prog=sys.argv[0])
     cmdline_parser.add_argument("-V", "--version", action="store_true",
                                 help="show version information and exit")
+    autocomplete(cmdline_parser)
     cmdline = cmdline_parser.parse_args()
 
     # print version and quit

--- a/src/bin/faf-migrate-db
+++ b/src/bin/faf-migrate-db
@@ -24,6 +24,7 @@ import argparse
 import logging
 from alembic.config import Config
 from alembic import command
+from argcomplete import autocomplete
 from pyfaf.common import get_connect_string
 from pyfaf.storage import getDatabase, GenericTable, migrations
 
@@ -46,6 +47,7 @@ parser.add_argument("--sql", action="store_true",
 parser.add_argument("--downgrade",
                     help="Downgrade to a previous version.")
 
+autocomplete(parser)
 args = parser.parse_args()
 
 logging.basicConfig()

--- a/src/bin/faf-migrate-db.bash_completion
+++ b/src/bin/faf-migrate-db.bash_completion
@@ -1,0 +1,1 @@
+eval "$(register-python-argcomplete faf-migrate-db)"

--- a/src/bin/faf.bash_completion
+++ b/src/bin/faf.bash_completion
@@ -1,0 +1,1 @@
+eval "$(register-python-argcomplete faf)"


### PR DESCRIPTION
You won't have to remember all the commands from now on or type --help
to run faf commands.*

Unfortunately the autocompletion isn't lightning fast.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>