### PR TITLE
Werkzeug 1.0 migration

### DIFF
--- a/faf.spec
+++ b/faf.spec
@@ -53,15 +53,15 @@ BuildRequires: python3-zeep
 BuildRequires: python3-argcomplete
 
 # webui
+BuildRequires: python3-dateutil
 BuildRequires: python3-flask
-BuildRequires: python3-flask-wtf
 BuildRequires: python3-flask-openid
-BuildRequires: python3-openid-teams
 BuildRequires: python3-flask-sqlalchemy
+BuildRequires: python3-flask-wtf
 BuildRequires: python3-jinja2
 BuildRequires: python3-markdown2
 BuildRequires: python3-munch
-BuildRequires: python3-dateutil
+BuildRequires: python3-openid-teams
 BuildRequires: python3-ratelimitingfilter
 
 BuildRequires: xstatic-patternfly-common

--- a/faf.spec
+++ b/faf.spec
@@ -53,6 +53,7 @@ BuildRequires: python3-zeep
 BuildRequires: python3-argcomplete
 
 # webui
+BuildRequires: python3-cachelib
 BuildRequires: python3-dateutil
 BuildRequires: python3-flask
 BuildRequires: python3-flask-openid
@@ -63,6 +64,7 @@ BuildRequires: python3-markdown2
 BuildRequires: python3-munch
 BuildRequires: python3-openid-teams
 BuildRequires: python3-ratelimitingfilter
+BuildRequires: python3-werkzeug
 
 BuildRequires: xstatic-patternfly-common
 BuildRequires: js-jquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic ~= 1.3.1
 argcomplete ~= 1.10.0
+cachelib ~= 0.1.1
 celery ~= 4.3.0
 fedora-messaging ~= 2.0.1
 flask ~= 1.1.1
@@ -13,6 +14,6 @@ python-bugzilla ~= 2.3.0
 python-openid-teams ~= 1.1
 ratelimitingfilter ~= 1.1
 SQLAlchemy ~= 1.3.13
-Werkzeug ~= 0.16.0
+Werkzeug ~= 1.0.1
 WTForms ~= 2.2.1
 zeep ~= 3.4.0

--- a/src/webfaf/webfaf_main.py
+++ b/src/webfaf/webfaf_main.py
@@ -3,15 +3,15 @@ import logging
 from logging.handlers import SMTPHandler
 import json
 
-from ratelimitingfilter import RateLimitingFilter
-import markdown2
-import munch
+from cachelib import MemcachedCache, NullCache, SimpleCache
 import flask
 from flask import Flask, Response, current_app, send_from_directory
 from flask_sqlalchemy import SQLAlchemy
-from werkzeug.contrib.fixers import ProxyFix
+import markdown2
+import munch
+from ratelimitingfilter import RateLimitingFilter
 from werkzeug.local import LocalProxy
-from werkzeug.contrib.cache import MemcachedCache, SimpleCache, NullCache
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from pyfaf.storage.user import User
 from pyfaf.storage import OpSysComponent, Report


### PR DESCRIPTION
Werkzeug's `contrib.cache` and `contrib.fixers` have been deprecated since 0.15 and removed in 1.0. This PR updates the imports to reflect these changes in the API.

A new dependency, `python3-cachelib`, is added to the spec file as well as an an explicit dependency on `python3-werkzeug`.

Resolves #905