### PR TITLE
Drop pycurl dependency

### DIFF
--- a/faf.spec
+++ b/faf.spec
@@ -21,7 +21,6 @@ Requires: python3-setuptools
 Requires: python3-psycopg2
 Requires: python3-sqlalchemy
 Requires: python3-rpm
-Requires: python3-pycurl
 Requires: python3-argcomplete
 Requires: python3-cachelib
 
@@ -47,7 +46,6 @@ BuildRequires: python3-sqlalchemy
 BuildRequires: python3-koji
 BuildRequires: python3-zeep
 BuildRequires: python3-fedora-messaging
-BuildRequires: python3-pycurl
 BuildRequires: python3-celery >= 3.1
 BuildRequires: python3-dnf
 BuildRequires: python3-zeep

--- a/pylintrc
+++ b/pylintrc
@@ -23,7 +23,7 @@ load-plugins=
 
 # A comma-separated list of package or module names from where C extensions may be loaded.
 # Extensions are loading into the active Python interpreter and may run arbitrary code.
-extension-pkg-whitelist=satyr,rpm,pycurl
+extension-pkg-whitelist=satyr,rpm
 
 [MESSAGES CONTROL]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ Flask-SQLAlchemy ~= 2.4.4
 koji ~= 1.24.1
 markdown2 ~= 2.4.0
 munch ~= 2.5.0
-pycurl ~= 7.43.0.5
 python-bugzilla ~= 3.0.2
 python-openid-teams ~= 1.1
 ratelimitingfilter ~= 1.1

--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -236,7 +236,7 @@ class Bugzilla(BugTracker):
         self.connect()
         return self.bz.query(queue)
 
-    def _convert_datetime(self, bz_datetime: xmlprc.client.Datetime) \
+    def _convert_datetime(self, bz_datetime: xmlrpc.client.DateTime) \
             -> datetime.datetime:
         """
         Convert `bz_datetime` returned by python-bugzilla

--- a/src/pyfaf/bugtrackers/bugzilla.py
+++ b/src/pyfaf/bugtrackers/bugzilla.py
@@ -87,9 +87,6 @@ class Bugzilla(BugTracker):
 
         self.connected = False
 
-        # url has to be string not unicode due to pycurl
-        self.api_url = str(self.api_url)
-
     def connect(self) -> None:
         if self.connected:
             return

--- a/src/pyfaf/repos/rpm_metadata.py
+++ b/src/pyfaf/repos/rpm_metadata.py
@@ -18,25 +18,25 @@
 #
 # vim: set makeprg=python3-flake8\ %
 
+import errno
+import gzip
 import os
 import time
-import gzip
-import zlib
-import errno
 import xml.sax
+import zlib
+from typing import Dict, List, Optional, Union
+from urllib.error import HTTPError
+from urllib.request import urlopen
 from xml.sax import SAXException
-
-from typing import Dict, List, Union
 
 import pycurl
 
+from pyfaf.common import FafError
 from pyfaf.utils import parse
 from pyfaf.repos import Repo
-from pyfaf.common import FafError
 
 
-class RepomdPrimaryLocationHandler(xml.sax.ContentHandler, object):
-
+class RepomdPrimaryLocationHandler(xml.sax.ContentHandler):
     def __init__(self) -> None:
         super().__init__()
         self._location = None
@@ -60,7 +60,7 @@ class RepomdPrimaryLocationHandler(xml.sax.ContentHandler, object):
         return self._location
 
 
-class PrimaryHandler(xml.sax.ContentHandler, object):
+class PrimaryHandler(xml.sax.ContentHandler):
 
     def __init__(self, baseurl) -> None:
         super().__init__()
@@ -125,6 +125,9 @@ class RpmMetadata(Repo):
 
     name = "rpmmetadata"
 
+    cachedir: str
+    cacheperiod: int
+
     def __init__(self, name, urls, *args) -> None:
         """
         Following `url` schemes are supported:
@@ -134,16 +137,14 @@ class RpmMetadata(Repo):
 
         super().__init__()
 
-        self.cachedir = None
         self.load_config_to_self("cachedir",
                                  ["rpmmetadata.cachedir"],
                                  "/var/tmp/faf-rpmmetadata")
         # Cache files for 1 hour by default
-        self.cacheperiod = None
         self.load_config_to_self("cacheperiod",
                                  ["rpmmetadata.cacheperiod"],
-                                 3600)
-        self.cacheperiod = int(self.cacheperiod)
+                                 3600,
+                                 int)
 
         self.name = name
         self.urls = urls


### PR DESCRIPTION
* Use `urllib` instead of a dedicated library for simple HTTP requests.
* Small refactoring here and there.
* Add type annotations.