### PR TITLE
Add Obsoletes version for faf-yum

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -144,7 +144,7 @@ A plugin for %{name} handling ruby scripts problems.
 Summary: %{name}'s dnf plugin
 Requires: %{name} = %{faf_version}
 Requires: python3-dnf
-Obsoletes: %{name}-yum
+Obsoletes: %{name}-yum < 1.3.5
 
 %description dnf
 A plugin for %{name} implementing unified access to dnf repositories.


### PR DESCRIPTION
I keep running into the following error during builds:  
`It's not recommended to have unversioned Obsoletes: Obsoletes: faf-yum`  
  
Not sure about the specific version to use though - 1.3.5 is the only one that I [found mentioned](https://copr.fedorainfracloud.org/coprs/g/abrt/faf-el7-devel/build/978502) anywhere. Somebody please correct me.

Signed-off-by: Michal Fabik <mfabik@redhat.com>