### PR TITLE
webfaf: Order summary plot by Opsys and Version

### DIFF
--- a/src/webfaf/summary.py
+++ b/src/webfaf/summary.py
@@ -34,7 +34,8 @@ def index_plot_data_cache(summary_form):
         opsysreleases = (
             db.session.query(OpSysRelease)
             .filter(OpSysRelease.status != "EOL")
-            .order_by(OpSysRelease.releasedate)
+            .order_by(OpSysRelease.opsys_id)
+            .order_by(OpSysRelease.version)
             .all())
 
     for osr in opsysreleases:


### PR DESCRIPTION
There is usually no release date set in database for releases and
so the releases in the plot are ordered by opsysrelease_id.

This should sort the plot graph first by opsys_id and the by versions.

Old:
```
CentOS 7 (opsysrelease_id=40,  opsys_id=1, release_date=, version=7)
Fedora 30 (opsysrelease_id=41, opsys_id=3, release_date=, version=30)
Fedora 31 (opsysrelease_id=42, opsys_id=3, release_date=, version=31)
CentOS 8 (opsysrelease_id=43,  opsys_id=1, release_date=, version=8)
Fedora 32 (opsysrelease_id=44, opsys_id=3, release_date=, version=32)
```
New:
```
CentOS 7 (opsysrelease_id=40,  opsys_id=1, release_date=, version=7)
CentOS 8 (opsysrelease_id=43,  opsys_id=1, release_date=, version=8)
Fedora 30 (opsysrelease_id=41, opsys_id=3, release_date=, version=30)
Fedora 31 (opsysrelease_id=42, opsys_id=3, release_date=, version=31)
Fedora 32 (opsysrelease_id=44, opsys_id=3, release_date=, version=32)
```

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>