### PR TITLE
Add a commit message template

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -1,0 +1,13 @@
+COMPONENT: Subject
+
+Explanation
+
+Resolves:
+https://github.com/abrt/faf/issues/XXXX
+https://bugzilla.redhat.com/show_bug.cgi?id=XXXXXX
+
+# Try to keep the subject line within 52 chars ----|
+# Also please try to not exceed 72 characters of length for the body --|
+# Avoid using exact file names as COMPONENT. Use keywords such as spec,
+# client, dump_dir etc. You do not need to follow this template 100%.
+# See git log for examples.

--- a/HACKING.md
+++ b/HACKING.md
@@ -227,7 +227,11 @@ For running only pylint, change to *src* directory and execute
 7. Add edited files (`git add <file_name>`)
 
 8. Create commit (`git commit`) [How to write a proper git commit
-   message](https://chris.beams.io/posts/git-commit/)
+   message](https://chris.beams.io/posts/git-commit/)  
+Note: You can set up a helpful commit message template for your text editor by running
+`$ git config commit.template .git-commit-template`. Remember though that
+committing with `git commit -m` defeats its purpose. You might want to rethink
+your habits.
 
 9. Push your branch (`git push -u origin <name_of_branch>`)
 


### PR DESCRIPTION
To start using this template:
$ git config commit.template .git-commit-template

Signed-off-by: Michal Fabik <mfabik@redhat.com>