### PR TITLE
pyfaf: Accommodate for multiple debug directories

### DIFF
--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -235,9 +235,10 @@ class CoredumpProblem(ProblemType):
         self.log_warn("Report #{0} has no crash thread".format(db_report.id))
         return None
 
-    def _get_file_name_from_build_id(self, build_id):
-        return "/usr/lib/debug/.build-id/{0}/{1}.debug".format(build_id[:2],
-                                                               build_id[2:])
+    def _build_id_to_debug_files(self, build_id):
+        return ["/usr/lib/debug/.build-id/{0}/{1}.debug".format(build_id[:2],
+                                                                build_id[2:]),
+                "/usr/lib/.build-id/{0}/{1}".format(build_id[:2], build_id[2:])]
 
     def validate_ureport(self, ureport):
         # Frames calling JIT compiled functions usually do not contain
@@ -469,9 +470,9 @@ class CoredumpProblem(ProblemType):
 
     def find_packages_for_ssource(self, db, db_ssource):
         self.log_debug("Build-id: %d", db_ssource.build_id)
-        filename = self._get_file_name_from_build_id(db_ssource.build_id)
-        self.log_debug("File name: %s", filename)
-        db_debug_package = get_package_by_file(db, filename)
+        files = self._build_id_to_debug_files(db_ssource.build_id)
+        self.log_debug("File names: %s", ', '.join(files))
+        db_debug_package = get_package_by_file(db, files)
         if db_debug_package is None:
             debug_nvra = "Not found"
         else:

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -620,7 +620,7 @@ class KerneloopsProblem(ProblemType):
                 debug_dirs = [os.path.join(task.debuginfo.unpacked_path,
                                            "usr", "lib", "debug"),
                               os.path.join(task.debuginfo.unpacked_path,
-                                           "usr/lib")]
+                                           "usr", "lib")]
                 debug_path = self._get_debug_path(db, module,
                                                   task.debuginfo.db_package)
                 if debug_path is None:

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -618,7 +618,7 @@ class KerneloopsProblem(ProblemType):
                     address = module_map[symbol_name] + db_ssource.func_offset
 
                 debug_dirs = [os.path.join(task.debuginfo.unpacked_path,
-                                           "usr/lib/debug"),
+                                           "usr", "lib", "debug"),
                               os.path.join(task.debuginfo.unpacked_path,
                                            "usr/lib")]
                 debug_path = self._get_debug_path(db, module,

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -617,8 +617,10 @@ class KerneloopsProblem(ProblemType):
 
                     address = module_map[symbol_name] + db_ssource.func_offset
 
-                debug_dir = os.path.join(task.debuginfo.unpacked_path,
-                                         "usr", "lib", "debug")
+                debug_dirs = [os.path.join(task.debuginfo.unpacked_path,
+                                           "usr/lib/debug"),
+                              os.path.join(task.debuginfo.unpacked_path,
+                                           "usr/lib")]
                 debug_path = self._get_debug_path(db, module,
                                                   task.debuginfo.db_package)
                 if debug_path is None:
@@ -628,7 +630,7 @@ class KerneloopsProblem(ProblemType):
                 try:
                     abspath = os.path.join(task.debuginfo.unpacked_path,
                                            debug_path[1:])
-                    results = addr2line(abspath, address, debug_dir)
+                    results = addr2line(abspath, address, ':'.join(debug_dirs))
                     results.reverse()
                 except FafError as ex:
                     self.log_debug("addr2line failed: %s", str(ex))

--- a/src/pyfaf/queries.py
+++ b/src/pyfaf/queries.py
@@ -490,23 +490,23 @@ def get_packages_by_osrelease(db, name, version, arch):
             .all())
 
 
-def get_package_by_file(db, filename):
+def get_package_by_file(db, filenames):
     """
-    Return pyfaf.storage.Package object providing the file named `filename`
-    or None if not found.
+    Return pyfaf.storage.Package object providing one of the files
+    listed in `filenames` or None if not found.
     """
 
     return (db.session.query(st.Package)
             .join(st.PackageDependency)
-            .filter(st.PackageDependency.name == filename)
+            .filter(st.PackageDependency.name.in_(filenames))
             .filter(st.PackageDependency.type == "PROVIDES")
             .first())
 
 
 def get_packages_by_file(db, filenames):
     """
-    Return a list of pyfaf.storage.Package objects
-    providing the file named `filename`.
+    Return a list of all pyfaf.storage.Package objects
+    providing the files listed in `filenames`.
     """
 
     return (db.session.query(st.Package)


### PR DESCRIPTION
A change was introduced in Fedora 27 to allow for installing multiple versions of debuginfo packages in parallel. In effect, `/usr/lib/.build-id` may contain debug files, as well, in addition to `/usr/lib/debug/.build-id`.

See https://fedoraproject.org/wiki/Changes/ParallelInstallableDebuginfo for more details.

Related: abrt/abrt#1462, abrt/abrt#1463, abrt/libreport#606