### PR TITLE
celery_tasks: Remove future-dependent annotation

### DIFF
--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -154,7 +154,7 @@ class ActionFormArgparser():
 
         self.F.argparse_fields[kwargs["dest"]] = kwargs
 
-    def add_argument_group(self) -> ActionFormArgGroup:
+    def add_argument_group(self):
         return ActionFormArgGroup(self.F)
 
     def add_opsys(self, multiple=False, required=False, positional=False, with_rel=False, helpstr=None) -> None: # pylint: disable=unused-argument


### PR DESCRIPTION
Fallout from https://github.com/abrt/faf/pull/967. Type annotation
without futures causes a crash when accessing the FAF web interface
because the class in the annotation is only defined later in the file.
Moving the code around causes the same issue with a different class so
I'm just dropping the annotation.

Signed-off-by: Michal Fabik <mfabik@redhat.com>