### PR TITLE
pull-releases: Skip EOLed releases

### DIFF
--- a/src/pyfaf/actions/pull_releases.py
+++ b/src/pyfaf/actions/pull_releases.py
@@ -83,6 +83,11 @@ class PullReleases(Action):
 
                 continue
 
+            if not opsys_plugin.eol and remote_status == "EOL":
+                self.log_debug("Skipping unsupported EOL release '%s' (%s)" %
+                               (release, remote_status))
+                continue
+
             self.log_info("Adding release '{0}' ({1})"
                           .format(release, remote_status))
 

--- a/src/pyfaf/opsys/centos.py
+++ b/src/pyfaf/opsys/centos.py
@@ -89,6 +89,7 @@ class CentOS(System):
 
     def __init__(self):
         super(CentOS, self).__init__()
+        self.eol = None
         self.repo_urls = []
         self.allow_unpackaged = None
         self.inactive_releases = None


### PR DESCRIPTION
With configuration option SupportEOL you can select whether you want to
pull and in that way "support" EOLed releases.

With this option switched off EOLed releases won't be added to the database and
any incoming uReport from that release will be rejected as not supported.