### PR TITLE
webfaf: Disassociate bug from report

### DIFF
--- a/src/webfaf/forms.py
+++ b/src/webfaf/forms.py
@@ -335,6 +335,10 @@ class AssociateBzForm(Form):
         (name, name) for name in bugtrackers])
 
 
+class DissociateBzForm(Form):
+    bug_id = BugIdField("Bug ID")
+
+
 class ProblemComponents(Form):
     component_names = StringField()
     submit = SubmitField("Reassign")

--- a/src/webfaf/static/css/style.css
+++ b/src/webfaf/static/css/style.css
@@ -1535,3 +1535,12 @@ li.empty-line:last-child {
   align-self: center;
   margin-top: 0.5em;
 }
+
+.external-bgz-btn {
+  padding-left: 0px !important;
+}
+
+button + .external-bgz-btn {
+  padding-left: 5px !important;
+  margin-right: 5px;
+}

--- a/src/webfaf/templates/_helpers.html
+++ b/src/webfaf/templates/_helpers.html
@@ -273,7 +273,7 @@
     {% if add_delete_btn %}
     <button class="btn btn-danger" data-toggle="modal" data-target="#delBzBugModal" data-bugid="{{ bug.id }}"><span class="pficon pficon-delete"></span></button>
     {% endif %}
-    <a class="btn btn-light"
+    <a class="btn btn-link external-bgz-btn"
       title="{{ bug.status }}{% if bug.status == "CLOSED" %} {{ bug.resolution }}{% endif %}: {{ bug.summary }}"
       href="{{ bug.url }}">{% if bug.status == "CLOSED" %}<del>{{ bug }}</del>{% else %}{{ bug }}{% endif %}
     </a>

--- a/src/webfaf/templates/_helpers.html
+++ b/src/webfaf/templates/_helpers.html
@@ -267,12 +267,53 @@
 {%- endmacro %}
 
 
-{% macro external_bugs(bugs) -%}
+{% macro external_bugs(associated_id, bugs, add_delete_btn=false) -%}
 {% for bug in bugs %}
-  <a
-    title="{{ bug.status }}{% if bug.status == "CLOSED" %} {{ bug.resolution }}{% endif %}: {{ bug.summary }}"
-    href="{{ bug.url }}">{% if bug.status == "CLOSED" %}<del>{{ bug }}</del>{% else %}{{ bug }}{% endif %}</a>
+  <div class="btn-group btn-group-xs" role="group">
+    {% if add_delete_btn %}
+    <button class="btn btn-danger" data-toggle="modal" data-target="#delBzBugModal" data-bugid="{{ bug.id }}"><span class="pficon pficon-delete"></span></button>
+    {% endif %}
+    <a class="btn btn-light"
+      title="{{ bug.status }}{% if bug.status == "CLOSED" %} {{ bug.resolution }}{% endif %}: {{ bug.summary }}"
+      href="{{ bug.url }}">{% if bug.status == "CLOSED" %}<del>{{ bug }}</del>{% else %}{{ bug }}{% endif %}
+    </a>
+  </div>
 {% endfor %}
+{% if add_delete_btn %}
+<div class="modal fade" id="delBzBugModal" tabindex="-1" role="dialog" aria-labelledby="maildata-modal"
+  aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h1 class="modal-title" id="maildata-modal">Dissociate bug</h1>
+      </div>
+      <div class="modal-body"></div>
+      <div class="modal-footer">
+        <form class="form-inline" enctype="multipart/form-data"
+          action="{{ url_for('reports.dissociate_bug', report_id=associated_id) }}" method="POST">
+          <input type="hidden" class="form-control" id="bug_id" name="bug_id" type="text" value="">
+          <button type="submit" class="btn btn-primary">Proceed</button>
+          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript">
+  $('#delBzBugModal').on('show.bs.modal', function (event) {
+    var button = $(event.relatedTarget) // Button that triggered the modal
+    var bugID = button.data('bugid') // Extract info from data-* attributes
+    var modal = $(this)
+    modal.find('.modal-title').text('Dissociate bug #' + bugID)
+    modal.find('.modal-body').text('Do you really want to dissociate bug #' + bugID + ' from the report?')
+    modal.find('.modal-footer form input').val(bugID)
+  })
+</script>
+{% endif %}
 {%- endmacro %}
 
 {% macro external_urls(urls) -%}

--- a/src/webfaf/templates/problems/item.html
+++ b/src/webfaf/templates/problems/item.html
@@ -101,7 +101,7 @@ Problem #{{ problem.id }} -
         <dd class="hide">{{ problem.quality }}</dd>
         {% if problem.bugs %}
           <dt>External bugs</dt>
-          <dd>{{ external_bugs(problem.bugs) }}</dd>
+          <dd>{{ external_bugs(problem.id, problem.bugs, false) }}</dd>
         {% endif %}
 
         {% if problem.urls %}

--- a/src/webfaf/templates/problems/list_table_rows.html
+++ b/src/webfaf/templates/problems/list_table_rows.html
@@ -28,7 +28,7 @@
       </span>
     </td>
     <td>
-      {{ external_bugs(problem.bugs) }}
+      {{ external_bugs(problem.id, problem.bugs, false) }}
     </td>
     <td>
       {%- if problem.probable_fixes %}

--- a/src/webfaf/templates/reports/item.html
+++ b/src/webfaf/templates/reports/item.html
@@ -112,7 +112,7 @@
           {% if report.bugs %}
             <dt>External bugs</dt>
             <dd>
-              {{ external_bugs(report.bugs) }}
+              {{ external_bugs(report.id, report.bugs, is_maintainer) }}
             </dd>
           {% endif %}
           {% if contact_emails %}


### PR DESCRIPTION
**What's the problem?**
Right now there is no way how to dissociate a bug from report that was
added by mistake.
    
**How does this commit help?**
This commit adds a small button (trashcan) in front of links to
bugzillas. The button is only available (visible) to component maintainers.
They can use it to dissociate bugs from reports. Modal window appears after
clicking on the trashcan to confirm dissociation action.

<h1>Screenshots:</h1>

Button appears when report has an associated bug:
![Button appears when report has an associated bug:](https://user-images.githubusercontent.com/24898105/84604097-e4c89e80-ae93-11ea-999d-64bb23ae6849.png)

Modal after clicking on trashcan:
![Modal after clicking on trashcan](https://user-images.githubusercontent.com/24898105/84604102-ee520680-ae93-11ea-9c20-0c04643828e3.png)

Bug dissociated successfuly:
![Bug dissociated successfuly](https://user-images.githubusercontent.com/24898105/84604112-06c22100-ae94-11ea-8dd8-43a8425e032d.png)

External bugs on Problem list page:
![External bugs on Problem list page](https://user-images.githubusercontent.com/24898105/84604118-18a3c400-ae94-11ea-8ca6-49d08a474936.png)


Fixes: #599

