### PR TITLE
Allow wildcards with faf repo manipulation

### DIFF
--- a/src/pyfaf/actions/repodel.py
+++ b/src/pyfaf/actions/repodel.py
@@ -63,4 +63,4 @@ class RepoDel(Action):
 
     def tweak_cmdline_parser(self, parser):
         parser.add_repo(multiple=True, helpstr="name of the repository to delete")
-        parser.add_argument("--all", action="store_true", default=False, help="delete all repositories")
+        parser.add_argument("-a", "--all", action="store_true", default=False, help="delete all repositories")

--- a/src/pyfaf/actions/repodel.py
+++ b/src/pyfaf/actions/repodel.py
@@ -16,9 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
-
 from pyfaf.actions import Action
+from pyfaf.queries import get_repos_by_wildcards
 from pyfaf.storage.opsys import Repo
 
 
@@ -36,12 +35,7 @@ class RepoDel(Action):
         if cmdline.all or '*' in cmdline.REPO:
             repos.extend(db.session.query(Repo).all())
         else:
-            for pattern in cmdline.REPO:
-                pattern = re.sub('_', r'\\_', pattern)
-                pattern = re.sub('%', r'\\%', pattern)
-                pattern = re.sub(r'\*', '%', pattern)
-                pattern = re.sub(r'\?', '_', pattern)
-                repos.extend(db.session.query(Repo).filter(Repo.name.like(pattern)).all())
+            repos.extend(get_repos_by_wildcards(db, cmdline.REPO))
 
         if repos:
             repos = sorted(list(set(repos)), key=lambda x: x.name)

--- a/src/pyfaf/actions/repolist.py
+++ b/src/pyfaf/actions/repolist.py
@@ -28,12 +28,26 @@ class RepoList(Action):
     def run(self, cmdline, db):
         if cmdline.detailed:
             data = []
-            header = ["Name", "Type", "URL", "Nice name"]
+            header = ["Name", "Type", "URL", "Nice name", "GPG check", "OS", "OS release", "Architecture"]
             for repo in db.session.query(Repo):
                 data.append((repo.name, repo.type, repo.url_list[0].url,
-                             repo.nice_name or ""))
-                for url in repo.url_list[1:]:
-                    data.append(("", "", url.url, ""))
+                             repo.nice_name or "", str(not repo.nogpgcheck),
+                             repo.opsys_list[0] if repo.opsys_list else "",
+                             repo.opsysrelease_list[0] if repo.opsysrelease_list else "",
+                             repo.arch_list[0] if repo.arch_list else ""))
+                for i in range(1, len(max([repo.url_list,
+                                           repo.opsys_list,
+                                           repo.opsysrelease_list,
+                                           repo.arch_list],
+                                          key=len))):
+                    data.append(("",
+                                 "",
+                                 repo.url_list[i].url if len(repo.url_list) > i else "",
+                                 "",
+                                 "",
+                                 repo.opsys_list[i] if len(repo.opsys_list) > i else "",
+                                 repo.opsysrelease_list[i] if len(repo.opsysrelease_list) > i else "",
+                                 repo.arch_list[i] if len(repo.arch_list) > i else ""))
 
             print(as_table(header, data, margin=2))
         else:

--- a/src/pyfaf/actions/repomod.py
+++ b/src/pyfaf/actions/repomod.py
@@ -16,10 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
-
 import pyfaf.repos
 from pyfaf.actions import Action
+from pyfaf.queries import get_repos_by_wildcards
 from pyfaf.storage.opsys import Repo, Url, UrlRepo
 
 
@@ -51,12 +50,7 @@ class RepoMod(Action):
             repos.extend(db.session.query(Repo).all())
 
         else:
