### PR TITLE
webfaf: reports: Don’t call download_bug_to_storage_no_retry()

### DIFF
--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -663,7 +663,7 @@ def associate_bug(report_id):
                 tracker = bugtrackers[form.bugtracker.data]
 
                 try:
-                    bug = tracker.download_bug_to_storage_no_retry(db, bug_id)
+                    bug = tracker.download_bug_to_storage(db, bug_id)
                 except Exception as e: #pylint: disable=broad-except
                     flash("Failed to fetch bug. {0}".format(str(e)), "danger")
                     return redirect(url_for("reports.associate_bug",


### PR DESCRIPTION
It is not part of the BugTracker interface and is not implemented by
Mantis. I’m not sure if taking the no-retry route was intentional,
however, so this commit assumes that it was a thinko.

Related to https://github.com/abrt/faf/issues/909.