### PR TITLE
opsys: Filter releases without numbered verion

### DIFF
--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -241,6 +241,10 @@ class Fedora(System):
         for release in response:
             ver = release["version"].lower()
 
+            # only accept Fedora version with decimals (or rawhide)
+            if not ver.isdecimal() and ver != "rawhide":
+                continue
+
             if self._is_ignored(ver):
                 continue
 


### PR DESCRIPTION
Product listings[0] for Fedora include releases that do not exist:
```
Fedora l
Fedora ln
Fedora pel7
Fedora pel8
```

This commit check if the version is a number (or rawhide) and skips
entries where this is not true.

Example of entry pulled from PDC:
```json
{
  "release_id": "fedora-30",
  "short": "fedora",
  "version": "30",
  "name": "Fedora",
  "base_product": null,
  "active": true,
  "product_version": "fedora-30",
  "release_type": "ga",
  "compose_set": [..],
  "integrated_with": null,
  "sigkey": null,
  "allow_buildroot_push": false,
  "allowed_debuginfo_services": [],
  "allowed_push_targets": [],
  "bugzilla": null,
  "dist_git": null
}
```
[0] https://pdc.fedoraproject.org/rest_api/v1/releases/?page_size=-1&short=fedora