### PR TITLE
pyfaf: problemtypes: core: Don’t ASCII-encode file names

### DIFF
--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -307,9 +307,7 @@ class CoredumpProblem(ProblemType):
             if i >= self.hashframes:
                 break
 
-            hashbase.append("{0} @ {1}".format(
-                frame[key],
-                frame["file_name"].encode("ascii", "ignore")))
+            hashbase.append("{0} @ {1}".format(frame[key], frame["file_name"]))
 
         return hash_list(hashbase)
 

--- a/tests/sample_reports/d856f816-6fad-46a3-baea-53673646bb72
+++ b/tests/sample_reports/d856f816-6fad-46a3-baea-53673646bb72
@@ -1,0 +1,77 @@
+{   "ureport_version": 2
+,   "reason": "Program /usr/bin/sleep was terminated by signal 11"
+,   "reporter": {   "name": "satyr"
+                ,   "version": "0.30"
+                }
+,   "os": {   "name": "fedora"
+          ,   "version": "32"
+          ,   "architecture": "x86_64"
+          ,   "cpe": "cpe:/o:fedoraproject:fedora:32"
+          ,   "variant": "server"
+          }
+,   "problem": {   "type": "core"
+               ,   "component": "coreutils"
+               ,   "user": {   "root": false
+                           ,   "local": true
+                           }
+               ,   "serial": 1
+               ,   "signal": 11
+               ,   "executable": "/usr/bin/sleep"
+               ,   "stacktrace":
+                     [ {   "crash_thread": true
+                       ,   "frames":
+                             [ {   "address": 140426730747822
+                               ,   "build_id": "d278249792061c6b74d1693ca59513be1def13f2"
+                               ,   "build_id_offset": 821166
+                               ,   "function_name": "clock_nanosleep@@GLIBC_2.17"
+                               ,   "file_name": "/lib64/libc.so.6"
+                               }
+                             , {   "address": 140426730770775
+                               ,   "build_id": "d278249792061c6b74d1693ca59513be1def13f2"
+                               ,   "build_id_offset": 844119
+                               ,   "function_name": "__nanosleep"
+                               ,   "file_name": "/lib64/libc.so.6"
+                               }
+                             , {   "address": 94575119272551
+                               ,   "build_id": "33a809d02477a2b537166fb4d8774158541231bf"
+                               ,   "build_id_offset": 23143
+                               ,   "function_name": "rpl_nanosleep"
+                               ,   "file_name": "/usr/bin/sleep"
+                               }
+                             , {   "address": 94575119271977
+                               ,   "build_id": "33a809d02477a2b537166fb4d8774158541231bf"
+                               ,   "build_id_offset": 22569
+                               ,   "function_name": "xnanosleep"
+                               ,   "file_name": "/usr/bin/sleep"
+                               }
+                             , {   "address": 94575119259632
+                               ,   "build_id": "33a809d02477a2b537166fb4d8774158541231bf"
+                               ,   "build_id_offset": 10224
+                               ,   "function_name": "main"
+                               ,   "file_name": "/usr/bin/sleep"
+                               } ]
+                       } ]
+               }
+,   "packages": [ {   "name": "coreutils"
+                  ,   "epoch": 0
+                  ,   "version": "8.32"
+                  ,   "release": "4.fc32.1"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1600079051
+                  ,   "package_role": "affected"
+                  }
+                , {   "name": "glibc"
+                  ,   "epoch": 0
+                  ,   "version": "2.31"
+                  ,   "release": "4.fc32"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1600079013
+                  }
+                , {   "name": "glibc-langpack-lt"
+                  ,   "epoch": 0
+                  ,   "version": "2.31"
+                  ,   "release": "4.fc32"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1600079013
+                  } ]
+}

