### PR TITLE
Fix deprecated Celery invocation with global options

### DIFF
--- a/config/celery-beat-env.conf
+++ b/config/celery-beat-env.conf
@@ -1,6 +1,6 @@
 CELERY_APP="pyfaf.celery_tasks.celery_app"
 CELERYD_NODES="beat"
-CELERYD_OPTS="-C -S pyfaf.celery_tasks.schedulers.DBScheduler"
+CELERYD_OPTS="-S pyfaf.celery_tasks.schedulers.DBScheduler"
 CELERYD_PID_FILE="/run/faf-celery/faf-celery-beat.pid"
 CELERYD_LOG_FILE="/var/log/faf/faf-celery-beat.log"
 CELERYD_LOG_LEVEL="INFO"

--- a/config/celery-worker-env.conf
+++ b/config/celery-worker-env.conf
@@ -1,6 +1,6 @@
 CELERY_APP="pyfaf.celery_tasks.celery_app"
 CELERYD_NODES="worker"
-CELERYD_OPTS="-C"
+CELERYD_OPTS=""
 CELERYD_PID_FILE="/run/faf-celery/faf-celery-%n.pid"
 CELERYD_LOG_FILE="/var/log/faf/faf-celery-%n.log"
 CELERYD_LOG_LEVEL="INFO"

--- a/container/files/usr/bin/faf-celery-beat
+++ b/container/files/usr/bin/faf-celery-beat
@@ -3,9 +3,10 @@
 source /etc/faf/celery-beat-env.conf
 
 start_beat () {
-        /usr/bin/python3 -m celery $CELERYD_NODES \
-        -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
-        --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+        /usr/bin/python3 -m celery -C -A $CELERY_APP $CELERYD_NODES \
+        --pidfile=${CELERYD_PID_FILE} \
+        --logfile=${CELERYD_LOG_FILE} \
+        --loglevel="${CELERYD_LOG_LEVEL}" \
         $CELERYD_OPTS &
 }
 

--- a/container/files/usr/bin/faf-celery-beat
+++ b/container/files/usr/bin/faf-celery-beat
@@ -3,7 +3,7 @@
 source /etc/faf/celery-beat-env.conf
 
 start_beat () {
-        /usr/bin/python3 -m celery -C -A $CELERY_APP $CELERYD_NODES \
+        /usr/bin/python3 -m celery -C -A $CELERY_APP beat \
         --pidfile=${CELERYD_PID_FILE} \
         --logfile=${CELERYD_LOG_FILE} \
         --loglevel="${CELERYD_LOG_LEVEL}" \

--- a/container/files/usr/bin/faf-celery-worker
+++ b/container/files/usr/bin/faf-celery-worker
@@ -4,9 +4,10 @@ source /etc/faf/celery-worker-env.conf
 
 case $1 in
 start)
-        /usr/bin/python3 -m celery multi start $CELERYD_NODES \
-        -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
-        --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+        /usr/bin/python3 -m celery -C -A $CELERY_APP multi start $CELERYD_NODES \
+        --pidfile=${CELERYD_PID_FILE} \
+        --logfile=${CELERYD_LOG_FILE} \
+        --loglevel="${CELERYD_LOG_LEVEL}" \
         $CELERYD_OPTS &
         ;;
 stop)
@@ -14,9 +15,10 @@ stop)
         --pidfile=${CELERYD_PID_FILE} &
         ;;
 reload)
-        /usr/bin/python3 -m celery multi restart $CELERYD_NODES \
-        -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-        --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+        /usr/bin/python3 -m celery -C -A $CELERY_APP multi restart $CELERYD_NODES \
+        --pidfile=${CELERYD_PID_FILE} \
+        --logfile=${CELERYD_LOG_FILE} \
+        --loglevel="${CELERYD_LOG_LEVEL}" \
         $CELERYD_OPTS &
         ;;
 esac

--- a/init-scripts/faf-celery-beat.service
+++ b/init-scripts/faf-celery-beat.service
@@ -7,9 +7,10 @@ User=faf
 Group=faf
 EnvironmentFile=/etc/faf/celery-beat-env.conf
 WorkingDirectory=/etc/faf
-ExecStart=/usr/bin/python3 -m celery beat \
-    -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
-    --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} \
+ExecStart=/usr/bin/python3 -m celery -C -A $CELERY_APP beat \
+    --pidfile=${CELERYD_PID_FILE} \
+    --logfile=${CELERYD_LOG_FILE} \
+    --loglevel=${CELERYD_LOG_LEVEL} \
     $CELERYD_OPTS
 PIDFile=${CELERYD_PID_FILE}
 

--- a/init-scripts/faf-celery-worker.service
+++ b/init-scripts/faf-celery-worker.service
@@ -8,15 +8,17 @@ User=faf
 Group=faf
 EnvironmentFile=/etc/faf/celery-worker-env.conf
 WorkingDirectory=/etc/faf
-ExecStart=/usr/bin/python3 -m celery multi start $CELERYD_NODES \
-    -A $CELERY_APP --pidfile=${CELERYD_PID_FILE} \
-    --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+ExecStart=/usr/bin/python3 -m celery -C -A ${CELERY_APP} multi start $CELERYD_NODES \
+    --pidfile=${CELERYD_PID_FILE} \
+    --logfile=${CELERYD_LOG_FILE} \
+    --loglevel="${CELERYD_LOG_LEVEL}" \
     $CELERYD_OPTS
 ExecStop=/usr/bin/python3 -m celery multi stopwait $CELERYD_NODES \
     --pidfile=${CELERYD_PID_FILE}
-ExecReload=/usr/bin/python3 -m celery multi restart $CELERYD_NODES \
-    -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
-    --logfile=${CELERYD_LOG_FILE} --loglevel="${CELERYD_LOG_LEVEL}" \
+ExecReload=/usr/bin/python3 -m celery -C -A ${CELERY_APP} multi restart $CELERYD_NODES \
+    --pidfile=${CELERYD_PID_FILE} \
+    --logfile=${CELERYD_LOG_FILE} \
+    --loglevel="${CELERYD_LOG_LEVEL}" \
     $CELERYD_OPTS
 
 [Install]


### PR DESCRIPTION
Celery 5.0 removed support of global options after sub-command.

Changes still work in older Celery versions (4.x is used in CentOS 8).

The error message from Celery 5.0:
You are using `-A` as an option of the beat sub-command:
celery beat -A celeryapp <...>
The support for this usage was removed in Celery 5.0. Instead you should use `-A` as a global option:
celery -A celeryapp beat <...>

See for more info:
https://docs.celeryproject.org/en/stable/whatsnew-5.0.html#step-1-adjust-your-command-line-invocation

## BONUS
You can run and schedule actions from frontend and even see the results:
![image](https://user-images.githubusercontent.com/24898105/98037098-5f7e6000-1e1b-11eb-8b42-2ed59ee1f332.png)

![image](https://user-images.githubusercontent.com/24898105/98037250-93598580-1e1b-11eb-958a-a35d98bbae27.png)
