### PR TITLE
storage: Handle oops LOBs as strings

### DIFF
--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -486,14 +486,14 @@ class KerneloopsProblem(ProblemType):
                 # do not append here, but create a new dict
                 # we only want save_ureport_post_flush process the most
                 # recently saved report
-                self.add_lob = {db_report: ureport["raw_oops"].encode("utf-8")}
+                self.add_lob = {db_report: ureport["raw_oops"]}
 
         if flush:
             db.session.flush()
 
     def save_ureport_post_flush(self):
         for report, raw_oops in self.add_lob.items():
-            report.save_lob("oops", raw_oops)
+            report.save_lob("oops", raw_oops, binary=False)
 
         # clear the list so that re-calling does not make problems
         self.add_lob = {}

--- a/src/pyfaf/storage/report.py
+++ b/src/pyfaf/storage/report.py
@@ -70,7 +70,7 @@ class Report(GenericTable):
 
     @property
     def oops(self):
-        return self.get_lob('oops')
+        return self.get_lob('oops', binary=False)
 
     @property
     def sorted_backtraces(self):


### PR DESCRIPTION
The LOB functions in `GenericTable` handle string encoding automatically so we don't need to encode the oops file manually.

This also ensures that a string is passed to the webui and we don't have to decode on the front end either.

Fixes #816