### PR TITLE
Fix issues detected by Pylint

### DIFF
--- a/src/pyfaf/actions/__init__.py
+++ b/src/pyfaf/actions/__init__.py
@@ -48,7 +48,7 @@ class Action(Plugin):
             raise FafError("You need to subclass the Action class "
                            "in order to implement an action.")
 
-        super(Action, self).__init__()
+        super().__init__()
 
     def run(self, cmdline, db) -> None:
         """

--- a/src/pyfaf/actions/archive_reports.py
+++ b/src/pyfaf/actions/archive_reports.py
@@ -40,7 +40,7 @@ class ArchiveReports(Action):
     dirname_archive = "archive"
 
     def __init__(self) -> None:
-        super(ArchiveReports, self).__init__()
+        super().__init__()
 
         basedir_keys = ["ureport.directory", "report.spooldirectory"]
         self.basedir = None
@@ -94,7 +94,7 @@ class ArchiveReports(Action):
         except OSError as ex:
             if ex.errno == errno.EEXIST:
                 raise FafError("The directory '{0}' already exists"
-                               .format(tmpsubdir))
+                               .format(tmpsubdir)) from ex
             raise
 
         untar = None

--- a/src/pyfaf/actions/assign_release_to_builds.py
+++ b/src/pyfaf/actions/assign_release_to_builds.py
@@ -27,7 +27,7 @@ class AssignReleaseToBuilds(Action):
     name = "assign-release-to-builds"
 
     def __init__(self) -> None:
-        super(AssignReleaseToBuilds, self).__init__()
+        super().__init__()
         self.uncommitted = 0
 
     def run(self, cmdline, db) -> int:

--- a/src/pyfaf/actions/create_problems.py
+++ b/src/pyfaf/actions/create_problems.py
@@ -53,7 +53,7 @@ class CreateProblems(Action):
     name = "create-problems"
 
     def __init__(self) -> None:
-        super(CreateProblems, self).__init__()
+        super().__init__()
         self._max_workers = 4
 
     def _remove_empty_problems(self, db) -> None:

--- a/src/pyfaf/actions/extfafclonebz.py
+++ b/src/pyfaf/actions/extfafclonebz.py
@@ -34,7 +34,7 @@ class ExternalFafCloneBZ(Action):
     BZ_PARSER = re.compile("BZ#([0-9]+)")
 
     def __init__(self) -> None:
-        super(ExternalFafCloneBZ, self).__init__()
+        super().__init__()
         self.baseurl = None
         self.load_config_to_self("baseurl", ["clonebz.baseurl"], None)
 

--- a/src/pyfaf/actions/fedmsg_notify.py
+++ b/src/pyfaf/actions/fedmsg_notify.py
@@ -166,9 +166,10 @@ class FedmsgNotify(Action):
         def valid_date(s) -> datetime.date:
             try:
                 return datetime.datetime.strptime(s, "%Y-%m-%d").date()
-            except ValueError:
+            except ValueError as ex:
                 msg = "Not a valid date: '{0}'.".format(s)
-                raise argparse.ArgumentTypeError(msg)
+                raise argparse.ArgumentTypeError(msg) from ex
+
         parser.add_argument("--date",
                             default=datetime.date.today().strftime("%Y-%m-%d"),
                             type=valid_date,

--- a/src/pyfaf/actions/hash_paths.py
+++ b/src/pyfaf/actions/hash_paths.py
@@ -27,7 +27,7 @@ class HashPaths(Action):
     name = "hash-paths"
 
     def __init__(self) -> None:
-        super(HashPaths, self).__init__()
+        super().__init__()
         self.prefixes = None
         self.load_config_to_self("prefixes", ["ureport.private_prefixes"],
                                  "/home /opt /usr/local /tmp /var/tmp")

--- a/src/pyfaf/actions/pull_reports.py
+++ b/src/pyfaf/actions/pull_reports.py
@@ -34,7 +34,7 @@ class PullReports(Action):
     KNOWN_FILE_NAME = "pull.pickle"
 
     def __init__(self) -> None:
-        super(PullReports, self).__init__()
+        super().__init__()
 
         self.master = None
         self.basedir = None

--- a/src/pyfaf/actions/repoadd.py
+++ b/src/pyfaf/actions/repoadd.py
@@ -25,7 +25,7 @@ class RepoAdd(Action):
     name = "repoadd"
 
     def __init__(self) -> None:
-        super(RepoAdd, self).__init__()
+        super().__init__()
         self.repo_types = pyfaf.repos.repo_types
 
     def run(self, cmdline, db) -> int:

--- a/src/pyfaf/actions/repoimport.py
+++ b/src/pyfaf/actions/repoimport.py
@@ -30,7 +30,7 @@ class RepoImport(Action):
     name = "repoimport"
 
     def __init__(self) -> None:
-        super(RepoImport, self).__init__()
+        super().__init__()
         self.repo_types = pyfaf.repos.repo_types
 
     def import_repo(self, fp, repo_type) -> Optional[List[Repo]]:

--- a/src/pyfaf/actions/repomod.py
+++ b/src/pyfaf/actions/repomod.py
@@ -26,7 +26,7 @@ class RepoMod(Action):
     name = "repomod"
 
     def __init__(self) -> None:
-        super(RepoMod, self).__init__()
+        super().__init__()
         self.repo_types = pyfaf.repos.repo_types
 
     def run(self, cmdline, db) -> int:

--- a/src/pyfaf/actions/retrace_remote.py
+++ b/src/pyfaf/actions/retrace_remote.py
@@ -29,7 +29,7 @@ class RetraceRemote(Action):
     name = "retrace-remote"
 
     def __init__(self) -> None:
-        super(RetraceRemote, self).__init__()
+        super().__init__()
         self.remote_url = None
         self.auth_key = None
         self.load_config_to_self("remote_url", ["retrace_remote.remote_url"],

--- a/src/pyfaf/actions/save_reports.py
+++ b/src/pyfaf/actions/save_reports.py
@@ -39,7 +39,7 @@ class SaveReports(Action):
     name = "save-reports"
 
     def __init__(self) -> None:
-        super(SaveReports, self).__init__()
+        super().__init__()
 
         basedir_keys = ["ureport.directory", "report.spooldirectory"]
         self.basedir = None

--- a/src/pyfaf/actions/stats.py
+++ b/src/pyfaf/actions/stats.py
@@ -48,7 +48,7 @@ class Stats(Action):
     name = "stats"
 
     def __init__(self) -> None:
-        super(Stats, self).__init__()
+        super().__init__()
 
         self.history_type = "daily"
         self.graph_symbols = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"]

--- a/src/pyfaf/bugtrackers/__init__.py
+++ b/src/pyfaf/bugtrackers/__init__.py
@@ -69,7 +69,7 @@ class BugTracker(Plugin):
             raise FafError("You need to subclass the BugTracker class "
                            "in order to implement a bugtracker plugin.")
 
-        super(BugTracker, self).__init__()
+        super().__init__()
 
     def list_bugs(self, *args, **kwargs) -> Union[Generator[int, None, None], List[int]]:
         """

