### PR TITLE
Only set up logging when __name__ == __main__

### DIFF
--- a/src/bin/faf
+++ b/src/bin/faf
@@ -56,18 +56,18 @@ def fix_ld_library_path():
 
 fix_ld_library_path()
 
-# pylint: disable=wrong-import-position
-import pyfaf
-from pyfaf.cmdline import CmdlineParser
-from pyfaf.config import config
-from pyfaf.common import Plugin, log, load_plugins
-from pyfaf.storage import getDatabase
-from pyfaf.utils.parse import str2bool
-
 NAME_PARSER = re.compile(r"^faf-([^{0}]+)$".format(os.sep))
 
 
 def main():
+    # pylint: disable=wrong-import-position
+    import pyfaf
+    from pyfaf.cmdline import CmdlineParser
+    from pyfaf.config import config
+    from pyfaf.common import Plugin, log, load_plugins
+    from pyfaf.storage import getDatabase
+    from pyfaf.utils.parse import str2bool
+
     name_match = NAME_PARSER.match(os.path.basename(sys.argv[0]))
     if name_match is not None:
         sys.argv[0] = os.path.join(os.path.dirname(sys.argv[0]), "faf")
@@ -149,4 +149,6 @@ def main():
         sys.exit(1)
 
 if __name__ == "__main__":
+    from pyfaf.config import configure_logging
+    configure_logging()
     main()

--- a/src/bin/faf-migrate-db
+++ b/src/bin/faf-migrate-db
@@ -21,10 +21,14 @@
 import inspect
 import os
 import argparse
-import logging
 from alembic.config import Config
 from alembic import command
 from argcomplete import autocomplete
+
+from pyfaf.config import configure_logging
+configure_logging()
+
+# pylint: disable=wrong-import-position
 from pyfaf.common import get_connect_string
 from pyfaf.storage import getDatabase, GenericTable, migrations
 
@@ -50,7 +54,6 @@ parser.add_argument("--downgrade",
 autocomplete(parser)
 args = parser.parse_args()
 
-logging.basicConfig()
 alembic_cfg = Config()
 alembic_cfg.set_main_option("script_location",
                             os.path.dirname(inspect.getfile(migrations)))

--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -22,7 +22,7 @@ import os
 import pwd
 import re
 import tempfile
-from pyfaf.config import config, configure_logging
+from pyfaf.config import config
 
 __all__ = ["FafError",
            "Plugin",
@@ -36,9 +36,6 @@ __all__ = ["FafError",
           ]
 
 RE_PLUGIN_NAME = re.compile(r"^[a-zA-Z0-9\-]+$")
-
-# Initialize common logging
-configure_logging()
 
 # Invalid name "log" for type constant
 # pylint: disable-msg=C0103

--- a/src/webfaf/webfaf_main.py
+++ b/src/webfaf/webfaf_main.py
@@ -221,5 +221,8 @@ def panic(_):
 
 
 if __name__ == '__main__':
+    from pyfaf.config import configure_logging
+    configure_logging()
+
     import_blueprint_plugins(app)
     app.run()


### PR DESCRIPTION
This avoids unpleasant surprises when some unrelated Python code
(say, retrace-server) sets up loggers of its own.

https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig

disable_existing_loggers defaults to True and results in rather
self-explanatory behavior: any loggers set up prior to importing
pyfaf.common will no longer output anything.