### PR TITLE
repos: dnf: Correctly handle debug packages

### DIFF
--- a/src/pyfaf/repos/dnf.py
+++ b/src/pyfaf/repos/dnf.py
@@ -102,8 +102,13 @@ class Dnf(Repo):
         pkgs = packagelist.available()
 
         for package in pkgs:
+            base_name = package.name
+            for suffix in (package.DEBUGINFO_SUFFIX, package.DEBUGSOURCE_SUFFIX):
+                if package.name.endswith(suffix):
+                    base_name = package.name[:-len(suffix)]
+                    break
             pkg = dict(name=package.name,
-                       base_package_name=package.name,
+                       base_package_name=base_name,
                        epoch=package.epoch,
                        version=package.version,
                        release=package.release,


### PR DESCRIPTION
5508c07b919a159e56acaad0bd192e02297152b8 completely ignored the problem
of base package names, resulting in debuginfo and debugsource packages
having distinct builds in the database and breaking retracing. While
there is no longer a property in DNF that spits out the base name, we
can use the class attributes and strip the suffixes as needed. This
commit does just that.

Fixes https://github.com/abrt/faf/issues/919