### PR TITLE
Make "file_name" an optional field in the ureport

### DIFF
--- a/src/pyfaf/problemtypes/core.py
+++ b/src/pyfaf/problemtypes/core.py
@@ -78,8 +78,13 @@ class CoredumpProblem(ProblemType):
             "frames":       ListChecker(DictChecker({
                 "address":         IntChecker(minval=0),
                 "build_id_offset": IntChecker(minval=0),
-                "file_name":       StringChecker(maxlen=column_len(SymbolSource,
-                                                                   "path")),
+                "file_name":       StringChecker(
+                                       maxlen=column_len(
+                                           SymbolSource,
+                                           "path"
+                                       ),
+                                       mandatory=False
+                                   ),
                 "build_id": StringChecker(pattern=r"^[a-fA-F0-9]+$",
                                           maxlen=column_len(SymbolSource,
                                                             "build_id"),


### PR DESCRIPTION
Virtual dynamic shared objects can appear in the stacktrace, and they don't have a file name as they are provided by the kernel.