### PR TITLE
fedora: Filter query for releases with short name

### DIFF
--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -235,13 +235,10 @@ class Fedora(System):
     def get_releases(self):
         result = {}
         # Page size -1 means, that all results are on one page
-        url = self.pdc_url + "releases/?page_size=-1"
+        url = self.pdc_url + "releases/?page_size=-1&short=" + Fedora.name
 
         response = json.load(urllib.request.urlopen(url))
         for release in response:
-            if release["short"] != Fedora.name:
-                continue
-
             ver = release["version"].lower()
 
             if self._is_ignored(ver):


### PR DESCRIPTION
We can just add the short name to the query and recieve less data from PDC.
(We don't need information about Fedora Docker/Atomic/Cloud/EPEL)

See:
https://pdc.fedoraproject.org/rest_api/v1/releases/?page_size=-1&short=fedora

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>