### PR TITLE
Create-problems speed-up

### DIFF
--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -100,9 +100,7 @@ class CreateProblems(Action):
 
             # Assign clusters to not yet processed threads
             if 1 <= len(detached_threads) <= max_cluster_size:
-                for thread in detached_threads:
-                    thread_map[thread] = detached_threads
-
+                thread_map.update({thread: detached_threads for thread in detached_threads})
                 thread_sets.add(detached_threads)
 
             # Biggest thread sets last
@@ -127,8 +125,7 @@ class CreateProblems(Action):
                 cluster = new_cluster
 
             # Save results for the last cluster
-            for thread in cluster:
-                thread_map[thread] = cluster
+            thread_map.update({thread: cluster for thread in cluster})
 
         return thread_map
 

--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -303,7 +303,7 @@ class CreateProblems(Action):
                     _satyr_reports.append(_satyr_report)
                     report_map[_satyr_report] = db_report
 
-                db.session.expire(db_report)
+            db.session.expire_all()
 
             self.log_debug("Clustering")
             clusters = self._create_clusters(_satyr_reports, 2000)


### PR DESCRIPTION
We can save some time if we use more workers (threads) to process the db_reports
concurrently.

The communication with the DB is slowing down the db_report processing.
So while some of the workers are loading reports from the DB, other workers can start
processing the loaded reports.

The number of workers is limited by 'pool_size' and 'max_overflow' settings of connection engine.
(Default is 5 for pool_size and 10 for max_overflow).

Default is 4 threads.

faf create-problems -w 8
faf create-problems --max-workers 8