-            for pattern in cmdline.REPO:
-                pattern = re.sub('_', r'\\_', pattern)
-                pattern = re.sub('%', r'\\%', pattern)
-                pattern = re.sub(r'\*', '%', pattern)
-                pattern = re.sub(r'\?', '_', pattern)
-                repos.extend(db.session.query(Repo).filter(Repo.name.like(pattern)).all())
+            repos.extend(get_repos_by_wildcards(db, cmdline.REPO))
 
         if repos:
             repos = sorted(list(set(repos)), key=lambda x: x.name)

--- a/src/pyfaf/actions/repomod.py
+++ b/src/pyfaf/actions/repomod.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
+
 import pyfaf.repos
 from pyfaf.actions import Action
 from pyfaf.storage.opsys import Repo, Url, UrlRepo
@@ -29,13 +31,38 @@ class RepoMod(Action):
         self.repo_types = pyfaf.repos.repo_types
 
     def run(self, cmdline, db):
-        repo = (db.session.query(Repo)
-                .filter(Repo.name == cmdline.REPO)
-                .first())
+        if not cmdline.REPO and not cmdline.all:
+            self.log_error("No repositories specified")
+            return 1
 
-        if not repo:
-            self.log_error("Repository '{0}' not found"
-                           .format(cmdline.REPO))
+        repos = []
+
+        for pattern in cmdline.REPO:
+            wildcard_used = any(c in pattern for c in ['?', '*'])
+            if wildcard_used:
+                break
+
+        if (len(cmdline.REPO) > 1 or cmdline.all or wildcard_used) and (cmdline.name or cmdline.nice_name):
+            self.log_error("Can't assign the same name to multiple repositories")
+            return 1
+
+
+        if cmdline.all or '*' in cmdline.REPO:
+            repos.extend(db.session.query(Repo).all())
+
+        else:
+            for pattern in cmdline.REPO:
+                pattern = re.sub('_', r'\\_', pattern)
+                pattern = re.sub('%', r'\\%', pattern)
+                pattern = re.sub(r'\*', '%', pattern)
+                pattern = re.sub(r'\?', '_', pattern)
+                repos.extend(db.session.query(Repo).filter(Repo.name.like(pattern)).all())
+
+        if repos:
+            repos = sorted(list(set(repos)), key=lambda x: x.name)
+
+        else:
+            self.log_warn("No matching repositories found")
             return 1
 
         if cmdline.name:
@@ -45,53 +72,57 @@ class RepoMod(Action):
             if dbrepo:
                 self.log_error("Unable to rename repository '{0}' to '{1}',"
                                " the latter is already defined"
-                               .format(repo.name, dbrepo.name))
+                               .format(cmdline.REPO[0], dbrepo.name))
                 return 1
 
         options = ["name", "type", "nice_name"]
-        for opt in options:
-            if hasattr(cmdline, opt) and getattr(cmdline, opt):
-                newval = getattr(cmdline, opt)
-                self.log_info("Updating {0} on '{1}' to '{2}'"
-                              .format(opt, repo.name, newval))
-                setattr(repo, opt, newval)
+        for repo in repos:
+            for opt in options:
+                if hasattr(cmdline, opt) and getattr(cmdline, opt):
+                    newval = getattr(cmdline, opt)
+                    self.log_info("Updating {0} on '{1}' to '{2}'"
+                                  .format(opt, repo.name, newval))
+                    setattr(repo, opt, newval)
 
-        if cmdline.add_url:
-            new_url = Url()
-            new_url.url = getattr(cmdline, "add_url")
-            repo.url_list.append(new_url)
+            if cmdline.add_url:
+                new_url = Url()
+                new_url.url = getattr(cmdline, "add_url")
+                repo.url_list.append(new_url)
 
-        if cmdline.remove_url:
-            url = (db.session.query(Url)
-                   .join(UrlRepo)
-                   .filter(Url.url == cmdline.remove_url)
-                   .filter(UrlRepo.repo_id == repo.id)
-                   .first())
-            if not url:
-                self.log_error("Url is not assigned to selected repository."
-                               " Use repoinfo to find out more about repository.")
-                return 1
+            if cmdline.remove_url:
+                url = (db.session.query(Url)
+                       .join(UrlRepo)
+                       .filter(Url.url == cmdline.remove_url)
+                       .filter(UrlRepo.repo_id == repo.id)
+                       .first())
+                if not url:
+                    self.log_warn("Url is not assigned to {0} repository."
+                                  " Use repoinfo to find out more about repository.".format(repo.name))
+                    continue
 