--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -63,7 +63,7 @@ class Bugzilla(BugTracker):
         Load required configuration based on instance name.
         """
 
-        super(Bugzilla, self).__init__()
+        super().__init__()
 
         # load config for corresponding bugzilla (e.g. fedorabz.api_url,
         # rhelbz.user, xyzbz.password)
@@ -129,7 +129,7 @@ class Bugzilla(BugTracker):
         except Fault as ex:
             if int(ex.faultCode) == 102:
                 # Access denied to a private bug
-                raise FafError(ex.faultString)
+                raise FafError(ex.faultString) from ex
             raise
         return self._save_bug(db, bug)
 

--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -391,7 +391,7 @@ class Bugzilla(BugTracker):
             self.log_debug("Bug #%d already exists in storage, updating", bug_dict["bug_id"])
 
             bugdict = {}
-            for col in new_bug.__table__._columns: #pylint: disable=protected-access
+            for col in new_bug.__table__._columns:  # pylint: disable=no-member,protected-access
                 bugdict[col.name] = getattr(new_bug, col.name)
 
             (db.session.query(BzBug)

--- a/src/pyfaf/bugtrackers/fedorabz.py
+++ b/src/pyfaf/bugtrackers/fedorabz.py
@@ -39,4 +39,4 @@ class FedoraBugzilla(bugzilla.Bugzilla):
         else:
             kwargs['custom_fields'] = abrt_specific
 
-        return super(FedoraBugzilla, self).list_bugs(*args, **kwargs)
+        return super().list_bugs(*args, **kwargs)

--- a/src/pyfaf/bugtrackers/mantisbt.py
+++ b/src/pyfaf/bugtrackers/mantisbt.py
@@ -79,7 +79,7 @@ class Mantis(BugTracker):
         Load required configuration based on instance name.
         """
 
-        super(Mantis, self).__init__()
+        super().__init__()
 
         # load config for corresponding bugzilla (e.g. fedorabz.api_url,
         # rhelbz.user, xyzbz.password)

--- a/src/pyfaf/bugtrackers/mantisbt.py
+++ b/src/pyfaf/bugtrackers/mantisbt.py
@@ -243,7 +243,7 @@ class Mantis(BugTracker):
             self.log_debug("Bug #%d already exists in storage, updating", bug_dict["bug_id"])
 
             bugdict = {}
-            for col in new_bug.__table__._columns: #pylint: disable=protected-access
+            for col in new_bug.__table__._columns:  # pylint: disable=no-member,protected-access
                 bugdict[col.name] = getattr(new_bug, col.name)
             # Otherwise id would be None, which would cause the following
             # update query to fail

--- a/src/pyfaf/bugtrackers/rhelbz.py
+++ b/src/pyfaf/bugtrackers/rhelbz.py
@@ -41,11 +41,10 @@ class RhelBugzilla(bugzilla.Bugzilla):
         else:
             kwargs['custom_fields'] = abrt_specific
 
-        return super(RhelBugzilla, self).list_bugs(*args, **kwargs)
+        return super().list_bugs(*args, **kwargs)
 
     def preprocess_bug(self, bug) -> Optional[Dict[str, Any]]:
-
-        bug_dict = super(RhelBugzilla, self).preprocess_bug(bug)
+        bug_dict = super().preprocess_bug(bug)
 
         # handle "Red Hat Enterprise Linux \d" product naming
         # by stripping the number which is redundant for our purposes

--- a/src/pyfaf/celery_tasks/__init__.py
+++ b/src/pyfaf/celery_tasks/__init__.py
@@ -63,13 +63,13 @@ def run_action(name, params=None, log_level=logging.DEBUG, output_length=1000) -
         root.addHandler(ch)
         try:
             action.run(cmdline, db)
-        except Exception as e:
-            logging.exception(e)
+        except Exception as ex:
+            logging.exception(ex)
             db.session.rollback()
             output = cap_stdout.getvalue()
             # There seems to be no way to pass a FAILURE status other than raising
             # an exception. self.update_status(status="FAILURE") didn't work.
-            raise ActionError(output[-output_length:])
+            raise ActionError(output[-output_length:]) from ex
 
         db.session.rollback()
         output = cap_stdout.getvalue()

--- a/src/pyfaf/checker.py
+++ b/src/pyfaf/checker.py
@@ -79,13 +79,13 @@ class IntChecker(Checker):
 
     def __init__(self, minval=None, maxval=None, **kwargs) -> None:
         # Use numbers.Integral to handle both `int` and `long`
-        super(IntChecker, self).__init__(Integral, **kwargs)
+        super().__init__(Integral, **kwargs)
 
         self.minval = minval
         self.maxval = maxval
 
     def check(self, obj) -> None:
