### PR TITLE
ureport_compat: Fix encoding during ureport1to2

### DIFF
--- a/src/pyfaf/ureport_compat.py
+++ b/src/pyfaf/ureport_compat.py
@@ -190,7 +190,7 @@ def ureport1to2(ureport1):
                             ureport2["problem"]["version"] = frame["buildid"]
                             break
 
-                koops = satyr.Kerneloops(ureport1["oops"].encode("utf-8"))
+                koops = satyr.Kerneloops(ureport1["oops"])
 
                 ureport2["problem"]["modules"] = koops.modules
 


### PR DESCRIPTION
I've run into this problem where ureport1 kerneloops would crash the
save-reports action during conversion from ureport1 to ureport2.

`TypeError: argument 1 must be str, not bytes`

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>