### PR TITLE
WIP: storage: Drop autocommit parameter

### DIFF
--- a/src/pyfaf/actions/find_report_solution.py
+++ b/src/pyfaf/actions/find_report_solution.py
@@ -27,7 +27,6 @@ class FindReportSolution(Action):
 
 
     def run(self, cmdline, db) -> None:
-        db.session.autocommit = False
         for report in db.session.query(Report).filter(Report.max_certainty.is_(None)):
             osr = get_report_opsysrelease(db=db, report_id=report.id)
             solutions = [find_solution(report, db=db, osr=osr)]

--- a/src/pyfaf/actions/reposync.py
+++ b/src/pyfaf/actions/reposync.py
@@ -129,14 +129,12 @@ class RepoSync(Action):
                 if not arch:
                     self.log_error("Architecture '{0}' not found, skipping"
                                    .format(pkg["arch"]))
-
                     continue
 
                 repo_arch = architectures.get(repo_instance["arch"], None)
                 if not repo_arch:
                     self.log_error("Architecture '{0}' not found, skipping"
                                    .format(repo_instance["arch"]))
-
                     continue
 
                 build = (db.session.query(Build)

--- a/src/pyfaf/celery_tasks/__init__.py
+++ b/src/pyfaf/celery_tasks/__init__.py
@@ -16,7 +16,7 @@ celery_app = Celery("pyfaf_tasks",
                     broker=get_env_or_config("celery_tasks.broker", "RDSBROKER", ""),
                     backend=get_env_or_config("celery_tasks.backend", "RDSBACKEND", ""))
 
-db_factory = DatabaseFactory(autocommit=True)
+db_factory = DatabaseFactory()
 
 
 class ActionError(Exception):

--- a/tests/faftests/__init__.py
+++ b/tests/faftests/__init__.py
@@ -93,10 +93,7 @@ class DatabaseCase(TestCase):
         cls.reports_path = os.path.abspath(
             os.path.join(cpath, "..", "sample_reports"))
 
-        cls.db = storage.Database(session_kwargs={
-            "autoflush": False,
-            "autocommit": False},
-                                  create_schema=True)
+        cls.db = storage.Database(create_schema=True)
 
     def prepare(self):
         """
@@ -132,9 +129,7 @@ class DatabaseCase(TestCase):
 
         # reinit DB with new version
         storage.Database.__instance__ = None
-        self.db = storage.Database(session_kwargs={
-            "autoflush": False,
-            "autocommit": False})
+        self.db = storage.Database()
 
         # required due to mixing of sqlalchemy and flask-sqlalchemy
         # fixed in flask-sqlalchemy >= 2.0


### PR DESCRIPTION
The autocommit mode [will be deprecated](https://docs.sqlalchemy.org/en/13/orm/session_transaction.html#session-autocommit) in SQLAlchemy 1.4. Although 1.4 has only been released in March 2021 and 1.3 is still going strong as of this month, we should begin to prepare for a migration to 1.4 (or even 2.0) in the future.

Related: #974