### PR TITLE
WIP: Truncate crash function in GUI Reports table

### DIFF
--- a/src/webfaf/static/css/style.css
+++ b/src/webfaf/static/css/style.css
@@ -1511,3 +1511,26 @@ li.empty-line:last-child {
 .cell-count {
   text-align: right;
 }
+
+.truncate {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.crash-fn {
+  width: 100%;
+  max-width: 0;
+}
+
+table th {
+  white-space: nowrap;
+}
+
+.expand-btn {
+  font-size: 10px;
+}
+
+div:truncate + .expand-btn {
+  display: block;
+}

--- a/src/webfaf/static/js/custom.js
+++ b/src/webfaf/static/js/custom.js
@@ -172,6 +172,33 @@ $(document).ready(function() {
       $('#advanced-filters').removeClass('hide');
       $(this).addClass('hide');
     });
+
+    const observer = new ResizeObserver(entries => {
+      for (let entry of entries) {
+	alert(entry+" "+entry.target)
+      	/*const domElement = entry.target;*/
+	entry.target.classList[entry.target.scrollWidth > entry.contentRect.width ? 'add' : 'remove']('truncate');
+      	/*if (domElement.scrollWidth >= domElement.clientWidth) {*/
+      	    const button = $("<button id=\"button\"></button>")
+      	    .text("show more")
+      	    .addClass('btn expand-btn')
+      	    .click(function() {
+      	      var textHolder = $(this).parent().children('.longtext');
+      	      textHolder.toggleClass('truncate');
+      	      if (textHolder.hasClass('truncate')) {
+      	          $(this).text('show more');
+      	      } else {
+      	          $(this).text('show less');
+      	      }
+      	    })
+      	    .appendTo($(entry.target));
+      	/*}*/
+      }
+    });
+
+    document.querySelectorAll(".crash-fn").forEach(element => {
+	    observer.observe(element);
+    });
 });
 
 

--- a/src/webfaf/templates/_helpers.html
+++ b/src/webfaf/templates/_helpers.html
@@ -317,9 +317,9 @@
     <abbr title="Unreliable frame">?</abbr>
   {% endif %}
   {% if frame.symbolsource.symbol.nice_name %}
-    {{ frame.symbolsource.symbol.nice_name }}
+    {{ frame.symbolsource.symbol.nice_name|truncate(1024, True) }}
   {% else %}
-    {{ frame.symbolsource.symbol.name }}
+    {{ frame.symbolsource.symbol.name|truncate(1024, True) }}
   {% endif %}
   {% if frame.inlined %}
     (inlined)

--- a/src/webfaf/templates/problems/item.html
+++ b/src/webfaf/templates/problems/item.html
@@ -10,7 +10,7 @@
 {% block title %}
 Problem #{{ problem.id }} -
 {% with comps = problem.unique_component_names|list %}
-  {{comps[0:3]|join(", ")}} in {{ problem.crash_function }}
+  {{comps[0:3]|join(", ")}} in {{ problem.crash_function|truncate(80, True) }}
 {% endwith %}
 {% endblock %}
 

--- a/src/webfaf/templates/reports/item.html
+++ b/src/webfaf/templates/reports/item.html
@@ -10,7 +10,7 @@
 
 {% block title -%}
   {{ "Report #%d - %s" | format(report.id, component.name) -}}
-  {{ " in %s" | format(report.backtraces[0].crash_function) if report.backtraces | length > 0 }}
+  {{ " in %s" | format(report.backtraces[0].crash_function|truncate(80, True) if report.backtraces | length > 0 }}
 {%- endblock %}
 
 {% block js %}

--- a/src/webfaf/templates/reports/list_table_rows.html
+++ b/src/webfaf/templates/reports/list_table_rows.html
@@ -2,9 +2,11 @@
 <tr>
     <td><a href="{{ url_for('reports.item', report_id=report.id)}}">{{report.id}}</a></td>
     <td>{{report.component}}</td>
-    <td>
+    <td class="crash-fn">
         {% if report.crashfn %}
-          {{ report.crashfn|truncate(120, True) }}
+	    <div class="longtext truncate" id="crashfn">
+	      {{ report.crashfn }}
+	    </div>
         {% endif %}
     </td>
         {% if not report.archived %}

--- a/src/webfaf/templates/reports/list_table_rows.html
+++ b/src/webfaf/templates/reports/list_table_rows.html
@@ -4,7 +4,7 @@
     <td>{{report.component}}</td>
     <td>
         {% if report.crashfn %}
-          {{ report.crashfn }}
+          {{ report.crashfn|truncate(120, True) }}
         {% endif %}
     </td>
         {% if not report.archived %}


### PR DESCRIPTION
With very long function names in crash reports (up to 1024 chars in the DB), the Crash function column in the table at http://.../faf/reports/ makes the table unreasonably wide. This PR truncates the function name to a more reasonable value.  
  
Dtto in detailed tables for individual reports, Problem table and page title. (W3C [recommends](https://www.w3.org/Provider/Style/TITLE.html) maximum title length at 64 chars. Page title limited at _roughly_ twice that.)

Signed-off-by: Michal Fabik <mfabik@redhat.com>