### PR TITLE
addcompathashes: Remove import of hashlib

### DIFF
--- a/src/pyfaf/actions/addcompathashes.py
+++ b/src/pyfaf/actions/addcompathashes.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with faf.  If not, see <http://www.gnu.org/licenses/>.
 
-import hashlib
-
 from pyfaf.actions import Action
 from pyfaf.common import FafError
 from pyfaf.problemtypes import problemtypes


### PR DESCRIPTION
Commit [0] removed only usage of hashlib and pylint is now complaining about
unused import.

[0] https://github.com/abrt/faf/commit/75f0d64a8214d3f303434fb8dc3c1cfa0c9d0daf