### PR TITLE
container: Dockerfile: Fix dest arg to COPY

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -15,7 +15,7 @@ RUN tito build --rpm
 
 FROM fedora:32 as build
 USER root
-COPY --from=0 /tmp/tito/noarch/faf-*.rpm /tmp
+COPY --from=0 /tmp/tito/noarch/faf-*.rpm /tmp/
 RUN \
     dnf --assumeyes upgrade && \
     dnf --assumeyes install findutils uwsgi /tmp/faf-*.rpm && \
@@ -44,8 +44,8 @@ LABEL summary="$SUMMARY" \
       maintainer="ABRT devel team <abrt-devel-list@redhat.com>"
 
 # Copy main run script
-COPY container/files/usr/bin /usr/bin
-COPY container/files/usr/libexec /usr/libexec
+COPY container/files/usr/bin/* /usr/bin/
+COPY container/files/usr/libexec/* /usr/libexec/
 
 RUN sed -i -e"s/CreateComponents\s*=\s*False/CreateComponents = True/i" /etc/faf/faf.conf && \
     sed -i -e"s/type\s*=\s*simple/type = null/i" /etc/faf/plugins/web.conf && \

--- a/container/Dockerfile_local
+++ b/container/Dockerfile_local
@@ -8,7 +8,7 @@ USER root
 RUN dnf -y install git-core make rpm-build sudo tito vim which
 
 # Copy sources to the docker image
-COPY --chown=faf:faf . /faf
+COPY --chown=faf:faf . /faf/
 
 # From not on work from faf directory
 WORKDIR '/faf'


### PR DESCRIPTION
When using `COPY` with more than one source file, the destination must be a directory and end with a `/`  
  
See latest [quay.io build](https://quay.io/repository/abrt/faf/build/787288ad-2879-4a2e-a90f-d2a424fda9ae).

Signed-off-by: Michal Fabik <mfabik@redhat.com>