### PR TITLE
Fix DeprecationWarnings

### DIFF
--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -255,7 +255,7 @@ class Plugin(object):
         self._logger = log.getChild(self.__class__.__name__)
         self.log_debug = self._logger.debug
         self.log_info = self._logger.info
-        self.log_warn = self._logger.warn
+        self.log_warn = self._logger.warning
         self.log_error = self._logger.error
         self.log_critical = self._logger.critical
     # pylint: enable-msg=W0613

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -4,7 +4,7 @@ from flask import (Blueprint, request, abort, render_template, flash,
 from wtforms import (Form,
                      validators,
                      SelectMultipleField,
-                     TextField,
+                     StringField,
                      SelectField,
                      BooleanField,
                      TextAreaField,
@@ -146,7 +146,7 @@ class ActionFormArgparser():
                         TagListField(*field_args, **field_kwargs))
             else:
                 setattr(self.F, kwargs["dest"],
-                        TextField(*field_args, **field_kwargs))
+                        StringField(*field_args, **field_kwargs))
 
         self.F.argparse_fields[kwargs["dest"]] = kwargs
 
@@ -381,20 +381,21 @@ def create_action_form(action):
     return ActionForm
 
 
-# custom TextField to avoid clashing field names in ActionForm and PeriodicTaskForm
+# custom StringField to avoid clashing field names in ActionForm and PeriodicTaskForm
 # which breaks form validation for extfafmod and repoadd
-class TaskNameField(TextField):
+class TaskNameField(StringField):
     def __init__(self, label="", _name="", **kwargs):
         super(TaskNameField, self).__init__(label, _name="task_name", **kwargs)
 
 class PeriodicTaskForm(Form):
     name = TaskNameField("Name", validators=[validators.Length(min=1, max=80)])
     enabled = BooleanField("Enabled", default="checked")
-    crontab_minute = TextField("Minute", [validators.Length(min=1, max=20)], description="Crontab format", default="*")
-    crontab_hour = TextField("Hour", [validators.Length(min=1, max=20)], default="*")
-    crontab_day_of_week = TextField("Day of week", [validators.Length(min=1, max=20)], default="*")
-    crontab_day_of_month = TextField("Day of month", [validators.Length(min=1, max=20)], default="*")
-    crontab_month_of_year = TextField("Month of year", [validators.Length(min=1, max=20)], default="*")
+    crontab_minute = StringField("Minute", [validators.Length(min=1, max=20)],
+                                 description="Crontab format", default="*")
+    crontab_hour = StringField("Hour", [validators.Length(min=1, max=20)], default="*")
+    crontab_day_of_week = StringField("Day of week", [validators.Length(min=1, max=20)], default="*")
+    crontab_day_of_month = StringField("Day of month", [validators.Length(min=1, max=20)], default="*")
+    crontab_month_of_year = StringField("Month of year", [validators.Length(min=1, max=20)], default="*")
 
 
 class JSONField(TextAreaField):
@@ -418,7 +419,7 @@ class JSONField(TextAreaField):
 
 
 class PeriodicTaskFullForm(PeriodicTaskForm):
-    task = TextField("Celery task", [validators.Length(min=1, max=80)])
+    task = StringField("Celery task", [validators.Length(min=1, max=80)])
     args = JSONField("Args", default=[])
     kwargs = JSONField("KW args", default={})
 

--- a/src/webfaf/forms.py
+++ b/src/webfaf/forms.py
@@ -12,7 +12,7 @@ from wtforms import (Form,
                      SubmitField,
                      validators,
                      SelectMultipleField,
-                     TextField,
+                     StringField,
                      SelectField,
                      FileField,
                      BooleanField)
@@ -27,7 +27,7 @@ from pyfaf.bugtrackers import bugtrackers
 from pyfaf.queries import get_associate_by_name
 
 
-class DaterangeField(TextField):
+class DaterangeField(StringField):
     date_format = "%Y-%m-%d"
     separator = ":"
 
@@ -66,7 +66,7 @@ class DaterangeField(TextField):
         return ""
 
 
-class TagListField(TextField):
+class TagListField(StringField):
     def _value(self):
         if self.data:
             return u', '.join(self.data)
@@ -160,7 +160,7 @@ solution_checkbox = BooleanField("Solution")
 class ProblemFilterForm(Form):
     opsysreleases = releases_multiselect
 
-    component_names = TextField()
+    component_names = StringField()
 
     daterange = DaterangeField(
         "Date range",
@@ -183,11 +183,11 @@ class ProblemFilterForm(Form):
     binary_names = TagListField()
     source_file_names = TagListField()
 
-    since_version = TextField()
-    since_release = TextField()
+    since_version = StringField()
+    since_release = StringField()
 
-    to_version = TextField()
-    to_release = TextField()
+    to_version = StringField()
+    to_release = StringField()
 
     solution = solution_checkbox
 
@@ -236,7 +236,7 @@ class ProblemFilterForm(Form):
 class ReportFilterForm(Form):
     opsysreleases = releases_multiselect
 
-    component_names = TextField()
+    component_names = StringField()
 
     daterange = DaterangeField(
         "Date range",
@@ -275,7 +275,7 @@ class ReportFilterForm(Form):
 class SummaryForm(Form):
     opsysreleases = releases_multiselect
 
-    component_names = TextField()
+    component_names = StringField()
 
     daterange = DaterangeField(
         "Date range",
@@ -308,7 +308,7 @@ class NewAttachmentForm(Form):
     file = FileField("Attachment file")
 
 
-class BugIdField(TextField):
+class BugIdField(StringField):
     def _value(self):
         if self.data:
             return str(self.data)
@@ -336,7 +336,7 @@ class AssociateBzForm(Form):
 
 
 class ProblemComponents(Form):
-    component_names = TextField()
+    component_names = StringField()
     submit = SubmitField("Reassign")
 
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -63,7 +63,7 @@ class QueriesTestCase(faftests.DatabaseCase):
 
         self.db.session.commit()
 
-        self.assertEquals(len(problem.reports), 1)
+        self.assertEqual(len(problem.reports), 1)
 
 
     def test_get_packages_and_their_reports_unknown_packages(self):


### PR DESCRIPTION
This PR replaces some deprecated method names with their more up-to-date versions.  
`logger.warn` was deprecated as of Python 3.3 in favour of `logger.warning`.  
`assertEquals` in `unittest.TestCase` was an alias for `assertEqual` and was deprecated as of Python 3.3.  
`TextField` in WTForms was deprecated, replaced with `StringField` and will be removed completely in the future.
