### PR TITLE
Require Python 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+- Bumped Python dependency to >= 3.6
 - Bumped Celery dependency to >= 5.2.2 due to a security bug in earlier versions
 - Added dependency on WTForms-SQLalchemy >= 0.3.0 due to the `wtforms.ext` module
   being removed in WTForms >= 3.0.0.

--- a/faf.spec
+++ b/faf.spec
@@ -8,8 +8,9 @@ Source0: https://github.com/abrt/%{name}/archive/%{version}/%{name}-%{version}.t
 
 BuildArch: noarch
 
-%global satyr_ver 0.26
 %global celery_ver 5.2.2
+%global python_ver 3.6
+%global satyr_ver 0.26
 
 Requires(pre): shadow-utils
 
@@ -17,7 +18,7 @@ Requires: cpio
 
 Requires: postgresql
 
-Requires: python3
+Requires: python3 >= %{python_ver}
 Requires: python3-argcomplete
 Requires: python3-cachelib
 Requires: python3-celery >= %{celery_ver}


### PR DESCRIPTION
We are using some features of the 3.6 language in code and do not feel like supporting older versions. Even RHEL 8 is on 3.6 so this should be fine for all the cases we want to support.