### PR TITLE
webfaf: Add ad-hoc banner

### DIFF
--- a/config/plugins/web.conf
+++ b/config/plugins/web.conf
@@ -8,6 +8,8 @@ url = https://example.org/faf/
 server_name = example.org/faf
 brand_title = ABRT
 brand_subtitle = Analytics
+# A simple banner to notify users of scheduled downtime etc. Fill in text as needed, no text means no banner.
+banner =
 # uncomment the following two options to enable Fedmenu
 # fedmenu_url = https://apps.fedoraproject.org/fedmenu
 # fedmenu_data_url = https://apps.fedoraproject.org/js/data.js

--- a/src/webfaf/config.py
+++ b/src/webfaf/config.py
@@ -28,6 +28,7 @@ class Config(object):
     MAIL_FROM = config.get("mail.from", 'no-reply@' + MAIL_SERVER)
     BRAND_TITLE = config.get("hub.brand_title", "ABRT")
     BRAND_SUBTITLE = config.get("hub.brand_subtitle", "Analytics")
+    BANNER = config.get("hub.banner", "")
     CACHE_TYPE = config.get("cache.type", "simple")
     MEMCACHED_HOST = config.get("cache.memcached_host", None)
     MEMCACHED_PORT = config.get("cache.memcached_port", None)

--- a/src/webfaf/templates/base.html
+++ b/src/webfaf/templates/base.html
@@ -30,6 +30,11 @@
     {% endblock js %}
   </head>
   <body>
+      {% if config['BANNER'] %}
+      <div class="alert alert-danger">
+              <b>{{config.BANNER}}</b>
+      </div>
+      {% endif %}
       <div class="navbar navbar-default navbar-pf" role="navigation">
           <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">


### PR DESCRIPTION
Add a quick and dirty way of putting up a banner notifying all visiors
of scheduled maintenance and similar issues.

While I was adding the possible discontinuation notice to fafreport, I thought I migh as well make it general purpose for similar occasions.

Signed-off-by: Michal Fabik <mfabik@redhat.com>