### PR TITLE
Fix broken Celery scheduler

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -136,6 +136,14 @@ Create faf-network and connect faf and faf-redis containers to it:
 
 The message broker and backend used by Celery (Redis, in our case) are already set up in the FAF container in the `RDSBROKER` and `RDSBACKEND` environment variables. Alternatively, they can be set up by editing `/etc/faf/plugins/celery_tasks.conf` in the FAF container, followed by container restart.
 
+#### Scheduler
+
+Make sure the database connection is properly set up in the `[Storage]` section of `/etc/faf/faf.conf` on the local machine.  
+  
+Start the `faf-celery-worker` and `faf-celery-beat` services:
+    $ systemctl start faf-celery-worker.service
+    $ systemctl start faf-celery-beat.service
+
 ### Reporting into FAF
 1. Set a `URL` to your server in `/etc/libreport/plugins/ureport.conf`
 

--- a/docker/files/usr/bin/faf-celery-beat
+++ b/docker/files/usr/bin/faf-celery-beat
@@ -2,21 +2,33 @@
 
 source /etc/faf/celery-beat-env.conf
 
-case $1 in
-start)
-        /usr/bin/python3 -m celery multi start $CELERYD_NODES \
+start_beat () {
+        /usr/bin/python3 -m celery $CELERYD_NODES \
         -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
         --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
         $CELERYD_OPTS &
+}
+
+kill_beat () {
+        if [[ -f ${CELERYD_PID_FILE} ]]; then
+               kill $(cat ${CELERYD_PID_FILE})
+        else
+                echo "ERROR: Pidfile (${CELERYD_PID_FILE}) doesn't exist."
+                echo "celery beat not running"
+                exit 1
+        fi
+
+}
+
+case $1 in
+start)
+        start_beat
         ;;
 stop)
-        /usr/bin/python3 -m celery multi stopwait $CELERYD_NODES \
-        --pidfile=${CELERYD_PID_FILE} &
+        kill_beat
         ;;
 reload)
-        /usr/bin/python3 -m celery multi restart $CELERYD_NODES \
-        -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-        --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
-        $CELERYD_OPTS &
+        kill_beat
+        start_beat
         ;;
 esac

--- a/src/pyfaf/celery_tasks/schedulers.py
+++ b/src/pyfaf/celery_tasks/schedulers.py
@@ -12,9 +12,8 @@ from pyfaf.storage import DatabaseFactory
 db_factory = DatabaseFactory()
 
 
-class DBScheduleEntry(ScheduleEntry, object):
-    def __init__(self, db_task):
-        super(DBScheduleEntry, self).__init__()
+class DBScheduleEntry(ScheduleEntry):
+    def __init__(self, db_task):    #pylint: disable=super-init-not-called
         self.db_task = db_task
         self.app = current_app._get_current_object() #pylint: disable=protected-access
         self.name = db_task.name

--- a/src/pyfaf/storage/migrations/versions/Makefile.am
+++ b/src/pyfaf/storage/migrations/versions/Makefile.am
@@ -37,7 +37,8 @@ versions_PYTHON = \
     cee07a513404_drop_not_used_.py \
     8ac9b3343649_add_semver_semrel_to_.py \
     fd5dc71471cc_set_pkg_name_to_256.py \
-    9596a0f03838_zero_unique_reports_to_one.py
+    9596a0f03838_zero_unique_reports_to_one.py \
+    bb2289ffb392_add_tz_info_to_periodictasks.py
 
 
 versionsdir = $(pythondir)/pyfaf/storage/migrations/versions

--- a/src/pyfaf/storage/migrations/versions/bb2289ffb392_add_tz_info_to_periodictasks.py
+++ b/src/pyfaf/storage/migrations/versions/bb2289ffb392_add_tz_info_to_periodictasks.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2019  ABRT Team
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+add TZ info to periodictasks
+
+Revision ID: bb2289ffb392
+Revises: 9596a0f03838
+Create Date: 2019-12-12 14:59:44.743113
+"""
+
+from alembic.op import alter_column
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'bb2289ffb392'
+down_revision = '9596a0f03838'
+
+
+def upgrade():
+    alter_column('periodictasks', 'last_run_at', type_=sa.DateTime(timezone=True), nullable=True)
+    alter_column('taskresult', 'finished_time', type_=sa.DateTime(timezone=True), nullable=True)
+
+
+def downgrade():
+    alter_column('periodictasks', 'last_run_at', type_=sa.DateTime(timezone=False), nullable=True)
+    alter_column('taskresult', 'finished_time', type_=sa.DateTime(timezone=False), nullable=True)

--- a/src/pyfaf/storage/task.py
+++ b/src/pyfaf/storage/task.py
@@ -36,7 +36,7 @@ class PeriodicTask(GenericTable):
     crontab_day_of_week = Column(String(20), nullable=False, default="*")
     crontab_day_of_month = Column(String(20), nullable=False, default="*")
     crontab_month_of_year = Column(String(20), nullable=False, default="*")
-    last_run_at = Column(DateTime, nullable=True)
+    last_run_at = Column(DateTime(timezone=True), nullable=True)
     args = Column(JSONType, nullable=False, default=[])
     kwargs = Column(JSONType, nullable=False, default={})
 
@@ -64,7 +64,7 @@ class TaskResult(GenericTable):
     __tablename__ = "taskresult"
     id = Column(String(50), primary_key=True)
     task = Column(String(100), nullable=False)
-    finished_time = Column(DateTime, nullable=True)
+    finished_time = Column(DateTime(timezone=True), nullable=True)
     state = Column(String(20), nullable=False)
     retval = Column(Text, nullable=False, default="")
     args = Column(JSONType, nullable=False, default=[])


### PR DESCRIPTION
Unnecessary `super()` call in `DBScheduleEntry` caused a crash on `faf-celery-beat.service` startup.  
Another crash was caused by comparison between timezone-aware and timezone-ignorant timestamp.  
  
Fixes fix #822