### PR TITLE
Do not pull components for EOL releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- The `faf pull-components` action no longer adds new components for EOL releases
 
 ## [2.4.1] - 2021-06-24
 ### Added

--- a/src/pyfaf/actions/pull_components.py
+++ b/src/pyfaf/actions/pull_components.py
@@ -71,7 +71,8 @@ class PullComponents(Action):
                                                          release))
                         continue
 
-                    result.add((osplugin, db_release))
+                    if db_release.status != "EOL":
+                        result.add((osplugin, db_release))
 
         # multiple opsys - pull all of their releases
         else:
@@ -89,7 +90,8 @@ class PullComponents(Action):
                     continue
 
                 for db_release in db_opsys.releases:
-                    result.add((osplugin, db_release))
+                    if db_release.status != "EOL":
+                        result.add((osplugin, db_release))
 
         return sorted(result, key=lambda p_r: (p_r[1].opsys.name, p_r[1].version))
 


### PR DESCRIPTION
Do not download new components for EOL releases since we are not really interested in them anymore and it's wasting CPU time.