### PR TITLE
Ameliorate LOB encoding craziness

### DIFF
--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -258,7 +258,7 @@ class RepoSync(Action):
     @retry(3, delay=5, backoff=3, verbose=True)
     def _download(self, obj, lob, url):
         pipe = urllib.request.urlopen(url)
-        obj.save_lob(lob, pipe.fp, truncate=True, binary=True)
+        obj.save_lob(lob, pipe.fp, truncate=True)
         pipe.close()
 
     def _get_parametrized_variants(self, repo):

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -493,7 +493,7 @@ class KerneloopsProblem(ProblemType):
 
     def save_ureport_post_flush(self):
         for report, raw_oops in self.add_lob.items():
-            report.save_lob("oops", raw_oops, binary=False)
+            report.save_lob("oops", raw_oops.encode("utf-8"))
 
         # clear the list so that re-calling does not make problems
         self.add_lob = {}

--- a/src/pyfaf/storage/bugzilla.py
+++ b/src/pyfaf/storage/bugzilla.py
@@ -55,7 +55,6 @@ class BzUser(GenericTable):
 # pylint: disable=too-many-instance-attributes
 class BzBug(GenericTable):
     __tablename__ = "bzbugs"
-    __lobs__ = {"optimized-backtrace": 1 << 16}
 
     id = Column(Integer, primary_key=True)
     summary = Column(String(256), nullable=False)

--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -230,7 +230,6 @@ class BuildOpSysReleaseArch(GenericTable):
 
 class BuildArch(GenericTable):
     __tablename__ = "buildarchs"
-    __lobs__ = {"build.log": 1 << 26, "state.log": 1 << 16, "root.log": 1 << 26}
 
     build_id = Column(Integer, ForeignKey("{0}.id".format(Build.__tablename__)), primary_key=True)
     arch_id = Column(Integer, ForeignKey("{0}.id".format(Arch.__tablename__)), primary_key=True)

--- a/src/pyfaf/storage/report.py
+++ b/src/pyfaf/storage/report.py
@@ -70,7 +70,7 @@ class Report(GenericTable):
 
     @property
     def oops(self):
-        return self.get_lob('oops', binary=False)
+        return self.get_lob('oops').decode('utf-8')
 
     @property
     def sorted_backtraces(self):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -55,7 +55,7 @@ class StorageTestCase(faftests.DatabaseCase):
 
         obj = self._add_llvmbuild_object()
 
-        obj.save_lob("result", "result_log_data")
+        obj.save_lob("result", b"result_log_data")
         self.assertEqual(obj.get_lob("result"), b"result_log_data")
         obj.del_lob("result")
 
@@ -66,12 +66,12 @@ class StorageTestCase(faftests.DatabaseCase):
 
         obj = self._add_llvmbuild_object()
 
-        obj.save_lob("result", "result_log_data")
+        obj.save_lob("result", b"result_log_data")
 
         with self.assertRaises(Exception):
-            obj.save_lob("result", "result_log_data")
+            obj.save_lob("result", b"result_log_data")
 
-        obj.save_lob("result", "overwritten", overwrite=True)
+        obj.save_lob("result", b"overwritten", overwrite=True)
         self.assertEqual(obj.get_lob("result"), b"overwritten")
         obj.del_lob("result")
 
@@ -86,13 +86,13 @@ class StorageTestCase(faftests.DatabaseCase):
             obj.get_lob_path("oops")
 
         with self.assertRaises(Exception):
-            obj.save_lob("oops", "llvm_build_cant_handle_oops_lobs")
+            obj.save_lob("oops", b"llvm_build_cant_handle_oops_lobs")
 
         with self.assertRaises(Exception):
-            obj.get_lob("oops", "llvm_build_cant_handle_oops_lobs")
+            obj.get_lob("oops", b"llvm_build_cant_handle_oops_lobs")
 
         with self.assertRaises(Exception):
-            obj.del_lob("oops", "llvm_build_cant_handle_oops_lobs")
+            obj.del_lob("oops", b"llvm_build_cant_handle_oops_lobs")
 
         self.assertEqual(obj.get_lob("result"), None)
 
@@ -105,7 +105,7 @@ class StorageTestCase(faftests.DatabaseCase):
         obj = self._add_llvmbuild_object()
         self.db.session.flush()
 
-        obj.save_lob("result", "result_log_data")
+        obj.save_lob("result", b"result_log_data")
         lobpath = obj.get_lob_path("result")
 
         self.assertTrue(os.path.isfile(lobpath))


### PR DESCRIPTION
Disallow implicit encoding and decoding of Unicode strings in `GenericTable`'s `get_lob()` and `save_lob()`. This requires callers to handle the coding the themselves and only supply byte strings.