### PR TITLE
Remove SMTP logging handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added dependency on WTForms-SQLalchemy >= 0.3.0 due to the `wtforms.ext` module
   being removed in WTForms >= 3.0.0.
 
+### Removed
+- Removed SMTP logging handler
+
 ## [2.5.0] - 2021-10-18
 ### Changed
 - The `faf pull-components` action no longer adds new components for EOL releases

--- a/faf.spec
+++ b/faf.spec
@@ -64,7 +64,6 @@ BuildRequires: python3-jinja2
 BuildRequires: python3-markdown2
 BuildRequires: python3-munch
 BuildRequires: python3-openid-teams
-BuildRequires: python3-ratelimitingfilter
 BuildRequires: python3-werkzeug
 BuildRequires: python3-wtforms-sqlalchemy >= 0.3.0
 
@@ -90,7 +89,6 @@ Requires: python3-mod_wsgi
 Requires: python3-markdown2
 Requires: python3-munch
 Requires: python3-openid-teams
-Requires: python3-ratelimitingfilter
 Requires: python3-wtforms-sqlalchemy >= 0.3.0
 
 Requires: xstatic-patternfly-common

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ markdown2 ~= 2.4.0
 munch ~= 2.5.0
 python-bugzilla ~= 3.0.2
 python-openid-teams ~= 1.1
-ratelimitingfilter ~= 1.1
 requests ~= 2.24.0
 SQLAlchemy ~= 1.3.24
 Werkzeug ~= 1.0.1

--- a/src/webfaf/config.py
+++ b/src/webfaf/config.py
@@ -21,11 +21,6 @@ class Config:
     PROXY_SETUP = False
     TEMPLATES_DIR = os.path.join(WEBFAF_DIR, "templates")
     ADMINS = config.get("mail.admins", "").split(",")
-    MAIL_SERVER = config.get("mail.server", "localhost")
-    MAIL_PORT = config.get("mail.port", "25")
-    MAIL_USERNAME = config.get("mail.username", None)
-    MAIL_PASSWORD = config.get("mail.password", None)
-    MAIL_FROM = config.get("mail.from", "no-reply@" + MAIL_SERVER)
     BRAND_TITLE = config.get("hub.brand_title", "ABRT")
     BRAND_SUBTITLE = config.get("hub.brand_subtitle", "Analytics")
     BANNER = config.get("hub.banner", "")
@@ -37,9 +32,6 @@ class Config:
     EVERYONE_IS_ADMIN = str2bool(config.get("hub.everyone_is_admin", "false"))
     FEDMENU_URL = config.get("hub.fedmenu_url", None)
     FEDMENU_DATA_URL = config.get("hub.fedmenu_data_url", None)
-    THROTTLING_RATE = int(config.get("throttle.rate", 1))
-    THROTTLING_TIMEFRAME = int(config.get("throttle.timeframe", 30))
-    THROTTLING_BURST = int(config.get("throttle.burst", 1))
     FAF_VERSION = pyfaf.__version__
 
 

--- a/src/webfaf/webfaf_main.py
+++ b/src/webfaf/webfaf_main.py
@@ -1,6 +1,5 @@
 import os
 import logging
-from logging.handlers import SMTPHandler
 import json
 
 from typing import Tuple
@@ -12,7 +11,6 @@ from flask import Flask, Response, current_app, send_from_directory
 from flask_sqlalchemy import SQLAlchemy
 import markdown2
 import munch
-from ratelimitingfilter import RateLimitingFilter
 from werkzeug.local import LocalProxy
 try:
     from werkzeug.middleware.proxy_fix import ProxyFix
@@ -184,28 +182,6 @@ def before_request() -> None:
             "mail": "admin@localhost",
             "admin": True
         })
-
-
-if not app.debug:
-    credentials = None
-    if app.config["MAIL_USERNAME"] or app.config["MAIL_PASSWORD"]:
-        credentials = (app.config["MAIL_USERNAME"],
-                       app.config["MAIL_PASSWORD"])
-
-    mail_handler = SMTPHandler(
-        (app.config["MAIL_SERVER"],
-         app.config["MAIL_PORT"]),
-        app.config["MAIL_FROM"],
-        app.config["ADMINS"],
-        "webfaf exception", credentials)
-
-    mail_handler.setLevel(logging.ERROR)
-    rate_limiter = RateLimitingFilter(app.config["THROTTLING_RATE"],
-                                      app.config["THROTTLING_TIMEFRAME"],
-                                      app.config["THROTTLING_BURST"])
-
-    mail_handler.addFilter(rate_limiter)
-    app.logger.addHandler(mail_handler) # pylint: disable=no-member
 
 
 @app.errorhandler(403)


### PR DESCRIPTION
Sending alerts for exception should not be a responsibility of the application but a monitoring system. Moreover, the SMTP handler is not configured correctly in production and only clutters log files with exceptions.