### PR TITLE
README: Reference the container readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ including verification that the report doesn't contain sensitive data.
 You can read more about the technical aspects of ABRT at our documentation site:
 [http://abrt.readthedocs.org](http://abrt.readthedocs.org).
 
+### Deploy in a container
+The easiest way to deploy ABRT Analytics is in a container using podman images.
+Learn how to use and build them in the [container specific README](https://github.com/abrt/faf/tree/master/container).
+
 
 ### Features
 


### PR DESCRIPTION
Add link to the container specific page on Github.
THis page also shows the readme file.

Related: https://github.com/abrt/faf/issues/908