### PR TITLE
openshift: Fix docker image names

### DIFF
--- a/container/openshift/faf-database-template.yml
+++ b/container/openshift/faf-database-template.yml
@@ -49,9 +49,9 @@ objects:
   metadata:
     name: ${DB_SERVICE_NAME}
   spec:
-    dockerImageRepository: abrt/postgres-semver
+    dockerImageRepository: abrt/faf-db
   status:
-    dockerImageRepository: abrt/postgres-semver
+    dockerImageRepository: abrt/faf-db
 
 - apiVersion: v1
   kind: PersistentVolumeClaim
@@ -108,7 +108,7 @@ objects:
       spec:
         containers:
         - name: ${DB_SERVICE_NAME}
-          image: abrt/postgres-semver:latest
+          image: abrt/faf-db:latest
           imagePullPolicy: IfNotPresent
           env:
           - name: POSTGRESQL_ADMIN_PASSWORD

--- a/container/openshift/faf-template.yml
+++ b/container/openshift/faf-template.yml
@@ -23,9 +23,9 @@ objects:
   metadata:
     name: ${FAF_SERVICE_NAME}
   spec:
-    dockerImageRepository: abrt/faf-image
+    dockerImageRepository: abrt/faf
   status:
-    dockerImageRepository: abrt/faf-image
+    dockerImageRepository: abrt/faf
 
 - apiVersion: v1
   kind: Secret
@@ -84,7 +84,7 @@ objects:
       spec:
         containers:
         - name: ${FAF_SERVICE_NAME}
-          image: abrt/faf-image:latest
+          image: abrt/faf:latest
           env:
           - name: PGUSER
             valueFrom:


### PR DESCRIPTION
The container image names were renamed 4 months ago to `faf` and `faf-db`.

Fixes #944