### PR TITLE
Update pattern for ignored Fedora releases

### DIFF
--- a/config/plugins/fedora.conf
+++ b/config/plugins/fedora.conf
@@ -4,4 +4,4 @@ PagureAPI = https://src.fedoraproject.org/api/0/
 SupportEOL = False
 build-aging-days = 14
 koji-url = https://koji.fedoraproject.org/kojihub
-ignored-releases = epel*, pel*
+ignored-releases = epel*, pel*, ln, l


### PR DESCRIPTION
Add the nonsensical releases "ln" and "l" which appeared recently in the JSON output from Fedora Product Definition Center.