### PR TITLE
Add configuration for systemd-tmpfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - The `faf pull-components` action no longer adds new components for EOL releases
 
+### Fixed
+- Temporary directories after RPM extraction not being cleaned up (#979)
+
 ## [2.4.1] - 2021-06-24
 ### Added
 - Configuration option `hub.banner` in `/etc/faf/plugins/web.conf` to display urgent information in a simple banner at the top of each page

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,9 +11,10 @@ EXTRA_DIST = autogen.sh faf-version faf.spec \
 
 
 if HAVE_SYSTEMD
-systemdsystemunitdir=/usr/lib/systemd/system/
+systemdsystemunitdir=$(prefix)/lib/systemd/system/
 systemdsystemunit_DATA = init-scripts/faf-celery-beat.service \
                          init-scripts/faf-celery-worker.service
-tmpfilesddir=/usr/lib/tmpfiles.d/
-tmpfilesd_DATA = init-scripts/faf-celery-tmpfiles.conf
+systemdtmpfilesdir=$(prefix)/lib/tmpfiles.d/
+systemdtmpfiles_DATA = init-scripts/faf.conf \
+                       init-scripts/faf-celery-tmpfiles.conf
 endif

--- a/faf.spec
+++ b/faf.spec
@@ -807,6 +807,9 @@ fi
 %{_datadir}/faf/fixtures/sql/taginheritances.sql
 %{_datadir}/faf/fixtures/sql/tags.sql
 
+# Configuration file for systemd-tmpfiles(8).
+%{_tmpfilesdir}/faf.conf
+
 %files webui
 # /etc
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/faf-web.conf

--- a/init-scripts/faf-celery-tmpfiles.conf
+++ b/init-scripts/faf-celery-tmpfiles.conf
@@ -1,1 +1,11 @@
-d /run/faf-celery 0755 faf faf -
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# See tmpfiles.d(5) for details
+
+#Type  Path            Mode  User  Group  Age
+d      /run/faf-celery 0755  faf   faf    -

--- a/init-scripts/faf.conf
+++ b/init-scripts/faf.conf
@@ -1,0 +1,12 @@
+# This file is part of faf.
+#
+# faf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# See tmpfiles.d(5) for details
+
+#Type  Path          Mode  User  Group  Age
+d      /tmp/faf      0755  faf   faf    28d
+d      /tmp/faf/rpm  0755  faf   faf    1d

--- a/src/pyfaf/common.py
+++ b/src/pyfaf/common.py
@@ -23,7 +23,7 @@ import pwd
 import re
 import tempfile
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pyfaf.config import config, configure_logging
 
@@ -156,7 +156,7 @@ def get_libname(path) -> str:
     return libname
 
 
-def get_temp_dir(subdir=None) -> str:
+def get_temp_dir(subdir: Optional[str] = None) -> str:
     """
     Get the temp directory path. If storage.tmpdir exists, it will be
     considered temp root, otherwise system default will be used.
@@ -171,7 +171,7 @@ def get_temp_dir(subdir=None) -> str:
     if username == "faf":
         userdir = "faf"
     else:
-        userdir = "faf-{0}".format(username)
+        userdir = f"faf-{username}"
 
     if subdir is None:
         return os.path.join(basetmp, userdir)

--- a/src/pyfaf/faf_rpm.py
+++ b/src/pyfaf/faf_rpm.py
@@ -22,8 +22,7 @@ import tempfile
 from subprocess import Popen, PIPE, TimeoutExpired
 from typing import Optional, Tuple
 import rpm
-from pyfaf.common import FafError, log
-from pyfaf.config import config
+from pyfaf.common import FafError, get_temp_dir, log
 from pyfaf.storage.opsys import PackageDependency
 
 log = log.getChild(__name__)
@@ -124,13 +123,13 @@ def store_rpm_provides(db, package, nogpgcheck=False) -> bool:
     db.session.flush()
 
 
-def unpack_rpm_to_tmp(path, prefix="faf") -> str:
+def unpack_rpm_to_tmp(path: str, prefix: str = "faf") -> str:
     """
     Unpack RPM package to a temp directory. The directory is either specified
     in storage.tmpdir config option or use the system default temp directory.
     """
 
-    tmpdir = config.get("storage.tmpdir", None)
+    tmpdir = get_temp_dir("rpm")
 
     result = tempfile.mkdtemp(prefix=prefix, dir=tmpdir)
     for dirname in ["bin", "lib", "lib64", "sbin"]:


### PR DESCRIPTION
* Extract RPMs during `faf retrace` into a separate directory inside `/tmp/faf`.
* Add config for systemd-tmpfiles to clean up `/tmp/faf` regularly.
* Small code style improvements.

See individual commits for more details.

Fixes #979