### PR TITLE
c2p: Find binary packages by build id

### DIFF
--- a/src/pyfaf/actions/c2p.py
+++ b/src/pyfaf/actions/c2p.py
@@ -52,9 +52,11 @@ class Coredump2Packages(Action):
                      "kernel-debug", "kernel-debug-debuginfo", "kernel-lpae"]
 
 
-    def _build_id_to_debug_file(self, build_id):
-        return "/usr/lib/debug/.build-id/{0}/{1}.debug".format(build_id[:2],
-                                                               build_id[2:])
+    def _build_id_to_debug_files(self, build_id):
+        return ["/usr/lib/debug/.build-id/{0}/{1}.debug".format(build_id[:2],
+                                                                build_id[2:]),
+                "/usr/lib/.build-id/{0}/{1}".format(build_id[:2], build_id[2:])]
+
 
     def _unstrip(self, cmdline):
         build_ids = []
@@ -110,8 +112,8 @@ class Coredump2Packages(Action):
         build_id_maps = {}
         debuginfos = {}
         for build_id, soname in build_ids:
-            debug_file = self._build_id_to_debug_file(build_id)
-            db_packages = get_packages_by_file(db, debug_file)
+            files = self._build_id_to_debug_files(build_id)
+            db_packages = get_packages_by_file(db, files)
             db_packages = [p for p in db_packages if p.has_lob("package")]
             if not db_packages:
                 self.log_warn("No debuginfo found for '{0}' ({1})"

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -502,7 +502,7 @@ def get_package_by_file(db, filename):
             .first())
 
 
-def get_packages_by_file(db, filename):
+def get_packages_by_file(db, filenames):
     """
     Return a list of pyfaf.storage.Package objects
     providing the file named `filename`.
@@ -510,7 +510,7 @@ def get_packages_by_file(db, filename):
 
     return (db.session.query(st.Package)
             .join(st.PackageDependency)
-            .filter(st.PackageDependency.name == filename)
+            .filter(st.PackageDependency.name.in_(filenames))
             .filter(st.PackageDependency.type == "PROVIDES")
             .all())
 


### PR DESCRIPTION
Fix `c2p`'s failure to find binary packages by build id (`/usr/lib/.build-id/12/34567890abcdef1234567890abcdef`). Affects retrace using FAF repos.

Signed-off-by: Michal Fabik <mfabik@redhat.com>