### PR TITLE
More informative error message on invalid uReport

### DIFF
--- a/src/webfaf/reports.py
+++ b/src/webfaf/reports.py
@@ -793,10 +793,7 @@ def new() -> Union[Dict[str, bool], Tuple[str, int], str, Response]:
                         data["os"]["name"] not in systems and
                         data["os"]["name"].lower() not in systems):
                     _save_unknown_opsys(db, data["os"])
-                if str(exp) == 'uReport must contain affected package':
-                    raise InvalidUsage(("Server is not accepting problems "
-                                        "from unpackaged files."), 400) from exp
-                raise InvalidUsage("uReport data is invalid.", 400) from exp
+                raise InvalidUsage(str(exp), 400) from exp
 
             report = data
 

--- a/tests/test_webfaf/test_reports.py
+++ b/tests/test_webfaf/test_reports.py
@@ -170,7 +170,7 @@ class ReportTestCase(WebfafTestCase):
         self.assertEqual(self.db.session.query(InvalidUReport).count(), 1)
 
         r = self.post_report('{"invalid":"json"}')
-        self.assertEqual(json.loads(r.data)["error"], u"uReport data is invalid.")
+        self.assertEqual(json.loads(r.data)["error"], u"uReport version 0 is not supported")
         self.assertEqual(self.db.session.query(InvalidUReport).count(), 2)
 
     def test_attach(self):


### PR DESCRIPTION
Return actual exception to reporter when an uReport is rejected. So far,
this was only done in one specific situation and otherwise an overly
generic error message was returned.

Resolves: https://github.com/abrt/faf/issues/461