### PR TITLE
Fix local Dockerfile build for tito changes

### DIFF
--- a/container/Dockerfile_local
+++ b/container/Dockerfile_local
@@ -24,8 +24,7 @@ USER faf
 ENV HOME /faf
 
 # Build faf
-RUN sed -i '/^pylint/s/$/ ||:/' faf.spec && \
-    tito build --rpm --test
+RUN tito build --rpm --test
 
 #And continue as root
 USER 0

--- a/container/Dockerfile_local
+++ b/container/Dockerfile_local
@@ -13,9 +13,9 @@ WORKDIR '/faf'
 # Change owner of /faf, clean git and install dependences
 RUN chown -R --silent faf /faf && \
     chmod -R --silent g=u /faf && \
-    dnf -y install rpm-build sudo git which vim make &&  \
+    dnf -y install git-core make rpm-build sudo tito vim which && \
     git clean -dfx && \
-    eval dnf -y --setopt=strict=0 --setopt=tsflags=nodocs install $(./autogen.sh sysdeps) && \
+    dnf -y --setopt=strict=0 --setopt=tsflags=nodocs builddep faf.spec && \
     dnf clean all
 
 # Build as non root
@@ -24,15 +24,14 @@ USER faf
 ENV HOME /faf
 
 # Build faf
-RUN sed -i '/^pylint/s/$/ ||:/' faf.spec.in && \
-    ./autogen.sh && \
-    make rpm
+RUN sed -i '/^pylint/s/$/ ||:/' faf.spec && \
+    tito build --rpm --test
 
 #And continue as root
 USER 0
 
 # Update ABRT Analytics (FAF)
-RUN rpm -Uvh noarch/faf-* && \
+RUN rpm -Uvh /tmp/tito/noarch/faf-* && \
     sed -i -e"s/everyone_is_admin\s*=\s*false/everyone_is_admin = true/i" /etc/faf/plugins/web.conf && \
     echo 'Defaults    env_keep = "PGHOST PGUSER PGPASSWORD PGPORT PGDATABASE RDSBROKER RDSBACKEND"' >> /etc/sudoers.d/faf && \
     /usr/libexec/fix-permissions /faf && \

--- a/container/Dockerfile_local
+++ b/container/Dockerfile_local
@@ -4,17 +4,17 @@ ENV TERM=linux
 
 USER root
 
+# install devel tools
+RUN dnf -y install git-core make rpm-build sudo tito vim which
+
 # Copy sources to the docker image
-COPY . /faf
+COPY --chown=faf:faf . /faf
 
 # From not on work from faf directory
 WORKDIR '/faf'
 
 # Change owner of /faf, clean git and install dependences
-RUN chown -R --silent faf /faf && \
-    chmod -R --silent g=u /faf && \
-    dnf -y install git-core make rpm-build sudo tito vim which && \
-    git clean -dfx && \
+RUN git clean -dfx && \
     dnf -y --setopt=strict=0 --setopt=tsflags=nodocs builddep faf.spec && \
     dnf clean all
 

--- a/container/Dockerfile_local
+++ b/container/Dockerfile_local
@@ -1,4 +1,6 @@
 FROM abrt/faf-image
+# rhbz#1733043 workaround
+ENV TERM=linux
 
 USER root
 


### PR DESCRIPTION
#### Issue 1:
tito crashed with `_curses.error: setupterm: could not find terminal`
during the Dockerfile build.

Specifying TERM env variable works around the issue.

bugzilla:
bugzilla.redhat.com/show_bug.cgi?id=1733043

#### Issue 2:
- Install tito for build
- Use dnf builddep to install dependencies
- Change paths to rpms