### PR TITLE
readme: Fix link to devel build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ You can read more about the technical aspects of ABRT at our documentation site:
 
 Nightly builds of ABRT Analytics can be obtained from these repositories:
 
- * Fedora, EPEL: https://copr.fedorainfracloud.org/coprs/g/abrt/faf-devel/
+ * Fedora, EPEL: https://copr.fedorainfracloud.org/coprs/g/abrt/faf-el8-devel/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ABRT Analytics
 
-[![Build status](https://copr.fedorainfracloud.org/coprs/g/abrt/faf-devel/package/faf/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/g/abrt/faf-devel/package/faf/)
+[![Build status](https://copr.fedorainfracloud.org/coprs/g/abrt/faf-el8-devel/package/faf/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/g/abrt/faf-el8-devel/package/faf/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/abrt/faf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/abrt/faf/context:python)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/abrt/faf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/abrt/faf/alerts/)
 


### PR DESCRIPTION
IIRC the `faf-devel` COPR repository was deleted and replaced with
`faf-el8-devel`.