### PR TITLE
Fix build on Fedora 34+

### DIFF
--- a/faf.spec
+++ b/faf.spec
@@ -40,7 +40,7 @@ BuildRequires: python3-alembic
 BuildRequires: python3-setuptools
 BuildRequires: python3-bugzilla >= 2.0
 BuildRequires: python3-psycopg2
-BuildRequires: python3-testing.postgresql < 1.2
+BuildRequires: python3-testing.postgresql >= 1.3.0
 BuildRequires: python3-rpm
 BuildRequires: python3-sqlalchemy
 BuildRequires: python3-koji

--- a/tests/faftests/__init__.py
+++ b/tests/faftests/__init__.py
@@ -473,7 +473,6 @@ def _set_up_db_conf(pg_obj):
     params = pg_obj.dsn()
     config.config["storage.dbuser"] = params["user"]
     config.config["storage.dbpasswd"] = ""
-    config.config["storage.dbhost"] = params['host']
-    config.config["storage.dbport"] = params['port']
-    # from python-testing.postgresql >= 1.2 dbname is changed to database
-    config.config["storage.dbname"] = params['dbname']
+    config.config["storage.dbhost"] = params["host"]
+    config.config["storage.dbport"] = params["port"]
+    config.config["storage.dbname"] = params["database"]


### PR DESCRIPTION
* The `dbname` parameter has been changed to `database` in python-testing.sqlalchemy.
* Bump dependency on python-testing.postgresql in spec file.