-            repo.url_list.remove(url)
-            db.session.delete(url)
+                repo.url_list.remove(url)
+                db.session.delete(url)
 
-        if cmdline.gpgcheck == "enable":
-            repo.nogpgcheck = False
+            if cmdline.gpgcheck == "enable":
+                repo.nogpgcheck = False
 
-        if cmdline.gpgcheck == "disable":
-            repo.nogpgcheck = True
+            if cmdline.gpgcheck == "disable":
+                repo.nogpgcheck = True
 
-        db.session.add(repo)
+            db.session.add(repo)
+            self.log_info("Repository {0} modified".format(repo.name))
+
         db.session.flush()
 
-        self.log_info("Repository modified")
         return 0
 
     def tweak_cmdline_parser(self, parser):
-        parser.add_repo(helpstr="current name of the repository")
+        parser.add_repo(multiple=True, helpstr="current name of the repository")
         parser.add_argument("--name", help="new name of the repository")
         parser.add_repo_type(choices=self.repo_types, helpstr="new type of the repository")
         parser.add_argument("--add-url", help="new repository URL")
         parser.add_argument("--remove-url", help="new repository URL")
         parser.add_argument("--nice-name", help="new human readable name")
         parser.add_gpgcheck_toggle(helpstr="toggle GPG check requirement for this repository")
+        parser.add_argument("-a", "--all", action="store_true", default=False, help="apply to all repositories; "
+                            "do not use with --name or --nice-name")

--- a/src/pyfaf/actions/repomod.py
+++ b/src/pyfaf/actions/repomod.py
@@ -114,8 +114,8 @@ class RepoMod(Action):
         parser.add_repo(multiple=True, helpstr="current name of the repository")
         parser.add_argument("--name", help="new name of the repository")
         parser.add_repo_type(choices=self.repo_types, helpstr="new type of the repository")
-        parser.add_argument("--add-url", help="new repository URL")
-        parser.add_argument("--remove-url", help="new repository URL")
+        parser.add_argument("--add-url", metavar="URL", help="new repository URL")
+        parser.add_argument("--remove-url", metavar="URL", help="repository URL to delete")
         parser.add_argument("--nice-name", help="new human readable name")
         parser.add_gpgcheck_toggle(helpstr="toggle GPG check requirement for this repository")
         parser.add_argument("-a", "--all", action="store_true", default=False, help="apply to all repositories; "

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -234,6 +234,17 @@ class ActionsTestCase(faftests.DatabaseCase):
         self.assertNotIn("file:///sample_rpms", self.action_stdout)
         self.assertIn("file:///some/new/url", self.action_stdout)
 
+        self.assertEqual(self.call_action_ordered_args("repomod", [
+            "sample_repo", "another_repo", "--gpgcheck", "disable"]), 0)
+
+        self.assertEqual(self.call_action_ordered_args("repolist", ["--detailed"]), 0)
+
+        self.assertRegex(self.action_stdout, r'sample_repo.*False')
+        self.assertRegex(self.action_stdout, r'another_repo.*False')
+
+        self.assertEqual(self.call_action_ordered_args("repomod", [
+            "*_repo", "--name=impossible_repo"]), 1)
+
     def test_repodel(self):
         for repo_type in repo_types:
             if repo_type in self.preferred_repo_types:


### PR DESCRIPTION
Allow multiple `REPO` arguments to `faf repomod` ~~and `faf repoinfo`~~, using either enumeration or wildcards.  
~~Change `faf repoinfo` output format for easier parsing.~~  
Add OS and architecture info to `faf repolist` output.
Add a short `-a` option as an alternative to `--all` to `faf repodel`.