### PR TITLE
Dockerfile_db: Update to f33/postgresql

### DIFF
--- a/container/Dockerfile_db
+++ b/container/Dockerfile_db
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f31/postgresql
+FROM registry.fedoraproject.org/f33/postgresql
 
 USER root
 


### PR DESCRIPTION
The pg-semver-0.30.0-1 package, the only version available for the
f31/postgresql docker image from registry.fedoraproject.org, which we're
using for the faf-db container, has the wrong default version 0.22.0 set
in `/usr/share/pgsql/extension/semver.control`, making it impossible to
create the extension and subsequently to run DB migrations and initialize
FAF.

~~This is just a temporary solution until the f32/postgresql image becomes
available.~~

See also https://github.com/theory/pg-semver/issues/53, the issue seems
to have been fixed upstream.

Signed-off-by: Michal Fabik <mfabik@redhat.com>