### PR TITLE
"duplicate of" mantis bug relationships can be empty

### DIFF
--- a/src/pyfaf/bugtrackers/mantisbt.py
+++ b/src/pyfaf/bugtrackers/mantisbt.py
@@ -153,7 +153,7 @@ class Mantis(BugTracker):
             return None
 
         if bug_dict["resolution"] == "DUPLICATE":
-            for relationship in bug.relationships:
+            for relationship in bug.relationships or []:
                 if relationship.type.name == "duplicate of":
                     bug_dict["dupe_id"] = relationship.target_id
                     break


### PR DESCRIPTION
Not sure how to fully test this as building the container image still generates an image without these changes.

I am trying to build it with `podman build -f container/Dockerfile ./`

EDIT: 
```
cd faf/container
make build
```
My bad