### PR TITLE
logging: Fix log formatting for build logs

### DIFF
--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -142,7 +142,7 @@ class RepoSync(Action):
                          .first())
 
                 if not build:
-                    self.log_debug("Adding build %s-%d", pkg["base_package_name"], pkg["version"])
+                    self.log_debug("Adding build %s-%s", pkg["base_package_name"], pkg["version"])
 
                     build = Build()
                     build.base_package_name = pkg["base_package_name"]


### PR DESCRIPTION
Build class has `version` as a String on https://github.com/abrt/faf/blob/1d3ccf592161be3665c1e7573b81dfb7be0c912b/src/pyfaf/storage/opsys.py#L188 but on logging is treated as a digit.

Logging while using rpmmetadata repo types was causing this:

```
[2020-06-12 10:30:23] DEBUG:faf.pyfaf.faf_rpm: qemu-kvm-common-ev-2.12.0-44.1.el7_8.1.x86_64 contains 139 files
[2020-06-12 10:30:23] DEBUG:faf.RepoSync: [3 / 8] Processing package qemu-kvm-common-ev
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib64/python3.8/logging/__init__.py", line 1081, in emit
    msg = self.format(record)
  File "/usr/lib64/python3.8/logging/__init__.py", line 925, in format
    return fmt.format(record)
  File "/usr/lib64/python3.8/logging/__init__.py", line 664, in format
    record.message = record.getMessage()
  File "/usr/lib64/python3.8/logging/__init__.py", line 369, in getMessage
    msg = msg % self.args
TypeError: %d format: a number is required, not str
Call stack:
  File "/usr/bin/faf", line 152, in <module>
    main()
  File "/usr/bin/faf", line 132, in main
    exitcode = cmdline.func(cmdline, db)
  File "/usr/lib/python3.8/site-packages/pyfaf/actions/reposync.py", line 145, in run
    self.log_debug("Adding build %s-%d", pkg["base_package_name"], pkg["version"])
Message: 'Adding build %s-%d'
Arguments: ('qemu-kvm-ev', '2.10.0')
[2020-06-12 10:30:23] INFO:faf.RepoSync: Adding link between build qemu-kvm-ev-2.10.0 operating system 'CentOS', release '7 and architecture x86_64
```