-        super(IntChecker, self).check(obj)
+        super().check(obj)
 
         if self.minval is not None and obj < self.minval:
             raise CheckError("Expected number greater or equal to {0}, "
@@ -103,7 +103,7 @@ class StringChecker(Checker):
     """
 
     def __init__(self, pattern=None, maxlen=0, **kwargs) -> None:
-        super(StringChecker, self).__init__(str, **kwargs)
+        super().__init__(str, **kwargs)
 
         if pattern is not None:
             self.re = re.compile(pattern)
@@ -113,7 +113,7 @@ class StringChecker(Checker):
         self.maxlen = maxlen
 
     def check(self, obj) -> None:
-        super(StringChecker, self).check(obj)
+        super().check(obj)
 
         if self.maxlen > 0 and len(obj) > self.maxlen:
             raise CheckError("String '{0}' is too long, the limit is {1} "
@@ -134,7 +134,7 @@ class ListChecker(Checker):
     """
 
     def __init__(self, elemchecker, minlen=0, maxlen=0, **kwargs) -> None:
-        super(ListChecker, self).__init__(list, **kwargs)
+        super().__init__(list, **kwargs)
 
         if not isinstance(elemchecker, Checker):
             raise CheckerError("`elemchecker` must be an instance of Checker")
@@ -144,7 +144,7 @@ class ListChecker(Checker):
         self.maxlen = maxlen
 
     def check(self, obj) -> None:
-        super(ListChecker, self).check(obj)
+        super().check(obj)
 
         if self.minlen > 0 and len(obj) < self.minlen:
             raise CheckError("The list must contain at least {0} elements"
@@ -157,9 +157,9 @@ class ListChecker(Checker):
         for elem in obj:
             try:
                 self.elemchecker.check(elem)
-            except CheckError as ex: # pylint: disable=try-except-raise
+            except CheckError as ex:
                 raise CheckError("List element is invalid: {0}"
-                                 .format(str(ex)))
+                                 .format(str(ex))) from ex
 
 
 class DictChecker(Checker):
@@ -169,7 +169,7 @@ class DictChecker(Checker):
     """
 
     def __init__(self, elements, **kwargs) -> None:
-        super(DictChecker, self).__init__(dict, **kwargs)
+        super().__init__(dict, **kwargs)
 
         if not isinstance(elements, dict):
             raise CheckerError("`elements` must be a dictionary in the form "
@@ -178,15 +178,15 @@ class DictChecker(Checker):
         self.elements = elements
 
     def check(self, obj) -> None:
-        super(DictChecker, self).check(obj)
+        super().check(obj)
 
         for name, checker in self.elements.items():
             if name in obj:
                 try:
                     checker.check(obj[name])
-                except CheckError as ex: # pylint: disable=try-except-raise
+                except CheckError as ex:
                     raise CheckError("Element '{0}' is invalid: {1}"
-                                     .format(name, str(ex)))
+                                     .format(name, str(ex))) from ex
 
             elif checker.mandatory:
                 raise CheckError("Element '{0}' is missing".format(name))

--- a/src/pyfaf/cmdline.py
+++ b/src/pyfaf/cmdline.py
@@ -63,14 +63,14 @@ class FafHelpFormatter(HelpFormatter):
 
             return "\n  ".join(lines)
 
-        sup = super(FafHelpFormatter, self)
+        sup = super()
         return sup._format_action_invocation(action) #pylint: disable=protected-access
 
     def _format_args(self, action, default_metavar) -> str:
         if isinstance(action, _SubParsersAction):
             return "action"
 
-        sup = super(FafHelpFormatter, self)
+        sup = super()
         return sup._format_args(action, default_metavar) #pylint: disable=protected-access
 
 
@@ -83,11 +83,11 @@ class CmdlineParser(ArgumentParser):
                  add_help=True, argument_default=None, prefix_chars="-",
                  toplevel=False) -> None:
 
-        super(CmdlineParser, self).__init__(description=desc, prog=prog,
-                                            usage=usage, add_help=add_help,
-                                            argument_default=argument_default,
-                                            prefix_chars=prefix_chars,
-                                            formatter_class=FafHelpFormatter)
+        super().__init__(description=desc, prog=prog,
+                         usage=usage, add_help=add_help,
+                         argument_default=argument_default,
+                         prefix_chars=prefix_chars,
+                         formatter_class=FafHelpFormatter)
 
         self.add_argument("-v", "--verbose", action="store_const",
                           const=logging.DEBUG, default=logging.INFO,
@@ -115,7 +115,7 @@ class CmdlineParser(ArgumentParser):
         if "validators" in kwargs:
             del(kwargs["validators"])
 
-        super(CmdlineParser, self).add_argument(*args, **kwargs)
+        super().add_argument(*args, **kwargs)
 
     def parse_args(self, args=None, namespace=None) -> Namespace:
         """

--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -145,7 +145,7 @@ def ensure_dirs(dirnames) -> None:
             if ex.errno != errno.EEXIST:
                 raise FafError("Required directory '{0}' does not "
                                "exist and can't be created: {1}"
-                               .format(dirname, ex.strerror))
+                               .format(dirname, ex.strerror)) from ex
 
 
 def get_libname(path) -> str:

--- a/src/pyfaf/faf_rpm.py
+++ b/src/pyfaf/faf_rpm.py
@@ -82,7 +82,7 @@ def store_rpm_deps(db, package, nogpgcheck=False) -> bool:
         header = ts.hdrFromFdno(rpm_file.fileno())
     except rpm.error as exc:
         rpm_file.close()
-        raise FafError("rpm error: {0}".format(exc))
+        raise FafError("rpm error: {0}".format(exc)) from exc
 
     files = header.fiFromHeader()
     log.debug("%s contains %d files", package.nvra(), len(files))
