### PR TITLE
Avoid zero unique report counts in summaries

### DIFF
--- a/src/pyfaf/storage/migrations/script.py.mako
+++ b/src/pyfaf/storage/migrations/script.py.mako
@@ -1,5 +1,5 @@
-# Copyright (C) 2019  ABRT Team
-# Copyright (C) 2019  Red Hat, Inc.
+# Copyright (C) 2020  ABRT Team
+# Copyright (C) 2020  Red Hat, Inc.
 #
 # This file is part of faf.
 #

--- a/src/pyfaf/storage/migrations/versions/9596a0f03838_zero_unique_reports_to_one.py
+++ b/src/pyfaf/storage/migrations/versions/9596a0f03838_zero_unique_reports_to_one.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2020  ABRT Team
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# faf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with faf.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Make all report summaries contain at least one unique report
+
+Revision ID: 9596a0f03838
+Revises: fd5dc71471cc
+Create Date: 2020-01-09 09:23:53.053811
+"""
+
+from alembic.op import execute
+from sqlalchemy import and_, update
+
+import pyfaf.storage as st
+
+
+# revision identifiers, used by Alembic.
+revision = '9596a0f03838'
+down_revision = 'fd5dc71471cc'
+
+
+def upgrade():
+    # Set the unique count to one for all report summaries which have no
+    # unique reports but have _some_ reports.
+    execute(update(st.ReportHistoryDaily)
+            .where(and_(st.ReportHistoryDaily.unique == 0,
+                        st.ReportHistoryDaily.count > 0))
+            .values(unique=1))
+    execute(update(st.ReportHistoryMonthly)
+            .where(and_(st.ReportHistoryMonthly.unique == 0,
+                        st.ReportHistoryMonthly.count > 0))
+            .values(unique=1))
+    execute(update(st.ReportHistoryWeekly)
+            .where(and_(st.ReportHistoryWeekly.unique == 0,
+                        st.ReportHistoryWeekly.count > 0))
+            .values(unique=1))
+
+
+def downgrade():
+    # It does not make sense to reverse this migration.
+    pass

--- a/src/pyfaf/storage/migrations/versions/Makefile.am
+++ b/src/pyfaf/storage/migrations/versions/Makefile.am
@@ -36,7 +36,8 @@ versions_PYTHON = \
     e17dc14292b9_add_ondelete_cascade_to_report_tables.py \
     cee07a513404_drop_not_used_.py \
     8ac9b3343649_add_semver_semrel_to_.py \
-    fd5dc71471cc_set_pkg_name_to_256.py
+    fd5dc71471cc_set_pkg_name_to_256.py \
+    9596a0f03838_zero_unique_reports_to_one.py
 
 
 versionsdir = $(pythondir)/pyfaf/storage/migrations/versions

--- a/src/pyfaf/ureport.py
+++ b/src/pyfaf/ureport.py
@@ -276,11 +276,11 @@ def save_ureport2(db, ureport, create_component=False, timestamp=None, count=1):
         db_daily.opsysrelease = db_osrelease
         db_daily.day = day
         db_daily.count = 0
-        db_daily.unique = 0
+        db_daily.unique = 1
         db.session.add(db_daily)
-
-    if "serial" in ureport["problem"] and ureport["problem"]["serial"] == 1:
+    elif ureport["problem"].get("serial") == 1:
         db_daily.unique += 1
+
     db_daily.count += count
 
     week = day - datetime.timedelta(days=day.weekday())
@@ -291,11 +291,11 @@ def save_ureport2(db, ureport, create_component=False, timestamp=None, count=1):
         db_weekly.opsysrelease = db_osrelease
         db_weekly.week = week
         db_weekly.count = 0
-        db_weekly.unique = 0
+        db_weekly.unique = 1
         db.session.add(db_weekly)
-
-    if "serial" in ureport["problem"] and ureport["problem"]["serial"] == 1:
+    elif ureport["problem"].get("serial") == 1:
         db_weekly.unique += 1
+
     db_weekly.count += count
 
     month = day.replace(day=1)
@@ -306,11 +306,11 @@ def save_ureport2(db, ureport, create_component=False, timestamp=None, count=1):
         db_monthly.opsysrelease = db_osrelease
         db_monthly.month = month
         db_monthly.count = 0
-        db_monthly.unique = 0
+        db_monthly.unique = 1
         db.session.add(db_monthly)
-
-    if "serial" in ureport["problem"] and ureport["problem"]["serial"] == 1:
+    elif ureport["problem"].get("serial") == 1:
         db_monthly.unique += 1
+
     db_monthly.count += count
 
     osplugin.save_ureport(db, db_report, ureport["os"], ureport["packages"],


### PR DESCRIPTION
When saving an incoming report, the number of unique reports in the corresponding daily/weekly/monthly summary was incremented if and only if the incoming report had `serial` of 1, i.e. it was the first report of its kind from the machine.

However, it may happen that the very first report gets lost, is delayed etc., in which case the report's `serial` field is greater than 1 and the uniqe count in the summary is set to 0 if the report is the first of its kind on the server.

This is now fixed by setting the unique count in a summary to 1 whenever we receive a new report in that period, ignoring its `serial`.

Lastly, add a database migration which sets the unique count to at least one for all the daily/weekly/monthly summaries which claim to have zero unique reports, but do have _some_ reports.

Fixes #847
