### PR TITLE
storage: Ignore Pylint error

### DIFF
--- a/src/pyfaf/storage/opsys.py
+++ b/src/pyfaf/storage/opsys.py
@@ -60,6 +60,8 @@ class OpSys(GenericTable):
 
     @property
     def active_releases(self) -> List[Dict[str, Any]]:
+        # self.releases is a backref from OpSysRelease.
+        # pylint: disable=no-member
         return [release for release in self.releases if release.status == 'ACTIVE']
 
 


### PR DESCRIPTION
Ignore one instance of the "Instance X has no Y member" Pylint error. `OpSys.releases` is a backref from `OpSysReleases`.