@@ -113,7 +113,8 @@ def store_rpm_deps(db, package, nogpgcheck=False) -> bool:
             except ValueError as ex:
                 rpm_file.close()
                 db.session.rollback()
-                raise FafError("Unparsable EVR in {} dependency {}: {}".format(package.name, p.N(), ex))
+                raise FafError("Unparsable EVR in {} dependency {}: {}"
+                               .format(package.name, p.N(), ex)) from ex
         db.session.add(new)
 
     requires = header.dsFromHeader('requirename')
@@ -130,7 +131,8 @@ def store_rpm_deps(db, package, nogpgcheck=False) -> bool:
             except ValueError as ex:
                 rpm_file.close()
                 db.session.rollback()
-                raise FafError("Unparsable EVR in {} dependency {}: {}".format(package.name, r.N(), ex))
+                raise FafError("Unparsable EVR in {} dependency {}: {}"
+                               .format(package.name, r.N(), ex)) from ex
         db.session.add(new)
 
     conflicts = header.dsFromHeader('conflictname')
@@ -147,7 +149,8 @@ def store_rpm_deps(db, package, nogpgcheck=False) -> bool:
             except ValueError as ex:
                 rpm_file.close()
                 db.session.rollback()
-                raise FafError("Unparsable EVR in {} dependency {}: {}".format(package.name, c.N(), ex))
+                raise FafError("Unparsable EVR in {} dependency {}: {}"
+                               .format(package.name, c.N(), ex)) from ex
         db.session.add(new)
     # pylint: enable-msg=C0103
 

--- a/src/pyfaf/opsys/__init__.py
+++ b/src/pyfaf/opsys/__init__.py
@@ -44,7 +44,7 @@ class System(Plugin):
             raise FafError("You need to subclass the System class "
                            "in order to implement an operating system plugin.")
 
-        super(System, self).__init__()
+        super().__init__()
 
     def validate_ureport(self, ureport) -> None:
         """

--- a/src/pyfaf/opsys/centos.py
+++ b/src/pyfaf/opsys/centos.py
@@ -90,7 +90,7 @@ class CentOS(System):
         return bool(get_opsys_by_name(db, cls.nice_name))
 
     def __init__(self) -> None:
-        super(CentOS, self).__init__()
+        super().__init__()
         self.eol = None
         self.repo_urls = []
         self.allow_unpackaged = None

--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -100,7 +100,7 @@ class Fedora(System):
         return bool(get_opsys_by_name(db, cls.nice_name))
 
     def __init__(self) -> None:
-        super(Fedora, self).__init__()
+        super().__init__()
         self.eol = None
         self.pdc_url = None
         self.pagure_url = None

--- a/src/pyfaf/problemtypes/__init__.py
+++ b/src/pyfaf/problemtypes/__init__.py
@@ -48,7 +48,7 @@ class ProblemType(Plugin):
             raise FafError("You need to subclass the ProblemType class "
                            "in order to implement a problem type plugin.")
 
-        super(ProblemType, self).__init__()
+        super().__init__()
 
     def hash_ureport(self, ureport) -> None:
         """

--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -96,7 +96,7 @@ class CoredumpProblem(ProblemType):
     })
 
     def __init__(self, *args, **kwargs) -> None:
-        super(CoredumpProblem, self).__init__()
+        super().__init__()
 
         hashkeys = ["processing.corehashframes", "processing.hashframes"]
         self.hashframes = None

--- a/src/pyfaf/problemtypes/java.py
+++ b/src/pyfaf/problemtypes/java.py
@@ -77,7 +77,7 @@ class JavaProblem(ProblemType):
     unknown = "Unknown"
 
     def __init__(self, *args, **kwargs) -> None:
-        super(JavaProblem, self).__init__()
+        super().__init__()
 
         hashkeys = ["processing.javahashframes", "processing.hashframes"]
         self.hashframes = None

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -147,7 +147,7 @@ class KerneloopsProblem(ProblemType):
         return True
 
     def __init__(self, *args, **kwargs) -> None:
-        super(KerneloopsProblem, self).__init__()
+        super().__init__()
 
         hashkeys = ["processing.oopshashframes", "processing.hashframes"]
         self.hashframes = None

--- a/src/pyfaf/problemtypes/kerneloops.py
+++ b/src/pyfaf/problemtypes/kerneloops.py
@@ -277,9 +277,9 @@ class KerneloopsProblem(ProblemType):
 
         try:
             version, release = head.rsplit("-", 1)
-        except ValueError:
+        except ValueError as ex:
             raise FafError("Unable to determine release from '{0}'"
-                           .format(head))
+                           .format(head)) from ex
 
         return version, release, arch, flavour
 

--- a/src/pyfaf/problemtypes/python.py
+++ b/src/pyfaf/problemtypes/python.py
@@ -77,7 +77,7 @@ class PythonProblem(ProblemType):
     })
 
     def __init__(self, *args, **kwargs) -> None:
-        super(PythonProblem, self).__init__()
+        super().__init__()
 
         hashkeys = ["processing.pythonhashframes", "processing.hashframes"]
         self.hashframes = None

--- a/src/pyfaf/problemtypes/ruby.py
+++ b/src/pyfaf/problemtypes/ruby.py
@@ -74,7 +74,7 @@ class RubyProblem(ProblemType):
     })
 
     def __init__(self, *args, **kwargs) -> None:
-        super(RubyProblem, self).__init__()
+        super().__init__()
 
         hashkeys = ["processing.rubyhashframes", "processing.hashframes"]
         self.hashframes = None

--- a/src/pyfaf/repos/__init__.py
+++ b/src/pyfaf/repos/__init__.py
@@ -47,7 +47,7 @@ class Repo(Plugin):
             raise FafError("You need to subclass the Repo class "
                            "in order to implement a repository plugin.")
 
