### PR TITLE
Only accept Fedora GA releases

### DIFF
--- a/src/pyfaf/opsys/centos.py
+++ b/src/pyfaf/opsys/centos.py
@@ -227,7 +227,7 @@ class CentOS(System):
                 .filter(Build.release.like("%%.el%%"))
                 .all())
 
-    def check_pkgname_match(self, packages, parser) -> None:
+    def check_pkgname_match(self, packages, parser) -> bool:
         for package in packages:
             if ("package_role" not in package or
                     package["package_role"].lower() != "affected"):

--- a/src/pyfaf/opsys/fedora.py
+++ b/src/pyfaf/opsys/fedora.py
@@ -237,7 +237,7 @@ class Fedora(System):
     def get_releases(self) -> Dict[str, Dict[str, str]]:
         result = {}
         # Page size -1 means, that all results are on one page
-        url = self.pdc_url + "releases/?page_size=-1&short=" + Fedora.name
+        url = "{}releases/?page_size=-1&short={}".format(self.pdc_url, Fedora.name)
 
         response = json.load(urllib.request.urlopen(url))
         for release in response:
@@ -247,7 +247,9 @@ class Fedora(System):
             if not ver.isdecimal() and ver != "rawhide":
                 continue
 
-            if self._is_ignored(ver):
+            # Only accept GA releases, i.e. skip updates and updates-testing
+            # pseudo-releases. Moreover check for specifically ignored releases.
+            if release.get("release_type") != "ga" or self._is_ignored(ver):
                 continue
 
             result[ver] = {"status": "ACTIVE" if release["active"] else "EOL"}


### PR DESCRIPTION
When retrieving the list of active Fedora releases from Fedora PDC, only consider GA (general availability) releases, i.e. ignore `*-updates`, `*-updates-testing` etc.

This should prevent EOL'd release from reappearing on the summary page, since `faf pull-releases` used to switch their state to `ACTIVE` back from `EOL` due to the confusion in release types.