### PR TITLE
Update config parser class name

### DIFF
--- a/src/pyfaf/config.py
+++ b/src/pyfaf/config.py
@@ -52,7 +52,7 @@ def load_config_files(config_files) -> Dict[str, Any]:
     """
 
     result = {}
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     parser.read(config_files)
 
     for section in parser.sections():


### PR DESCRIPTION
`SafeConfigParser` has been renamed in Python 3.2 and will be removed in Python 3.12.