-        super(Repo, self).__init__()
+        super().__init__()
 
     def list_packages(self, architectures) -> None:
         """

--- a/src/pyfaf/repos/dnf.py
+++ b/src/pyfaf/repos/dnf.py
@@ -44,7 +44,7 @@ class Dnf(Repo):
         path is passed).
         """
 
-        super(Dnf, self).__init__()
+        super().__init__()
 
         self.dnf_metadata_expire = "24h"
         self.load_config_to_self("dnf_metadata_expire", ["dnf.metadata_expire"],

--- a/src/pyfaf/repos/rpm_metadata.py
+++ b/src/pyfaf/repos/rpm_metadata.py
@@ -38,7 +38,7 @@ from pyfaf.common import FafError
 class RepomdPrimaryLocationHandler(xml.sax.ContentHandler, object):
 
     def __init__(self) -> None:
-        super(RepomdPrimaryLocationHandler, self).__init__()
+        super().__init__()
         self._location = None
         self._searching = "data"
 
@@ -63,7 +63,7 @@ class RepomdPrimaryLocationHandler(xml.sax.ContentHandler, object):
 class PrimaryHandler(xml.sax.ContentHandler, object):
 
     def __init__(self, baseurl) -> None:
-        super(PrimaryHandler, self).__init__()
+        super().__init__()
         self._baseurl = baseurl
         self._current = None
         self._package = None
@@ -132,7 +132,7 @@ class RpmMetadata(Repo):
         path is passed).
         """
 
-        super(RpmMetadata, self).__init__()
+        super().__init__()
 
         self.cachedir = None
         self.load_config_to_self("cachedir",
@@ -155,7 +155,7 @@ class RpmMetadata(Repo):
         except OSError as ex:
             if ex.errno != 17:
                 raise FafError("Cache directories error '{0}': {1}"
-                               .format(self.cachedir, str(ex)))
+                               .format(self.cachedir, str(ex))) from ex
         return dirname
 
     def _get_repo_file_path(self, reponame, repourl, remote, local=None) -> str:
@@ -178,7 +178,7 @@ class RpmMetadata(Repo):
             mtime = os.path.getmtime(cachename)
         except OSError as ex:
             if errno.ENOENT != ex.errno:
-                raise FafError("Cannot access cache: {0}".format(str(ex)))
+                raise FafError("Cannot access cache: {0}".format(str(ex))) from ex
 
         if (mtime + self.cacheperiod) <= time.time():
             curl = pycurl.Curl()
@@ -188,7 +188,7 @@ class RpmMetadata(Repo):
                 fp = open(cachename, "wb")
             except Exception as ex:
                 raise FafError("Creating cache file {0} filed with: {1}"
-                               .format(cachename, str(ex)))
+                               .format(cachename, str(ex))) from ex
             else:
                 with fp:
                     curl.setopt(pycurl.WRITEDATA, fp)
@@ -196,7 +196,7 @@ class RpmMetadata(Repo):
                         curl.perform()
                     except pycurl.error as ex:
                         raise FafError("Downloading failed: {0}"
-                                       .format(str(ex)))
+                                       .format(str(ex))) from ex
                     finally:
                         curl.close()
 
@@ -215,14 +215,14 @@ class RpmMetadata(Repo):
         try:
             mdfp = open(repomdfilename, "r")
         except Exception as ex:
-            raise FafError("Reading: {0}".format(str(ex)))
+            raise FafError("Reading: {0}".format(str(ex))) from ex
         else:
             with mdfp:
                 try:
                     repomdparser.parse(mdfp)
                 except SAXException as ex:
                     raise FafError("Failed to parse repomd.xml: {0}"
-                                   .format(str(ex)))
+                                   .format(str(ex))) from ex
 
         return self._get_repo_file_path(reponame,
                                         repourl,
@@ -243,8 +243,8 @@ class RpmMetadata(Repo):
                 pfp = open(filename, "r")
             primaryparser.parse(pfp)
         except (Exception, SAXException, zlib.error) as ex:
-            raise FafError("Failed to parse primary.xml[.gz]: {0}".format(
-                str(ex)))
+            raise FafError("Failed to parse primary.xml[.gz]: {0}"
+                           .format(str(ex))) from ex
         finally:
             if pfp is not None:
                 pfp.close()

--- a/src/pyfaf/repos/rpm_metadata.py
+++ b/src/pyfaf/repos/rpm_metadata.py
@@ -221,8 +221,9 @@ class RpmMetadata(Repo):
                 try:
                     repomdparser.parse(mdfp)
                 except SAXException as ex:
+                    # pylint: disable=raise-missing-from
                     raise FafError("Failed to parse repomd.xml: {0}"
-                                   .format(str(ex))) from ex
+                                   .format(str(ex)))
 
         return self._get_repo_file_path(reponame,
                                         repourl,

--- a/src/pyfaf/solutionfinders/__init__.py
+++ b/src/pyfaf/solutionfinders/__init__.py
@@ -73,7 +73,7 @@ class SolutionFinder(Plugin):
             raise FafError("You need to subclass the SolutionFinder class "
                            "in order to implement a solution finder plugin.")
 
-        super(SolutionFinder, self).__init__()
+        super().__init__()
 
         # Lower number means higher priority
         self.solution_priority = None

--- a/src/pyfaf/storage/__init__.py
+++ b/src/pyfaf/storage/__init__.py
@@ -24,7 +24,7 @@ from pyfaf.common import FafError, log, get_connect_string, import_dir
 
 # sqlalchemy dependency is preferred to be explicit
 # also required for EL6
-import __main__
+import __main__  # pylint: disable=wrong-import-order
 __main__.__requires__ = __requires__ = []
 __requires__.append("SQLAlchemy >= 0.8.2")
 pkg_resources.require(__requires__)

--- a/src/pyfaf/storage/bugtracker.py
+++ b/src/pyfaf/storage/bugtracker.py
@@ -33,7 +33,7 @@ class Bugtracker(GenericTable):
     name = Column(String(64), nullable=False)
 
     def __str__(self) -> str:
-        return self.name
+        return str(self.name)
 
     @property
     def web_url(self) -> Optional[str]:

--- a/src/pyfaf/storage/bugzilla.py
+++ b/src/pyfaf/storage/bugzilla.py
@@ -51,7 +51,7 @@ class BzUser(GenericTable):
     can_login = Column(Boolean, nullable=False)
 
     def __str__(self) -> str:
-        return self.email
+        return str(self.email)
 
 
 # pylint: disable=too-many-instance-attributes

--- a/src/pyfaf/storage/fixtures/__init__.py
+++ b/src/pyfaf/storage/fixtures/__init__.py
@@ -165,7 +165,8 @@ class Generator(object):
                 for release in randutils.pickmost(obj.releases):
                     release_assoc = OpSysReleaseComponent()
                     release_assoc.release = release
-                    compobj.opsysreleases.append(release_assoc)
+                    # OpSysComponent.releases is a backref from OpSysReleaseComponent.
+                    compobj.releases.append(release_assoc)  # pylint: disable=no-member
                 self.add(compobj)
         self.commit()
 

--- a/src/pyfaf/storage/llvm.py
+++ b/src/pyfaf/storage/llvm.py
@@ -34,7 +34,8 @@ class LlvmBuild(GenericTable):
                 "stderr": 1 << 22, }
 
     id = Column(Integer, primary_key=True)
-    build_id = Column(Integer, ForeignKey("{0}.id".format(Build.__tablename__)), nullable=True, index=True)
+    build_id = Column(Integer, ForeignKey("{0}.id".format(Build.__tablename__)),
+                      nullable=True, index=True)
     started = Column(DateTime, nullable=False)
     duration = Column(Integer, nullable=False)
     success = Column(Boolean, nullable=False)
@@ -53,7 +54,8 @@ class LlvmBcFile(GenericTable):
     __lobs__ = {"bcfile": 1 << 28}
 
     id = Column(Integer, primary_key=True)
-    llvmbuild_id = Column(Integer, ForeignKey("{0}.id".format(LlvmBuild.__tablename__)), nullable=False, index=True)
+    llvmbuild_id = Column(Integer, ForeignKey("{0}.id".format(LlvmBuild.__tablename__)),
+                          nullable=False, index=True)
     path = Column(String(256), nullable=False, index=True)
     llvm_build = relationship(LlvmBuild, backref="bc_files")
 
@@ -62,6 +64,7 @@ class LlvmResultFile(GenericTable):
     __tablename__ = "llvm_resultfiles"
 
     id = Column(Integer, primary_key=True)
-    llvmbuild_id = Column(Integer, ForeignKey("{0}.id".format(LlvmBuild.__tablename__)), nullable=False, index=True)
+    llvmbuild_id = Column(Integer, ForeignKey("{0}.id".format(LlvmBuild.__tablename__)),
+                          nullable=False, index=True)
     path = Column(String(256), nullable=False, index=True)
     llvm_build = relationship(LlvmBuild, backref="result_files")

--- a/src/pyfaf/storage/llvm.py
+++ b/src/pyfaf/storage/llvm.py
@@ -47,9 +47,6 @@ class LlvmBuild(GenericTable):
     def add_nvr(self) -> None:
         self.nvr = self.build.nvr()
 
-    def count_bcfiles(self) -> None:
-        self.bcfiles_count = len(self.bc_files)
-
 
 class LlvmBcFile(GenericTable):
     __tablename__ = "llvm_bcfiles"

--- a/src/pyfaf/storage/migrations/versions/e1e54ec3137d_use_rpm_extension_with_lobs.py
+++ b/src/pyfaf/storage/migrations/versions/e1e54ec3137d_use_rpm_extension_with_lobs.py
@@ -54,7 +54,8 @@ def upgrade() -> None:
         db_package.build_id = build
         db_package.pkgtype = pkgtype
         ext_len = len(pkgtype) + 1
-        lobpath = db_package.get_lob_path("package")
+        # Package inherits get_lob_path() from GenericTable.
+        lobpath = db_package.get_lob_path("package")  # pylint: disable=no-member
         if lobpath.endswith(".{}".format(pkgtype)) and os.path.isfile(lobpath[:-ext_len]):
             os.rename(lobpath[:-ext_len], lobpath)
 
@@ -71,6 +72,7 @@ def downgrade() -> None:
         db_package.build_id = build
         db_package.pkgtype = pkgtype
         ext_len = len(pkgtype) + 1
-        lobpath = db_package.get_lob_path("package")
+        # Package inherits get_lob_path() from GenericTable.
+        lobpath = db_package.get_lob_path("package")  # pylint: disable=no-member
         if lobpath.endswith(".{}".format(pkgtype)) and os.path.isfile(lobpath):
             os.rename(lobpath, lobpath[:-ext_len])

--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -140,11 +140,12 @@ class OpSysComponent(GenericTable):
 
     id = Column(Integer, primary_key=True)
     name = Column(String(256), nullable=False, index=True)
-    opsys_id = Column(Integer, ForeignKey("{0}.id".format(OpSys.__tablename__)), nullable=False, index=True)
+    opsys_id = Column(Integer, ForeignKey("{0}.id".format(OpSys.__tablename__)),
+                      nullable=False, index=True)
     opsys = relationship(OpSys, backref="components")
 
     def __str__(self) -> str:
-        return self.name
+        return str(self.name)
 
 
 class OpSysReleaseComponent(GenericTable):

--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -42,7 +42,7 @@ class Arch(GenericTable):
     name = Column(String(8), nullable=False)
 
     def __str__(self) -> str:
-        return self.name
+        return str(self.name)
 
 
 class OpSys(GenericTable):
@@ -53,7 +53,7 @@ class OpSys(GenericTable):
     name = Column(String(32), nullable=False)
 
     def __str__(self) -> str:
-        return self.name
+        return str(self.name)
 
     def __lt__(self, other) -> bool:
         return self.name < other.name
@@ -104,7 +104,7 @@ class Repo(GenericTable):
     url_list = relationship(Url, secondary="urlrepo")
 
     def __str__(self) -> str:
-        return self.name
+        return str(self.name)
 
 
 class OpSysRepo(GenericTable):

--- a/src/pyfaf/storage/report.py
+++ b/src/pyfaf/storage/report.py
@@ -66,7 +66,8 @@ class Report(GenericTable):
             "first_occurrence": self.first_occurrence,
             "last_occurrence": self.last_occurrence,
             "problem_id": self.problem_id,
-            "comments": self.comments,
+            # self.comments is a backref from ReportComment
+            "comments": self.comments,  # pylint: disable=no-member
         }
 
     @property
@@ -83,7 +84,8 @@ class Report(GenericTable):
 
     @property
     def oops(self) -> Optional[str]:
-        result = self.get_lob('oops')
+        # get_lob() is inherited from GenericTable.
+        result = self.get_lob('oops')  # pylint: disable=no-member
         if result:
             return result.decode('utf-8')
         return result
@@ -94,6 +96,8 @@ class Report(GenericTable):
         List of all backtraces assigned to this report
         sorted by quality.
         '''
+        # self.backtraces is a backref from ReportBacktrace.
+        # pylint: disable=no-member
         return sorted(self.backtraces, key=lambda bt: bt.quality, reverse=True)
 
     @property
@@ -114,6 +118,8 @@ class Report(GenericTable):
         if self.type.lower() != "kerneloops":
             return False
 
+        # self.backtraces is a backref from ReportBacktrace.
+        # pylint: disable=no-member
         return all(bt.tainted for bt in self.backtraces)
 
     @property
@@ -123,6 +129,8 @@ class Report(GenericTable):
         report
         """
 
