### PR TITLE
pyfaf: core: Use correct format specifier

### DIFF
--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -469,7 +469,7 @@ class CoredumpProblem(ProblemType):
         return q
 
     def find_packages_for_ssource(self, db, db_ssource):
-        self.log_debug("Build-id: %d", db_ssource.build_id)
+        self.log_debug("Build-id: %s", db_ssource.build_id)
         files = self._build_id_to_debug_files(db_ssource.build_id)
         self.log_debug("File names: %s", ', '.join(files))
         db_debug_package = get_package_by_file(db, files)


### PR DESCRIPTION
SymbolSource.build_id is a string. Fallout from
a3e43889b2db7fe5a393ec6ffc6c84a28c0f0a36.

Fixes https://github.com/abrt/faf/issues/910