--- a/tests/sample_reports/unikhod_failnejm
+++ b/tests/sample_reports/unikhod_failnejm
@@ -1,0 +1,65 @@
+{   "ureport_version": 2
+,   "reason": "Program /usr/bin/sleep was terminated by signal 11"
+,   "reporter": {   "name": "satyr"
+                ,   "version": "0.30"
+                }
+,   "os": {   "name": "fedora"
+          ,   "version": "32"
+          ,   "architecture": "x86_64"
+          ,   "cpe": "cpe:/o:fedoraproject:fedora:32"
+          ,   "variant": "server"
+          }
+,   "problem": {   "type": "core"
+               ,   "component": "coreutils"
+               ,   "user": {   "root": false
+                           ,   "local": true
+                           }
+               ,   "serial": 1
+               ,   "signal": 11
+               ,   "executable": "/usr/bin/sleep"
+               ,   "stacktrace":
+                     [ {   "crash_thread": true
+                       ,   "frames":
+                             [ {   "address": 140426730747822
+                               ,   "build_id": "d278249792061c6b74d1693ca59513be1def13f2"
+                               ,   "build_id_offset": 821166
+                               ,   "function_name": "clock_nanosleep@@GLIBC_2.17"
+                               ,   "file_name": "Č:¥Wíňďowš¥šýšťém32¥řéǧšvř32.dll"
+                               }
+                             , {   "address": 140426730770775
+                               ,   "build_id": "d278249792061c6b74d1693ca59513be1def13f2"
+                               ,   "build_id_offset": 844119
+                               ,   "function_name": "__nanosleep"
+                               ,   "file_name": "C:¥Windows¥system32¥user32.dll"
+                               }
+                             , {   "address": 94575119259632
+                               ,   "build_id": "33a809d02477a2b537166fb4d8774158541231bf"
+                               ,   "build_id_offset": 10224
+                               ,   "function_name": "main"
+                               ,   "file_name": "Ｃ：:¥Ｐｒｏｇｒａｍ Ｆｉｌｅｓ¥Ｈａｌｆ−Ｌｉｆｅ¥ｈｌ．ｅｘｅ"
+                               } ]
+                       } ]
+               }
+,   "packages": [ {   "name": "coreutils"
+                  ,   "epoch": 0
+                  ,   "version": "8.32"
+                  ,   "release": "4.fc32.1"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1600079051
+                  ,   "package_role": "affected"
+                  }
+                , {   "name": "glibc"
+                  ,   "epoch": 0
+                  ,   "version": "2.31"
+                  ,   "release": "4.fc32"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1600079013
+                  }
+                , {   "name": "glibc-langpack-lt"
+                  ,   "epoch": 0
+                  ,   "version": "2.31"
+                  ,   "release": "4.fc32"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1600079013
+                  } ]
+}

--- a/tests/test_webfaf/test_reports.py
+++ b/tests/test_webfaf/test_reports.py
@@ -104,14 +104,28 @@ class ReportTestCase(WebfafTestCase):
         Test saving of ureport version 2
         """
 
-        path = os.path.join(self.reports_path, 'ureport2')
-        with open(path) as file:
-            r = self.post_report(file.read())
+        cases = [
+            [
+                os.path.join(self.reports_path, "ureport2"),
+                "2dd542ba1f1e074216196b6c0bd548609bf38ebc",
+            ],
+            [
+                os.path.join(self.reports_path,
+                             "d856f816-6fad-46a3-baea-53673646bb72"),
+                "ae74a26cff6e6bb36b8997c0e4748cf4688dca2e",
+            ],
+            [
+                os.path.join(self.reports_path, "unikhod_failnejm"),
+                "e221c0322c5dfbf634d3609161f80efac97946bc",
+            ],
+        ]
+        for case in cases:
+            with open(case[0]) as file:
+                r = self.post_report(file.read())
 
-        js = json.loads(r.data)
-        self.assertEqual(js["result"], False)
-        self.assertEqual(js["bthash"],
-                         "2dd542ba1f1e074216196b6c0bd548609bf38ebc")
+            js = json.loads(r.data)
+            self.assertEqual(js["result"], False)
+            self.assertEqual(js["bthash"], case[1])
 
     def test_new_report_prefilter_solution(self):
         """


### PR DESCRIPTION
Currently, when building a list of symbol strings, the file name ends up
being converted to ASCII and added to a Unicode string, which somehow
results in the byte-literal prefix being stored verbatim, which further
results in inconsistent hashes for identical crash threads.

This commit drops the encoding bit.

Closes https://github.com/abrt/faf/issues/922