+        # self.backtraces is a backref from ReportBacktrace.
+        # pylint: disable=no-member
         return most_common_crash_function(self.backtraces)
 
     @property
@@ -142,6 +150,8 @@ class Report(GenericTable):
 
     @property
     def archived(self) -> bool:
+        # self.archive is a backref from ReportArchive.
+        # pylint: disable=no-member
         if self.archive and self.archive.active:
             return True
 
@@ -181,6 +191,8 @@ class ReportBacktrace(GenericTable):
         # but the DB schema allows multiple or none, so let's
         # be ready for such case
 
+        # self.threads is a backref from ReportBtThread.
+        # pylint: disable=no-member
         crashthreads = [t for t in self.threads if t.crashthread]
 
         if not crashthreads:
@@ -194,6 +206,8 @@ class ReportBacktrace(GenericTable):
 
         Frames with missing information lower the backtrace quality.
         '''
+        # self.taint_flags is a backref from ReportBtTaintFlag.
+        # pylint: disable=no-member
         quality = -len(self.taint_flags)
 
         # empty backtrace
@@ -219,6 +233,8 @@ class ReportBacktrace(GenericTable):
 
     @property
     def tainted(self) -> bool:
+        # self.taint_flags is a backref from ReportBtTaintFlag.
+        # pylint: disable=no-member
         return any(flag.taintflag.character.upper() != 'G'
                    for flag in self.taint_flags)
 

--- a/src/pyfaf/storage/report.py
+++ b/src/pyfaf/storage/report.py
@@ -278,7 +278,7 @@ class ReportBtHash(GenericTable):
     backtrace = relationship(ReportBacktrace, backref="hashes")
 
     def __str__(self) -> str:
-        return self.hash
+        return str(self.hash)
 
 
 class ReportOpSysRelease(GenericTable):

--- a/src/pyfaf/storage/task.py
+++ b/src/pyfaf/storage/task.py
@@ -45,13 +45,8 @@ class PeriodicTask(GenericTable):
         return self.task == "pyfaf.celery_tasks.run_action"
 
     @property
-    def args_parsed(self):
-
-        return self._foo
-
-    @property
-    def nice_name(self):
-        return self.name
+    def nice_name(self) -> str:
+        return str(self.name)
 
     @property
     def nice_task(self) -> str:

--- a/src/pyfaf/ureport.py
+++ b/src/pyfaf/ureport.py
@@ -122,8 +122,8 @@ def get_version(ureport) -> int:
     if "ureport_version" in ureport:
         try:
             ver = int(ureport["ureport_version"])
-        except ValueError:
-            raise FafError("`ureport_version` must be an integer")
+        except ValueError as ex:
+            raise FafError("`ureport_version` must be an integer") from ex
 
     return ver
 
@@ -517,8 +517,8 @@ def save_attachment(db, attachment) -> None:
 
         try:
             db.session.flush()
-        except IntegrityError:
-            raise FafError("Email address already assigned to the report")
+        except IntegrityError as ex:
+            raise FafError("Email address already assigned to the report") from ex
 
     elif atype == "url":
         url = attachment["data"]
@@ -541,8 +541,8 @@ def save_attachment(db, attachment) -> None:
 
         try:
             db.session.flush()
-        except IntegrityError:
-            raise FafError("Unable to save URL")
+        except IntegrityError as ex:
+            raise FafError("Unable to save URL") from ex
 
     else:
         log.warning("Unknown attachment type")

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -389,7 +389,7 @@ def create_action_form(action):
 # which breaks form validation for extfafmod and repoadd
 class TaskNameField(StringField):
     def __init__(self, label="", _name="", **kwargs) -> None:
-        super(TaskNameField, self).__init__(label, _name="task_name", **kwargs)
+        super().__init__(label, _name="task_name", **kwargs)
 
 class PeriodicTaskForm(Form):
     name = TaskNameField("Name", validators=[validators.Length(min=1, max=80)])
@@ -407,9 +407,9 @@ class JSONField(TextAreaField):
         if valuelist:
             try:
                 self.data = json.loads(valuelist[0])
-            except: # pylint: disable=bare-except
+            except json.decoder.JSONDecodeError as ex:
                 self.data = None
-                raise ValidationError("Not valid JSON data")
+                raise ValidationError("Not valid JSON data") from ex
         else:
             self.data = None
 

--- a/src/webfaf/blueprints/celery_tasks.py
+++ b/src/webfaf/blueprints/celery_tasks.py
@@ -25,7 +25,7 @@ from pyfaf.solutionfinders import solution_finders
 
 from webfaf.forms import TagListField
 from webfaf.utils import Pagination, admin_required
-from webfaf_main import db
+from webfaf_main import db  # pylint: disable=wrong-import-order
 
 url_prefix = "/celery_tasks"
 
@@ -445,7 +445,8 @@ def action_run(action_name) -> Union[Response, str]:
             pt = PeriodicTask()
             pt.task = "pyfaf.celery_tasks.run_action"
             pt.args = (action_name, action_form.to_cmdline_dict())
-            pt_form.populate_obj(pt)
+            # populate_obj() is a method of wtforms.form.Form.
+            pt_form.populate_obj(pt)  # pylint: disable=no-member
             db.session.add(pt)
             db.session.commit()
             flash("Action {0} scheduled successfully.".format(action_name), "success")
@@ -481,7 +482,8 @@ def schedule_item(pt_id) -> Union[Response, str]:
         if request.values.get("schedule") and (action_form is None or action_form.validate()) and pt_form.validate():
             if action:
                 pt.args = (action_name, action_form.to_cmdline_dict())
-            pt_form.populate_obj(pt)
+            # populate_obj() is a method of wtforms.form.Form.
+            pt_form.populate_obj(pt)  # pylint: disable=no-member
             db.session.commit()
             flash("Schedule item {0} saved successfully.".format(pt.name), "success")
             return redirect(url_for("celery_tasks.index"))

--- a/src/webfaf/blueprints/symbol_transfer.py
+++ b/src/webfaf/blueprints/symbol_transfer.py
@@ -15,7 +15,7 @@ from pyfaf.storage import (OpSysComponent,
                            ReportHash,
                            SymbolSource)
 from pyfaf.config import config
-from webfaf_main import db
+from webfaf_main import db  # pylint: disable=wrong-import-order
 
 
 url_prefix = "/symbol_transfer"

--- a/src/webfaf/forms.py
+++ b/src/webfaf/forms.py
@@ -41,7 +41,7 @@ class DaterangeField(StringField):
             today = datetime.date.today()
             kwargs["default"] = lambda: (
                 today - datetime.timedelta(days=self.default_days), today)
-        super(DaterangeField, self).__init__(label, validators_, **kwargs)
+        super().__init__(label, validators_, **kwargs)
 
     def process_formdata(self, valuelist) -> None:
         if valuelist:
@@ -322,10 +322,10 @@ class BugIdField(StringField):
             for value in valuelist:
                 try:
                     self.data = int(value)
-                except ValueError:
+                except ValueError as ex:
                     m = re.search(r"id=(\d+)", value)
                     if m is None:
-                        raise validators.ValidationError("Invalid Bug ID")
+                        raise validators.ValidationError("Invalid Bug ID") from ex
                     self.data = int(m.group(1))
         else:
             self.data = None

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -770,9 +770,9 @@ def new() -> Union[Dict[str, bool], Tuple[str, int], str, Response]:
             raw_data = request.files[form.file.name].read()
             try:
                 data = json.loads(raw_data)
-            except Exception as ex: # pylint: disable=broad-except
+            except json.decoder.JSONDecodeError as ex:
                 _save_invalid_ureport(db, raw_data, str(ex))
-                raise InvalidUsage("Couldn't parse JSON data.", 400)
+                raise InvalidUsage("Couldn't parse JSON data.", 400) from ex
 
             try:
                 ureport.validate(data)
@@ -794,8 +794,8 @@ def new() -> Union[Dict[str, bool], Tuple[str, int], str, Response]:
                     _save_unknown_opsys(db, data["os"])
                 if str(exp) == 'uReport must contain affected package':
                     raise InvalidUsage(("Server is not accepting problems "
-                                        "from unpackaged files."), 400)
-                raise InvalidUsage("uReport data is invalid.", 400)
+                                        "from unpackaged files."), 400) from exp
+                raise InvalidUsage("uReport data is invalid.", 400) from exp
 
             report = data
 
@@ -948,13 +948,13 @@ def attach() -> Union[Tuple[str, int], str, Response]:
 
             try:
                 data = json.loads(raw_data)
-            except:
-                raise InvalidUsage("Invalid JSON file", 400)
+            except json.decoder.JSONDecodeError as ex:
+                raise InvalidUsage("Invalid JSON file", 400) from ex
 
             try:
                 ureport.validate_attachment(data)
             except Exception as ex:
-                raise InvalidUsage("Validation failed: %s" % ex, 400)
+                raise InvalidUsage("Validation failed: %s" % ex, 400) from ex
 
             attachment = data
 

--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -736,7 +736,8 @@ def _save_invalid_ureport(_, report, errormsg, reporter=None) -> None:
         db.session.add(newInvalid)
         db.session.commit()
 
-        newInvalid.save_lob("ureport", report)
+        # InvalidUReport inherits save_lob() from GenericTable.
+        newInvalid.save_lob("ureport", report)  # pylint: disable=no-member
     except Exception as ex: # pylint: disable=broad-except
         logging.error(str(ex))
 


### PR DESCRIPTION
This fixes some long-standing errors and warnings from Pylint so that we can marvel at the green check mark again :heavy_check_mark:

* Re-raise exceptions using `raise … from …`.
* Call `super()` with no arguments in constructors.
* Make `__str__()` return a string in all cases.
* Suppress warnings about wrong import order.
* Remove some unused methods.
* Wrap long lines.