### PR TITLE
webfaf: Fix serialization of reports with solutions

### DIFF
--- a/faf.spec.in
+++ b/faf.spec.in
@@ -779,6 +779,7 @@ fi
 %{python3_sitelib}/pyfaf/utils/decorators.py
 %{python3_sitelib}/pyfaf/utils/format.py
 %{python3_sitelib}/pyfaf/utils/hash.py
+%{python3_sitelib}/pyfaf/utils/json.py
 %{python3_sitelib}/pyfaf/utils/parse.py
 %{python3_sitelib}/pyfaf/utils/proc.py
 %{python3_sitelib}/pyfaf/utils/storage.py

--- a/src/pyfaf/utils/Makefile.am
+++ b/src/pyfaf/utils/Makefile.am
@@ -5,6 +5,7 @@ utils_PYTHON = \
     decorators.py \
     format.py \
     hash.py \
+    json.py \
     parse.py \
     proc.py \
     storage.py \

--- a/src/pyfaf/utils/json.py
+++ b/src/pyfaf/utils/json.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2013  ABRT Team
-# Copyright (C) 2013  Red Hat, Inc.
+# Copyright © 2020  Red Hat, Inc.
 #
 # This file is part of faf.
 #
@@ -16,12 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ["date", "decorators", "format", "json", "parse", "proc", "storage"]
+from json import JSONEncoder
 
-from pyfaf.utils import date
-from pyfaf.utils import decorators
-from pyfaf.utils import format # pylint: disable=redefined-builtin
-from pyfaf.utils import json
-from pyfaf.utils import parse
-from pyfaf.utils import proc
-from pyfaf.utils import storage
+from pyfaf.solutionfinders import Solution
+
+class FAFJSONEncoder(JSONEncoder):
+    def default(self, o):
+        if isinstance(o, Solution):
+            solution = o.__dict__.copy()
+            solution['since'] = str(solution['since'])
+
+            return solution
+
+        return super().default(o)

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -9,8 +9,16 @@ import datetime
 from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 
-from flask import (Blueprint, render_template, request, abort, redirect,
-                   url_for, flash, jsonify, g)
+from flask import (Blueprint,
+                   Response,
+                   render_template,
+                   request,
+                   abort,
+                   redirect,
+                   url_for,
+                   flash,
+                   jsonify,
+                   g)
 from sqlalchemy import literal, desc, or_
 from sqlalchemy.exc import (SQLAlchemyError, DatabaseError, InterfaceError)
 
@@ -51,7 +59,7 @@ from pyfaf.queries import (get_report,
                            get_crashed_package_for_report,
                            get_crashed_unknown_package_nevr_for_report
                           )
-from pyfaf import ureport
+from pyfaf import queries, ureport
 from pyfaf.opsys import systems
 from pyfaf.bugtrackers import bugtrackers
 from pyfaf.config import paths
@@ -59,7 +67,7 @@ from pyfaf.ureport import ureport2
 from pyfaf.solutionfinders import find_solution
 from pyfaf.common import FafError
 from pyfaf.problemtypes import problemtypes
-from pyfaf import queries
+from pyfaf.utils.json import FAFJSONEncoder
 from webfaf.utils import (Pagination,
                           diff as seq_diff,
                           InvalidUsage,
@@ -305,7 +313,9 @@ def items():
         if report is not None:
             data[report_hash] = item(report.id, True)
 
-    return jsonify(data)
+    return Response(response=json.dumps(data, cls=FAFJSONEncoder),
+                    status=200,
+                    mimetype="application/json")
 
 
 @reports.route("/get_hash/", endpoint="get_hash")
@@ -613,7 +623,9 @@ def item(report_id, want_object=False):
         return forward
 
     if request_wants_json():
-        return jsonify(forward)
+        return Response(response=json.dumps(forward, cls=FAFJSONEncoder),
+                        status=200,
+                        mimetype="application/json")
 
     forward["is_maintainer"] = is_maintainer
     forward["extfafs"] = get_external_faf_instances(db)


### PR DESCRIPTION
Currently, a dictionary is being passed to jsonify() from Flask that
includes an array of Solution objects (if any exist). The result is a
TypeError, because Python classes are not JSON-serializable, hence the
need to take \_\_dict\_\_ first. Moreover, the “since” attribute of type
datetime.datetime needs to be stringified, because it’s also not
JSON-serializable.