### PR TITLE
container: db: Upgrade to Fedora 31

### DIFF
--- a/container/Dockerfile_db
+++ b/container/Dockerfile_db
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f29/postgresql
+FROM registry.fedoraproject.org/f31/postgresql
 
 USER root
 


### PR DESCRIPTION
New postgresql image:
https://bodhi.fedoraproject.org/updates/FEDORA-CONTAINER-2020-9b4488f9fe

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>