### PR TITLE
Fix LOB saving issue

### DIFF
--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -784,7 +784,7 @@ def new() -> Union[Dict[str, bool], Tuple[str, int], str, Response]:
                     reporter = "{0} {1}".format(data["reporter"]["name"],
                                                 data["reporter"]["version"])
 
-                _save_invalid_ureport(db, json.dumps(data, indent=2),
+                _save_invalid_ureport(db, json.dumps(data, indent=2).encode('utf-8'),
                                       str(exp), reporter=reporter)
 
                 if ("os" in data and


### PR DESCRIPTION
- Encode the JSON of an invalid report to a bytestring before saving it as a LOB.
- Add typing annotations to all methods of `GenericTableBase`.
- Add casts where necessary.
- Improve an error message in `save_lob()` to report the name of the LOB.
- Fix minor issues reported by Pylint.

Resolves #954