### PR TITLE
Prevent exception when calling decode on None

### DIFF
--- a/src/pyfaf/storage/report.py
+++ b/src/pyfaf/storage/report.py
@@ -70,7 +70,10 @@ class Report(GenericTable):
 
     @property
     def oops(self):
-        return self.get_lob('oops').decode('utf-8')
+        result = self.get_lob('oops')
+        if result:
+            return result.decode('utf-8')
+        return result
 
     @property
     def sorted_backtraces(self):


### PR DESCRIPTION
This PR fixes an exception caused by calling `decode()` as a member of [`NoneType`](https://github.com/abrt/faf/blob/master/src/pyfaf/storage/generic_table.py#L52), introduced with a change of src/pyfaf/storage/report.py in #876.

Signed-off-by: Michal Fabik <mfabik@redhat.com>