### PR TITLE
container: Make configuration files writable by root group

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -61,7 +61,8 @@ RUN sed -i -e"s/CreateComponents\s*=\s*False/CreateComponents = True/i" /etc/faf
     /usr/libexec/fix-permissions /run/uwsgi && \
     /usr/libexec/fix-permissions /run/faf-celery && \
     /usr/libexec/fix-permissions /var/log/faf && \
-    /usr/libexec/fix-permissions /var/spool/faf
+    /usr/libexec/fix-permissions /var/spool/faf && \
+    /usr/libexec/fix-permissions /etc/faf/
 
 VOLUME /var/spool/faf
 

--- a/container/Dockerfile_local
+++ b/container/Dockerfile_local
@@ -36,7 +36,8 @@ RUN rpm -Uvh /tmp/tito/noarch/faf-* && \
     /usr/libexec/fix-permissions /faf && \
     /usr/libexec/fix-permissions /run/faf-celery && \
     /usr/libexec/fix-permissions /var/log/faf && \
-    /usr/libexec/fix-permissions /var/spool/faf
+    /usr/libexec/fix-permissions /var/spool/faf && \
+    /usr/libexec/fix-permissions /etc/faf/
 
 #Switch workdir back to /
 WORKDIR '/'


### PR DESCRIPTION
With rootless containers, the configuration is essentially immutable.
That can be worked around by making it group-writable (the faf user will
have membership of the root group).

Closes https://github.com/abrt/faf/issues/918